### PR TITLE
Set up AI Central and refresh FootyStats archive UI

### DIFF
--- a/.codex/steering/repository-steering.md
+++ b/.codex/steering/repository-steering.md
@@ -1,0 +1,52 @@
+# Repository Scope And Priorities
+
+This repository builds Footy Stats, an Angular application for exploring groomed historical football statistics.
+
+Primary deliverables:
+
+- Angular UI for navigating seasons, league tables, team performance, and historical comparisons
+- Local static data assets that power the app experience
+- Focused utility, store, and component code for turning football data into readable views
+
+Core priorities:
+
+- showcase the prepared football data clearly
+- keep football-data semantics stable and inspectable
+- make comparison workflows fast and understandable
+- maintain accessible, responsive, data-dense UI surfaces
+- preserve local-first development and static deploy compatibility
+
+## Active Boundaries
+
+- `src/app/components/` owns reusable Angular UI components.
+- `src/app/store/` owns app state, derived data, and data-loading behavior.
+- `src/app/types/` owns shared TypeScript view and domain types.
+- `src/app/utils/` owns pure helpers such as link builders and data transforms.
+- `src/assets/` owns static application data consumed by the frontend.
+- `sql/` owns database exploration and hydration scripts; do not treat it as the runtime source of truth unless the app is changed to use it.
+- `screenshots/` contains visual reference artifacts and should not churn during unrelated changes.
+
+## Data Semantics
+
+- Preserve season, team, standings, tier, and table semantics unless a task explicitly changes them.
+- Prefer typed transforms over ad hoc template logic when shaping football data.
+- Keep derived views deterministic and easy to test.
+- Do not hand-edit generated or groomed data assets without confirming the source and intended data contract.
+
+## Safe Refactor Boundaries
+
+Do not refactor these without explicit instruction:
+
+- public route names used by the GitHub Pages deployment
+- static asset structure consumed by the Angular app
+- league table and season data contracts
+- existing store API shape used by components
+- CI and deployment workflows
+
+Safe default changes:
+
+- feature-scoped component improvements
+- focused accessibility and responsive-layout fixes
+- typed helper extraction when it reduces real duplication
+- tests for stores, pipes, utilities, and data transforms
+- documentation updates for setup or workflow changes

--- a/.codex/steering/testing-quality-gates-steering.md
+++ b/.codex/steering/testing-quality-gates-steering.md
@@ -1,0 +1,30 @@
+# Testing And Quality Gates
+
+Testing should protect football-data behavior, Angular rendering assumptions, and deployment confidence.
+
+## Default Expectations
+
+- Add or update focused Jest coverage for behavior changes.
+- Cover edge cases for standings, seasons, league tiers, sorting, filtering, routing, and link generation.
+- Keep test fixtures small and explicit.
+- Prefer deterministic data-transform tests over brittle DOM assertions when possible.
+- Use Angular component tests when behavior depends on template bindings, Material controls, or user interaction.
+
+## Before Finishing Work
+
+Run the smallest reliable command that validates the changed area:
+
+- Utility, pipe, store, or component behavior: `pnpm test`
+- Type or production bundling changes: `pnpm build`
+- Formatting or lint-sensitive edits: `pnpm lint`
+- AI Central link changes: `pnpm codex:links`
+
+If a command cannot run locally, document why and what risk remains.
+
+## Quality Gates
+
+- No known failing tests introduced by the change.
+- No unrelated formatting churn.
+- Public routes and deploy settings preserved unless intentionally changed.
+- Docs updated for setup, command, or workflow changes.
+- Data contract changes paired with focused tests and clear notes.

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Codex local integration links. These point at user-specific AI Central
+# checkouts and are recreated with `pnpm codex:links`.
+.codex/skills/
+.codex/steering/*-steering.md
+!.codex/steering/repository-steering.md
+!.codex/steering/testing-quality-gates-steering.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Footy Stats Agent Guide
+
+This file is the root AI-agent guidance for `footy-stats`.
+
+## Scope
+
+- Applies to the full repository unless a nested `AGENTS.md` is closer to the edited file.
+- Use `.codex/steering/*` for reusable repo-wide standards and skill context.
+- Local links under `.codex/skills/` are generated from AI Central and are not source files.
+- Shared steering symlinks under `.codex/steering/` are local AI Central links; repo-specific steering remains tracked.
+
+## Project Summary
+
+Footy Stats is an Angular application for exploring groomed historical football data, currently focused on Premier League data.
+
+Core priorities:
+
+- Make the football data easy to inspect, compare, and understand.
+- Preserve stable data semantics for seasons, teams, standings, league tiers, and derived views.
+- Prefer focused UI and data-model improvements over broad rewrites.
+- Keep Angular, Material, ECharts, NgRx Signals, and Tailwind usage consistent with existing patterns.
+- Update docs when setup, commands, data contracts, or user-facing workflows change.
+
+## Repository Conventions
+
+- Follow `.codex/steering/repository-steering.md` for repo scope and boundaries.
+- Follow `.codex/steering/testing-quality-gates-steering.md` for verification expectations.
+- Follow linked AI Central steering such as `.codex/steering/angular-steering.md`, `.codex/steering/javascript-esm-steering.md`, and `.codex/steering/frontend-design-steering.md` when present.
+- Prefer existing helper APIs, route patterns, store patterns, and component conventions.
+- Add focused tests for behavior changes.
+- Avoid unrelated refactors and generated artifact churn.
+
+## Useful Commands
+
+- Install dependencies: `pnpm install`
+- Start local dev server: `pnpm start`
+- Build: `pnpm build`
+- Test: `pnpm test`
+- Watch tests: `pnpm test:watch`
+- Lint: `pnpm lint`
+- Refresh local AI Central links: `pnpm codex:links`
+
+## Branch And PR Metadata
+
+- Use feature branches for behavior, contract, test, or documentation changes unless explicitly asked to work on `main`.
+- When work is ready, provide:
+  - branch name
+  - PR title
+  - PR summary
+  - test evidence

--- a/README.md
+++ b/README.md
@@ -21,3 +21,27 @@ pnpm start
 ```bash
 ng generate @angular/material:theme-color
 ```
+
+## AI Central Context
+
+This repo uses AI Central steering and local Codex skill links.
+
+Tracked files:
+
+- `AGENTS.md`
+- `.codex/steering/repository-steering.md`
+- `.codex/steering/testing-quality-gates-steering.md`
+
+Ignored local links:
+
+- `.codex/skills/`
+- linked shared steering under `.codex/steering/`
+
+Refresh local symlinks with:
+
+```bash
+pnpm codex:links
+```
+
+By default this expects AI Central at `../ai-central` relative to this repository. Set
+`AI_CENTRAL_HOME` if your checkout lives somewhere else.

--- a/docs/view-audit.md
+++ b/docs/view-audit.md
@@ -1,0 +1,438 @@
+# FootyStats View Audit
+
+Date: 2026-06-16
+
+## Audit Goal
+
+Evolve FootyStats from a dashboard-feeling application into a historical football archive, reference publication, and research tool.
+
+Target perception:
+
+- English football history archive
+- Research tool
+- Reference publication
+- Digital encyclopedia
+
+Avoid optimizing toward:
+
+- Admin dashboard
+- Analytics SaaS
+- Business intelligence console
+- Widget-heavy app UI
+
+## Evidence Reviewed
+
+- Current desktop screenshots for Dashboard and Teams
+- Current desktop captures for Tables and Movement
+- Attached design direction notes
+- Live local app at `http://127.0.0.1:4200`
+- Source files under `src/app` and `src/styles.scss`
+- Desktop viewport: `1280 x 720`
+- Mobile viewport check: `390 x 844`
+
+## High-Level Findings
+
+### 1. The Visual System Creates Too Much Chrome
+
+The current global primitives make most UI surfaces visually heavy:
+
+- `.app-surface` adds border, gradient, shadow, and blur.
+- `.app-panel` adds another border, gradient, and shadow.
+- `.app-data-shell` adds border, gradient, shadow, and blur.
+- `.app-pill-control` and active states add bordered pills and gradients.
+
+This makes every section compete for attention. The app reads as a dashboard because nearly all content is inside framed controls or panels.
+
+Audit metrics from the rendered app:
+
+- Dashboard: 15 bordered visible elements, 14 shadows, 11 gradients.
+- Tables: 213 bordered visible elements, 24 shadows, 17 gradients.
+- Movement default: 35 bordered visible elements, 19 shadows, 12 gradients.
+- Teams: 511 bordered visible elements and 728 links due the large table.
+
+Recommendation:
+
+- Start the overhaul in `src/styles.scss`.
+- Replace gradient-heavy surface primitives with flatter archive primitives.
+- Use borders only for true data boundaries, not for every section.
+- Use typography, spacing, and table structure as the main hierarchy.
+
+### 2. Page Hierarchy Is Controls First, Data Second
+
+The strongest content is often below controls:
+
+- Tables starts with selector controls, then summary cards, then the league table.
+- Movement starts with warning and filters; the chart appears below the fold after a club is selected.
+- Teams starts with a large pill filter before the directory table.
+- Dashboard leads with stat widgets before archive/navigation storytelling.
+
+Recommendation:
+
+- Adopt this rule for all major pages: `Data > Context > Controls`.
+- Controls should support the archive, not visually dominate it.
+- Place primary data views earlier and make filters quieter.
+
+### 3. Typography Is Too Application-Sized
+
+Current live heading scale:
+
+- Dashboard H1: about `29px`
+- Tables H1: about `29px`
+- Movement H1: about `29px`
+- Teams H1: about `29px`
+- Feature card headings: `17px`
+- Control section headings: about `16.8px`
+
+This feels like app UI, not a publication or archive.
+
+Recommendation:
+
+- Introduce a publication scale.
+- H1: `44-56px` desktop, `32-38px` mobile.
+- Page lede: `18-20px`.
+- Section headings: `28-36px`.
+- Data table text can remain denser, but page framing should feel editorial.
+
+### 4. The Palette Is Less Bad Than The Treatment
+
+The dark navy, purple, and pink/red direction can work, but the repeated gradients, pink borders, glowing edges, and orange-red logo treatment make the palette feel noisy.
+
+Contrast notes:
+
+- `#e11d48` on `#0f172a` is about `3.8:1`.
+- This is acceptable for large/bold text but too weak for small normal table text.
+- The current pink/red is used for small values, active pills, links, borders, and highlights, so some usage is risky.
+
+Recommendation:
+
+- Keep navy as the foundation.
+- Use one restrained accent for selection/action.
+- Add a warmer archive-neutral surface color, not beige-heavy, for contrast.
+- Stop using red/pink as the default data emphasis everywhere.
+- Use semantic colors sparingly for promotion/relegation markers.
+
+### 5. Mobile Has Horizontal Overflow Beyond Tables
+
+At `390 x 844`, pages overflow horizontally:
+
+- Dashboard scroll width: `476px`
+- Tables scroll width: `736px`
+- Movement scroll width: `476px`
+- Teams scroll width: `758px`
+
+Tables naturally need horizontal scrolling, but the toolbar and page shell also overflow. This should be fixed before table-specific mobile behavior.
+
+Recommendation:
+
+- Make toolbar/nav responsive first.
+- Ensure `.app-page-shell` and `.app-surface` never exceed viewport width.
+- Keep table overflow local to the table container only.
+- Consider compact mobile navigation instead of full pill nav.
+
+## Page Audit
+
+## Dashboard
+
+Current strengths:
+
+- Copy is close to the target direction.
+- It already introduces the archive concept.
+- Primary navigation actions are present.
+
+Current problems:
+
+- The page still says "dashboard" visually because stats and feature cards dominate.
+- The H1 is too small for a landing/archive entry point.
+- Summary metrics have equal emphasis but do not tell a story.
+- Feature cards repeat generic product claims instead of archive pathways.
+- The disabled "View Rankings" action creates a dead primary-area control.
+
+Recommended overhaul:
+
+- Rename the route-facing concept away from Dashboard in UI, even if the route remains `/dashboard`.
+- Lead with "English Football Archive" or "FootyStats Archive".
+- Replace stat cards with a short narrative:
+  - "Explore 137 seasons of English football history."
+  - "Follow clubs through promotions, relegations, league tables, and long-run patterns."
+- Make primary actions:
+  - Browse Tables
+  - Explore Clubs
+  - Track Movement
+- Convert feature cards into archive sections or remove them.
+- Use a flatter first viewport with more whitespace and stronger type.
+
+Priority: High
+
+## Tables
+
+Current strengths:
+
+- The table itself is valuable and readable.
+- Season summary data is useful.
+- Selectors are simple.
+
+Current problems:
+
+- Controls are the first visual object on the page.
+- The table is the product, but it appears after controls and summary cards.
+- "League Table Viewer" sounds like an app tool, not an archive entry.
+- Season summary is nested: summary card plus fact cards plus chips.
+- Top-four highlighting uses a gold-ish badge treatment that clashes with the palette.
+- Points use red, which is visually strong but not semantically clear.
+
+Recommended overhaul:
+
+- Page title should be content-first:
+  - "2024 Premier League Table"
+  - "Premier League, 2024"
+- Put season/league controls inline near the title or in a quiet secondary row.
+- Move the table directly below the title/context.
+- Convert summary cards into a compact historical note above or beside the table.
+- Use restrained table styling:
+  - Sticky header
+  - Clear row rhythm
+  - Minimal borders
+  - Subtle top/relegation markers
+- Make promotion/relegation/top-four semantics explicit in a key.
+
+Priority: High
+
+## Movement
+
+Current strengths:
+
+- This is the most distinctive product feature.
+- ECharts implementation is already substantial.
+- URL state, quick picks, presets, and selected chips are useful.
+- The chart height is generous once shown.
+
+Current problems:
+
+- Default page shows controls and an empty state, not the graph.
+- With one selected club, the chart starts around `y=779px` in a `720px` desktop viewport, below the fold.
+- Collapsing filters moves the chart to about `y=470px`, which proves layout order is the main issue.
+- The data coverage warning is visually louder than the graph.
+- The club picker has too many pill controls at once.
+- The empty state requires the user to understand setup before seeing the unique feature.
+
+Recommended overhaul:
+
+- Treat Movement as the flagship page.
+- Show an opinionated starter graph by default, such as selected common clubs or a "Big Six" / "Historic clubs" preset.
+- Put the graph before filters.
+- Move filters into a right sidebar on desktop or a drawer/disclosure below the graph.
+- Keep the data coverage warning, but style it as a research note, not a warning panel.
+- Add graph explanation:
+  - lower tier number means higher league
+  - gaps indicate missing or unavailable data
+  - markers represent promotion/relegation
+- Improve chart labeling and legend so the graph can stand alone.
+
+Priority: Highest
+
+## Teams
+
+Current strengths:
+
+- This page already feels closest to an archive index.
+- The simple team directory structure is appropriate.
+- External links are useful for research workflows.
+
+Current problems:
+
+- Alphabet filter is styled as large app pills.
+- The table has 242 rows and 728 external links, which creates heavy visual density.
+- The team names are not yet meaningful destination links.
+- External links dominate each row and repeat the same three labels.
+- Mobile table width forces page-level horizontal overflow.
+
+Recommended overhaul:
+
+- Replace pill alphabet buttons with a compact archive index:
+  - `A B C D E F G ... All`
+- Make team names the primary links when team profile pages exist.
+- Collapse external links into quieter icon/text actions or a per-row details pattern.
+- Consider grouping by initial letter with section headers.
+- Add search only if it stays visually secondary.
+- Keep the page simple; do not over-card it.
+
+Priority: Medium-High
+
+## Rankings
+
+Current state:
+
+- Navigation shows Rankings as disabled/coming soon.
+- Dashboard includes a disabled View Rankings button.
+
+Current problems:
+
+- Disabled nav/actions imply incomplete product surface.
+- The UI gives equal navigation weight to a page that does not exist.
+
+Recommended overhaul:
+
+- Remove Rankings from primary nav until it exists, or create a lightweight placeholder that explains planned rankings.
+- Do not place disabled actions in the hero/primary flow.
+- If rankings are planned, define the first useful archive ranking:
+  - all-time points by club
+  - top-flight seasons
+  - titles/promotions/relegations
+  - best defensive seasons
+
+Priority: Medium
+
+## Navigation And Brand
+
+Current strengths:
+
+- Brand name and archive label are clear.
+- Sticky header is useful.
+
+Current problems:
+
+- Header is a full `app-surface`, so it competes with page content.
+- Nav pills look like SaaS filters.
+- Logo mark gradient is loud compared with the archive target.
+- Mobile nav does not fit the viewport cleanly.
+
+Recommended overhaul:
+
+- Make header flatter and quieter.
+- Use text nav or restrained tabs instead of pill buttons.
+- Keep active state obvious but less saturated.
+- Consider `Archive`, `Tables`, `Movement`, `Clubs` as nav labels.
+- Use a compact mobile nav pattern.
+
+Priority: High
+
+## Component And Styling Inventory
+
+Components that should be revisited early:
+
+- `src/styles.scss`
+  - Global tokens, backgrounds, surfaces, data shells, pill controls.
+- `src/app/components/main-toolbar/*`
+  - Header and primary nav visual direction.
+- `src/app/pages/home/*`
+  - Archive entry point and narrative hierarchy.
+- `src/app/components/league-tables-viewer/*`
+  - Controls-first layout.
+- `src/app/components/season-summary-card/*`
+  - Nested card summaries.
+- `src/app/components/league-table/*`
+  - Data table styling and semantic highlights.
+- `src/app/pages/movement-explorer/*`
+  - Flagship graph-first restructure.
+- `src/app/components/team-list/*`
+  - Archive index and external-link density.
+- `src/app/components/notification-banner/*`
+  - Research-note styling instead of warning chrome.
+
+## Proposed Overhaul Sequence
+
+## Prototype Slice For Direction Check
+
+Before doing the full overhaul, build a small visible slice that answers one question:
+
+> Does this feel more like a football history archive?
+
+Recommended prototype scope:
+
+- Flatten the global surface treatment enough to reduce gradients, shadows, and pink borders.
+- Flatten the header and primary navigation.
+- Reframe `/dashboard` as an archive home while preserving the existing route.
+- Replace Dashboard stat cards with narrative archive copy and compact metadata.
+- Convert the Teams alphabet filter from large app pills into a compact archive index.
+
+Out of scope for the first prototype:
+
+- Rebuilding Movement layout.
+- Reworking ECharts options.
+- Rebuilding Tables order and summary semantics.
+- Adding team profile routes.
+- Changing data contracts.
+
+Why this slice:
+
+- It is fast to review visually.
+- It touches the main perception layer without risking data behavior.
+- It produces one publication-style entry page and one archive-index page.
+- It keeps the highest-risk page, Movement, unchanged until the direction is approved.
+
+Prototype acceptance checks:
+
+- `/dashboard` should read as an archive home, not a metrics dashboard.
+- `/teams` should read more like an index and less like a filter form.
+- Primary navigation should stop feeling like SaaS pill filters.
+- No generated data or route contracts should change.
+- Existing tests should continue to pass.
+
+### Phase 1: Visual System Reset
+
+- Flatten global background.
+- Replace `.app-surface`, `.app-panel`, and `.app-data-shell` with restrained archive primitives.
+- Reduce border, shadow, blur, and gradient use.
+- Define typography scale.
+- Define table, note, and index primitives.
+- Fix mobile shell overflow.
+
+Why first:
+
+Most page-level problems are amplified by global styling. Fixing page layouts before tokens will cause churn.
+
+### Phase 2: Header And Dashboard
+
+- Flatten header/nav.
+- Reframe Dashboard as archive home.
+- Replace stat widgets with narrative entry copy.
+- Promote three primary archive pathways.
+
+Why second:
+
+This sets the perception for the whole app.
+
+### Phase 3: Tables
+
+- Make the selected table the main object.
+- Move controls into a secondary context row.
+- Collapse summary cards into concise facts.
+- Refine table semantics and highlights.
+
+Why third:
+
+Tables are a core archive use case and will validate the new data-presentation primitives.
+
+### Phase 4: Movement
+
+- Make graph-first layout.
+- Add default starter graph.
+- Move filters into sidebar/drawer.
+- Restyle warning as research note.
+- Improve legend and tier explanations.
+
+Why fourth:
+
+This is the highest-value product feature, but it benefits from the visual primitives established in earlier phases.
+
+### Phase 5: Teams
+
+- Convert alphabet pills to archive index.
+- Reduce external-link density.
+- Prepare for team profile pages.
+- Fix mobile table behavior.
+
+Why fifth:
+
+Teams is already the strongest page conceptually, so it can follow the bigger hierarchy work.
+
+## Recommended Acceptance Checks
+
+- Desktop first viewport communicates "English football archive" without relying on nav text.
+- Movement graph is visible on first load or immediately after default selection.
+- Tables page shows the league table before large control panels.
+- No page-level horizontal overflow at `390px` width except inside intended table scroll containers.
+- Accent color is not used for small normal text below AA contrast.
+- Visible bordered/shadowed elements are reduced by at least 50% on Dashboard, Tables, and Movement.
+- Disabled primary actions are removed from hero/primary flows.
+- `pnpm test`, `pnpm build`, and `pnpm lint` run cleanly or have documented pre-existing warnings.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "jest",
     "test:watch": "jest --watch",
+    "codex:links": "node scripts/dev/setup-codex-links.mjs",
     "hooks:setup": "npx lefthook install",
     "lint": "eslint . --ext .ts,.js,.html,.json",
     "lint:fix": "eslint . --ext .ts,.js,.html,.json --fix"

--- a/scripts/dev/setup-codex-links.mjs
+++ b/scripts/dev/setup-codex-links.mjs
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '../..');
+const codexDir = path.join(repoRoot, '.codex');
+const skillsDir = path.join(codexDir, 'skills');
+const steeringDir = path.join(codexDir, 'steering');
+const templatesRoot = resolveTemplatesRoot();
+const dryRun = process.argv.includes('--dry-run');
+const reset = process.argv.includes('--reset');
+
+function usage() {
+  console.log(`Usage: node scripts/dev/setup-codex-links.mjs [--dry-run] [--reset]
+
+Creates local .codex symlinks from AI Central.
+
+Environment:
+  AI_CENTRAL_HOME       Path to ai-central or ai-central/templates.
+                        Defaults to ../ai-central/templates.
+  AI_CENTRAL_REFERENCE  Optional repo whose existing .codex symlinks can be
+                        mirrored when AI Central is blocked by local privacy
+                        permissions. Defaults to a known sibling repo when
+                        present.
+
+Options:
+  --dry-run             Report changes without writing links.
+  --reset               Remove generated .codex/skills and linked shared
+                        steering files before recreating links.
+  --help                Show this help.`);
+}
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  usage();
+  process.exit(0);
+}
+
+function resolveTemplatesRoot() {
+  const input = process.env.AI_CENTRAL_HOME ?? path.resolve(repoRoot, '../ai-central/templates');
+  const absolute = path.resolve(input);
+  return path.basename(absolute) === 'ai-central' ? path.join(absolute, 'templates') : absolute;
+}
+
+async function pathExists(target) {
+  try {
+    await fs.lstat(target);
+    return true;
+  } catch (error) {
+    if (error.code === 'ENOENT' || error.code === 'EACCES' || error.code === 'EPERM') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function* walkDirs(root) {
+  let entries;
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT' || error.code === 'EACCES' || error.code === 'EPERM') {
+      return;
+    }
+    throw error;
+  }
+
+  yield root;
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      yield* walkDirs(path.join(root, entry.name));
+    }
+  }
+}
+
+async function findSkillLinksFromTemplates() {
+  const skillRoot = path.join(templatesRoot, 'skills');
+  const links = [];
+
+  for await (const dir of walkDirs(skillRoot)) {
+    if (!(await pathExists(path.join(dir, 'SKILL.md')))) {
+      continue;
+    }
+
+    const relativeDir = path.relative(skillRoot, dir);
+    const parts = relativeDir.split(path.sep);
+    const name = parts.at(-1);
+    const linkName = skillLinkName(parts, name);
+
+    if (linkName) {
+      links.push({ linkName, target: dir });
+    }
+  }
+
+  return sortLinks(links);
+}
+
+function skillLinkName(parts, name) {
+  if (!name) {
+    return undefined;
+  }
+
+  if (parts[0] === 'adapted') {
+    return name;
+  }
+
+  if (parts[0] !== 'imported') {
+    return name;
+  }
+
+  if (parts[1] === 'agent-skills') {
+    return name;
+  }
+
+  if (parts[1] === 'pm-skills') {
+    return `pm-${name}`;
+  }
+
+  if (parts[1] === 'claude-skills') {
+    return `claude-${name}`;
+  }
+
+  if (parts[1] === 'agent-toolkit') {
+    return `toolkit-${name}`;
+  }
+
+  if (parts[1] === 'web-quality-skills') {
+    return `web-${name}`;
+  }
+
+  return name;
+}
+
+async function findSteeringLinksFromTemplates() {
+  const root = path.join(templatesRoot, 'steering');
+  let entries;
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT' || error.code === 'EACCES' || error.code === 'EPERM') {
+      return [];
+    }
+    throw error;
+  }
+
+  return sortLinks(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+      .map((entry) => ({
+        linkName: entry.name,
+        target: path.join(root, entry.name),
+      }))
+  );
+}
+
+async function findLinksFromReference(directoryName) {
+  const referenceRoot = await resolveReferenceRepo();
+  if (!referenceRoot) {
+    return [];
+  }
+
+  const referenceDir = path.join(referenceRoot, '.codex', directoryName);
+  let entries;
+  try {
+    entries = await fs.readdir(referenceDir);
+  } catch (error) {
+    if (error.code === 'ENOENT' || error.code === 'EACCES' || error.code === 'EPERM') {
+      return [];
+    }
+    throw error;
+  }
+
+  const links = [];
+  for (const entry of entries) {
+    const linkPath = path.join(referenceDir, entry);
+    const stat = await fs.lstat(linkPath);
+    if (!stat.isSymbolicLink()) {
+      continue;
+    }
+
+    links.push({
+      linkName: entry,
+      target: path.resolve(path.dirname(linkPath), await fs.readlink(linkPath)),
+    });
+  }
+
+  return sortLinks(links);
+}
+
+async function resolveReferenceRepo() {
+  const candidates = [
+    process.env.AI_CENTRAL_REFERENCE,
+    path.resolve(repoRoot, '../reef'),
+    path.resolve(repoRoot, '../forage'),
+    path.resolve(repoRoot, '../breakerflow-platform'),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (await pathExists(path.join(candidate, '.codex'))) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+function sortLinks(links) {
+  return links.sort((left, right) => left.linkName.localeCompare(right.linkName));
+}
+
+async function removeGeneratedLinks() {
+  if (!dryRun) {
+    await fs.rm(skillsDir, { recursive: true, force: true });
+  }
+
+  let entries;
+  try {
+    entries = await fs.readdir(steeringDir);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const linkPath = path.join(steeringDir, entry);
+    const stat = await fs.lstat(linkPath);
+    if (stat.isSymbolicLink() && !dryRun) {
+      await fs.unlink(linkPath);
+    }
+  }
+}
+
+async function ensureSymlink(directory, linkName, target) {
+  const linkPath = path.join(directory, linkName);
+  let existing;
+
+  try {
+    existing = await fs.lstat(linkPath);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  if (existing && !existing.isSymbolicLink()) {
+    return { action: 'skip-real-file', linkPath, target };
+  }
+
+  if (existing?.isSymbolicLink()) {
+    const currentTarget = await fs.readlink(linkPath);
+    const resolvedCurrentTarget = path.resolve(path.dirname(linkPath), currentTarget);
+
+    if (resolvedCurrentTarget === target) {
+      return { action: 'unchanged', linkPath, target };
+    }
+
+    if (!dryRun) {
+      await fs.unlink(linkPath);
+    }
+  }
+
+  if (!dryRun) {
+    await fs.symlink(target, linkPath);
+  }
+
+  return {
+    action: existing ? 'updated' : 'created',
+    linkPath,
+    target,
+  };
+}
+
+async function main() {
+  if (reset) {
+    await removeGeneratedLinks();
+  }
+
+  if (!dryRun) {
+    await fs.mkdir(skillsDir, { recursive: true });
+    await fs.mkdir(steeringDir, { recursive: true });
+  }
+
+  let skillLinks = await findSkillLinksFromTemplates();
+  let steeringLinks = await findSteeringLinksFromTemplates();
+  let source = templatesRoot;
+
+  if (skillLinks.length === 0) {
+    skillLinks = await findLinksFromReference('skills');
+    source = 'reference repo symlinks';
+  }
+
+  if (steeringLinks.length === 0) {
+    steeringLinks = await findLinksFromReference('steering');
+  }
+
+  const links = [
+    ...skillLinks.map((link) => ({ ...link, directory: skillsDir })),
+    ...steeringLinks.map((link) => ({ ...link, directory: steeringDir })),
+  ];
+
+  if (links.length === 0) {
+    console.error(`No AI Central links found from ${templatesRoot} or sibling reference repos.`);
+    console.error('Set AI_CENTRAL_HOME or AI_CENTRAL_REFERENCE to a readable checkout.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const results = [];
+  for (const link of links) {
+    results.push(await ensureSymlink(link.directory, link.linkName, link.target));
+  }
+
+  const counts = results.reduce((accumulator, result) => {
+    accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
+    return accumulator;
+  }, {});
+
+  for (const result of results.filter((item) => item.action !== 'unchanged')) {
+    const relativeLink = path.relative(repoRoot, result.linkPath);
+    console.log(`${result.action}: ${relativeLink} -> ${result.target}`);
+  }
+
+  console.log(
+    `Codex links checked from ${source}: ${results.length} ` +
+      `(created ${counts.created ?? 0}, updated ${counts.updated ?? 0}, ` +
+      `unchanged ${counts.unchanged ?? 0}, skipped ${counts['skip-real-file'] ?? 0})`
+  );
+}
+
+await main();

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -5,4 +5,60 @@
   <main class="app-content">
     <router-outlet />
   </main>
+  <footer class="app-footer">
+    <div class="footer-inner">
+      <section class="footer-brand" aria-label="FootyStats project">
+        <a
+          class="footer-mark"
+          href="https://shwimp.studio/org/wimpy-productions/"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Wimpy Productions"
+        >
+          FS
+        </a>
+        <div>
+          <p class="footer-kicker">A Wimpy Productions Project</p>
+          <p class="footer-title">FootyStats</p>
+          <p class="footer-copy">
+            Historical English football tables, club records, and movement research.
+          </p>
+        </div>
+      </section>
+
+      <nav class="footer-nav" aria-label="Footer">
+        <div class="footer-link-group">
+          <p>Explore</p>
+          <a routerLink="/tables">Tables</a>
+          <a routerLink="/movement">Movement</a>
+          <a routerLink="/teams">Clubs</a>
+        </div>
+        <div class="footer-link-group">
+          <p>Studio</p>
+          <a
+            href="https://shwimp.studio/org/wimpy-productions/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Wimpy Productions
+          </a>
+          <a href="https://shwimp.studio/" target="_blank" rel="noopener noreferrer">
+            Shwimp Studios
+          </a>
+          <a
+            href="https://github.com/dills122/footy-stats"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Source
+          </a>
+        </div>
+      </nav>
+    </div>
+
+    <div class="footer-bottom">
+      <span>&copy; 2026 FootyStats</span>
+      <span>Wimpy Productions / Shwimp Studios</span>
+    </div>
+  </footer>
 </div>

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -7,7 +7,7 @@
 .app-shell {
   min-height: 100vh;
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto 1fr auto;
 }
 
 .app-header {
@@ -18,4 +18,127 @@
 
 .app-content {
   padding: 28px clamp(12px, 2vw, 24px) 28px;
+}
+
+.app-footer {
+  padding: 24px clamp(12px, 2vw, 24px) 30px;
+}
+
+.footer-inner {
+  width: min(1160px, calc(100% - 24px));
+  margin: 0 auto;
+  padding-top: 24px;
+  border-top: 1px solid var(--app-border);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 32px;
+}
+
+.footer-brand {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  max-width: 560px;
+}
+
+.footer-mark {
+  flex: 0 0 auto;
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  display: inline-grid;
+  place-items: center;
+  color: var(--app-text-strong);
+  background: rgba(15, 23, 42, 0.72);
+  border-radius: 6px;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+}
+
+.footer-mark:hover {
+  border-color: rgba(248, 250, 252, 0.42);
+  color: #fff;
+}
+
+.footer-kicker {
+  margin: 0;
+  color: var(--app-text-subtle);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.footer-title {
+  margin: 4px 0 0;
+  color: var(--app-text-strong);
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.footer-copy {
+  margin: 8px 0 0;
+  color: var(--app-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.footer-nav {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, auto));
+  gap: 32px;
+}
+
+.footer-link-group p {
+  margin: 0 0 10px;
+  color: var(--app-text-subtle);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.footer-link-group a {
+  display: block;
+  color: var(--app-text-muted);
+  text-decoration: none;
+  font-size: 0.94rem;
+  font-weight: 650;
+  line-height: 1.75;
+}
+
+.footer-link-group a:hover {
+  color: var(--app-text-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.footer-bottom {
+  width: min(1160px, calc(100% - 24px));
+  margin: 22px auto 0;
+  padding-top: 14px;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--app-text-subtle);
+  font-size: 0.82rem;
+}
+
+@media (max-width: 700px) {
+  .footer-inner {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .footer-nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 20px;
+  }
+
+  .footer-bottom {
+    flex-direction: column;
+  }
 }

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -25,7 +25,7 @@
 }
 
 .footer-inner {
-  width: min(1160px, calc(100% - 24px));
+  width: min(1160px, calc(100vw - 24px));
   margin: 0 auto;
   padding-top: 24px;
   border-top: 1px solid var(--app-border);
@@ -116,7 +116,7 @@
 }
 
 .footer-bottom {
-  width: min(1160px, calc(100% - 24px));
+  width: min(1160px, calc(100vw - 24px));
   margin: 22px auto 0;
   padding-top: 14px;
   border-top: 1px solid rgba(148, 163, 184, 0.12);

--- a/src/app/components/league-table/league-table.html
+++ b/src/app/components/league-table/league-table.html
@@ -1,70 +1,72 @@
 <div class="table-container app-data-shell">
   <table mat-table [dataSource]="sortedTable" class="footy-table">
     <ng-container matColumnDef="position">
-      <th mat-header-cell *matHeaderCellDef class="head app-data-head">#</th>
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head app-data-head">#</th>
       <td mat-cell *matCellDef="let element; let i = index" class="cell app-data-cell">
         <span class="rank" [class.rank-top]="i < 4">{{ i + 1 }}</span>
       </td>
     </ng-container>
 
     <ng-container matColumnDef="teamName">
-      <th mat-header-cell *matHeaderCellDef class="head app-data-head">Team</th>
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head app-data-head">Team</th>
       <td mat-cell *matCellDef="let element" class="cell team app-data-cell">
         {{ element.teamName }}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="played">
-      <th mat-header-cell *matHeaderCellDef class="head center app-data-head">P</th>
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head center app-data-head">P</th>
       <td mat-cell *matCellDef="let element" class="cell center app-data-cell">
         {{ element.played }}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="won">
-      <th mat-header-cell *matHeaderCellDef class="head center app-data-head">W</th>
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head center app-data-head">W</th>
       <td mat-cell *matCellDef="let element" class="cell center app-data-cell">
         {{ element.won }}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="drawn">
-      <th mat-header-cell *matHeaderCellDef class="head center app-data-head">D</th>
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head center app-data-head">D</th>
       <td mat-cell *matCellDef="let element" class="cell center app-data-cell">
         {{ element.drawn }}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="lost">
-      <th mat-header-cell *matHeaderCellDef class="head center app-data-head">L</th>
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head center app-data-head">L</th>
       <td mat-cell *matCellDef="let element" class="cell center app-data-cell">
         {{ element.lost }}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="goalsFor">
-      <th mat-header-cell *matHeaderCellDef class="head center app-data-head">GF</th>
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head center app-data-head">GF</th>
       <td mat-cell *matCellDef="let element" class="cell center app-data-cell">
         {{ element.goalsFor }}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="goalsAgainst">
-      <th mat-header-cell *matHeaderCellDef class="head center app-data-head">GA</th>
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head center app-data-head">GA</th>
       <td mat-cell *matCellDef="let element" class="cell center app-data-cell">
         {{ element.goalsAgainst }}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="goalDifference">
-      <th mat-header-cell *matHeaderCellDef class="head center app-data-head">GD</th>
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head center app-data-head">GD</th>
       <td mat-cell *matCellDef="let element" class="cell center app-data-cell">
         {{ element.goalDifference }}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="points">
-      <th mat-header-cell *matHeaderCellDef class="head center points app-data-head">Pts</th>
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head center points app-data-head">
+        Pts
+      </th>
       <td mat-cell *matCellDef="let element" class="cell center points app-data-cell">
         {{ element.points }}
       </td>

--- a/src/app/components/league-table/league-table.scss
+++ b/src/app/components/league-table/league-table.scss
@@ -1,4 +1,6 @@
 .table-container {
+  width: 100%;
+  max-width: 100%;
   overflow: auto;
 }
 
@@ -7,13 +9,14 @@
   border-collapse: separate;
   border-spacing: 0;
   min-width: 760px;
+  background: transparent;
 }
 
 .head {
   position: sticky;
   top: 0;
   z-index: 2;
-  padding: 12px 10px;
+  padding: 13px 10px;
   font-size: 11px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -21,16 +24,16 @@
 }
 
 .cell {
-  padding: 11px 10px;
+  padding: 12px 10px;
   color: color-mix(in srgb, var(--app-text-subtle) 96%, var(--app-text-strong) 4%);
 }
 
 .row-top .cell {
-  background: color-mix(in srgb, var(--app-accent-soft) 24%, transparent);
+  background: rgba(245, 158, 11, 0.08);
 }
 
 .row-top .cell:first-child {
-  box-shadow: inset 3px 0 0 rgba(251, 191, 36, 0.5);
+  box-shadow: inset 3px 0 0 rgba(245, 158, 11, 0.54);
 }
 
 .center {
@@ -44,26 +47,26 @@
 
 .points {
   font-weight: 700;
-  color: #be123c;
+  color: var(--app-text-strong);
 }
 
 .rank {
-  width: 28px;
-  height: 28px;
+  width: 26px;
+  height: 26px;
   display: inline-grid;
   place-items: center;
-  border-radius: 999px;
+  border-radius: 6px;
   font-weight: 700;
   font-size: 13px;
   color: var(--app-text-subtle);
-  border: 1px solid color-mix(in srgb, var(--app-surface-border) 70%, transparent);
-  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid transparent;
+  background: transparent;
 }
 
 .rank-top {
-  color: #9a3412;
-  border-color: rgba(245, 158, 11, 0.45);
-  background: rgba(254, 243, 199, 0.9);
+  color: #fde68a;
+  border-color: rgba(245, 158, 11, 0.42);
+  background: rgba(245, 158, 11, 0.12);
 }
 
 .footy-table tr:last-child .cell {

--- a/src/app/components/league-tables-viewer/league-tables-viewer.html
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.html
@@ -1,12 +1,20 @@
 <div class="viewer">
-  <section class="controls app-surface">
-    <header class="controls-head app-page-header">
-      <p class="app-page-eyebrow">Table Explorer</p>
-      <h1 class="app-page-title">League Table Viewer</h1>
+  <section class="table-record">
+    <header class="record-header app-page-header">
+      <p class="app-page-eyebrow">League Table Archive</p>
+      <h1 class="app-page-title">
+        @if (selectedYear() && currentLeagueLabel()) { {{ selectedYear() }} {{ currentLeagueLabel()
+        | leagueTierToStringy }} Table } @else { League Tables }
+      </h1>
+      <p class="app-page-lede">
+        Read preserved season standings with wins, draws, losses, scoring record, goal difference,
+        and points.
+      </p>
     </header>
-    <div class="selectors">
+
+    <div class="record-tools" aria-label="Select season table">
       <mat-form-field class="field" appearance="fill">
-        <mat-label>Select Year</mat-label>
+        <mat-label>Season</mat-label>
         <mat-icon matPrefix>calendar_today</mat-icon>
         <mat-select [value]="selectedYear()" (selectionChange)="onYearChange($event.value)">
           @for (year of years; track year) {
@@ -19,7 +27,7 @@
 
       @if (leaguesForYear.length > 0) {
       <mat-form-field class="field" appearance="fill">
-        <mat-label>Select League</mat-label>
+        <mat-label>Competition</mat-label>
         <mat-icon matPrefix>sports_soccer</mat-icon>
         <mat-select [value]="selectedLeague()" (selectionChange)="onLeagueChange($event.value)">
           @for (league of leaguesForYear; track league) {
@@ -29,13 +37,10 @@
       </mat-form-field>
       }
     </div>
-  </section>
 
-  @if (currentTable(); as tableData) {
-  <section class="results">
-    <h2>{{ selectedYear() }} Season Results - {{ currentLeagueLabel() | leagueTierToStringy }}</h2>
+    @if (currentTable(); as tableData) {
     <app-season-summary-card [tableData]="tableData" />
     <app-league-table [leagueTable]="tableData" />
+    }
   </section>
-  }
 </div>

--- a/src/app/components/league-tables-viewer/league-tables-viewer.scss
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.scss
@@ -3,79 +3,54 @@
 }
 
 .viewer {
-  display: grid;
-  gap: 16px;
-}
-
-.controls {
-  padding: 20px;
-}
-
-.controls-head {
-  margin-bottom: 10px;
-}
-
-.eyebrow {
-  margin: 0;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--app-text-muted);
-}
-
-h1 {
-  margin: 4px 0 0;
-  font-size: 22px;
-}
-
-.selectors {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.results {
-  display: grid;
-  gap: 14px;
-}
-
-app-season-summary-card,
-app-league-table {
   display: block;
+  min-width: 0;
 }
 
-h2 {
-  margin: 6px 2px 0;
-  font-size: 20px;
-  color: var(--app-text-strong);
+.table-record {
+  display: grid;
+  gap: clamp(24px, 4vw, 42px);
+  min-width: 0;
+}
+
+.table-record > * {
+  min-width: 0;
+}
+
+.record-header {
+  margin-bottom: 0;
+  padding-bottom: clamp(16px, 2.4vw, 26px);
+  border-bottom: 1px solid var(--app-border);
+}
+
+.record-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+  max-width: 760px;
+  margin-top: -4px;
 }
 
 .field {
-  --mdc-filled-text-field-container-color: color-mix(
-    in srgb,
-    var(--app-surface-bg) 94%,
-    transparent
-  );
-  --mdc-filled-text-field-container-shape: 12px;
+  width: min(100%, 280px);
+  --mdc-filled-text-field-container-color: rgba(7, 10, 19, 0.3);
+  --mdc-filled-text-field-container-shape: 8px;
   --mdc-filled-text-field-active-indicator-color: transparent;
   --mdc-filled-text-field-focus-active-indicator-color: transparent;
   --mdc-filled-text-field-hover-active-indicator-color: transparent;
-  --mat-select-panel-background-color: color-mix(in srgb, var(--app-surface-bg) 98%, transparent);
+  --mat-select-panel-background-color: #111827;
 }
 
 :host ::ng-deep .field .mdc-text-field--filled {
-  border: 1px solid color-mix(in srgb, var(--app-border) 82%, #fff 18%);
-  background: linear-gradient(
-    145deg,
-    color-mix(in srgb, var(--app-surface-bg) 98%, #fff 2%),
-    color-mix(in srgb, var(--app-surface-bg) 92%, #0f172a 8%)
-  );
-  box-shadow: 0 4px 10px rgba(2, 6, 23, 0.08);
+  border: 1px solid var(--app-border);
+  background: rgba(7, 10, 19, 0.28);
+  box-shadow: none;
 }
 
 :host ::ng-deep .field .mdc-text-field--filled:hover,
 :host ::ng-deep .field .mdc-text-field--filled.mdc-text-field--focused {
-  border-color: rgba(251, 113, 133, 0.45);
+  border-color: rgba(251, 113, 133, 0.4);
 }
 
 :host ::ng-deep .field .mat-mdc-select-value,
@@ -87,8 +62,17 @@ h2 {
   color: var(--app-text-strong) !important;
 }
 
+app-league-table,
+app-season-summary-card {
+  display: block;
+}
+
 @media (max-width: 760px) {
-  .selectors {
-    grid-template-columns: 1fr;
+  .record-tools {
+    display: grid;
+  }
+
+  .field {
+    width: 100%;
   }
 }

--- a/src/app/components/league-tables-viewer/league-tables-viewer.scss
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.scss
@@ -50,7 +50,7 @@
 
 :host ::ng-deep .field .mdc-text-field--filled:hover,
 :host ::ng-deep .field .mdc-text-field--filled.mdc-text-field--focused {
-  border-color: rgba(251, 113, 133, 0.4);
+  border-color: rgba(148, 163, 184, 0.42);
 }
 
 :host ::ng-deep .field .mat-mdc-select-value,

--- a/src/app/components/main-toolbar/main-toolbar.html
+++ b/src/app/components/main-toolbar/main-toolbar.html
@@ -1,5 +1,5 @@
 <mat-toolbar class="main-toolbar">
-  <div class="toolbar-inner app-surface">
+  <div class="toolbar-inner">
     <a class="brand" routerLink="/dashboard">
       <span class="brand-mark">
         <mat-icon fontIcon="sports_soccer" />
@@ -11,13 +11,10 @@
     </a>
 
     <nav class="nav-links" aria-label="Primary">
-      <a mat-button routerLink="/dashboard" routerLinkActive="is-active">Dashboard</a>
+      <a mat-button routerLink="/dashboard" routerLinkActive="is-active">Archive</a>
       <a mat-button routerLink="/tables" routerLinkActive="is-active">Tables</a>
       <a mat-button routerLink="/movement" routerLinkActive="is-active">Movement</a>
-      <a mat-button routerLink="/teams" routerLinkActive="is-active">Teams</a>
-      <span matTooltip="Coming soon">
-        <button mat-button disabled>Rankings</button>
-      </span>
+      <a mat-button routerLink="/teams" routerLinkActive="is-active">Clubs</a>
     </nav>
   </div>
 </mat-toolbar>

--- a/src/app/components/main-toolbar/main-toolbar.scss
+++ b/src/app/components/main-toolbar/main-toolbar.scss
@@ -1,21 +1,25 @@
 :host {
   display: block;
+  background: rgba(11, 18, 32, 0.92);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+  backdrop-filter: blur(12px);
 }
 
 .main-toolbar {
   background: transparent;
-  padding: 24px 0 0;
+  padding: 12px 0 0;
   min-height: auto;
 }
 
 .toolbar-inner {
   width: min(1160px, calc(100% - 24px));
   margin: 0 auto;
-  padding: 12px 14px;
+  padding: 10px 0 12px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 14px;
+  border-bottom: 0;
 }
 
 .brand {
@@ -27,14 +31,15 @@
 }
 
 .brand-mark {
-  width: 38px;
-  height: 38px;
-  border-radius: 12px;
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
   display: grid;
   place-items: center;
-  color: #fff;
-  background: linear-gradient(135deg, #e11d48, #f59e0b);
-  box-shadow: 0 10px 26px rgba(225, 29, 72, 0.3);
+  color: #fecdd3;
+  background: rgba(225, 29, 72, 0.16);
+  border: 1px solid rgba(251, 113, 133, 0.28);
+  box-shadow: none;
 }
 
 .brand-copy {
@@ -58,39 +63,43 @@
 .nav-links {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 2px;
 }
 
 .nav-links a,
 .nav-links button {
-  border: 1px solid color-mix(in srgb, var(--app-border) 82%, #fff 18%);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
   color: var(--app-text-subtle);
-  min-height: 40px;
-  padding-inline: 14px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  min-height: 36px;
+  padding-inline: 11px;
+  box-shadow: none;
 }
 
 .nav-links a:hover:not(.is-active) {
-  background: rgba(255, 255, 255, 0.07);
+  background: rgba(148, 163, 184, 0.08);
   color: var(--app-text-strong);
 }
 
 .nav-links .is-active {
-  color: #fff1f2;
-  border-color: rgba(251, 113, 133, 0.58);
-  background: linear-gradient(135deg, rgba(225, 29, 72, 0.3), rgba(190, 24, 93, 0.18));
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    0 4px 10px rgba(225, 29, 72, 0.12);
+  color: #fecdd3;
+  background: rgba(225, 29, 72, 0.14);
+  box-shadow: inset 0 -2px 0 rgba(251, 113, 133, 0.5);
 }
 
 @media (max-width: 720px) {
   .toolbar-inner {
-    padding: 10px;
+    width: min(100% - 24px, 1160px);
+    padding: 10px 0;
     gap: 10px;
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .nav-links {
+    width: 100%;
+    overflow-x: auto;
+    padding-bottom: 4px;
   }
 }

--- a/src/app/components/main-toolbar/main-toolbar.scss
+++ b/src/app/components/main-toolbar/main-toolbar.scss
@@ -12,7 +12,7 @@
 }
 
 .toolbar-inner {
-  width: min(1160px, calc(100% - 24px));
+  width: min(1160px, calc(100vw - 24px));
   margin: 0 auto;
   padding: 10px 0 12px;
   display: flex;
@@ -36,9 +36,9 @@
   border-radius: 9px;
   display: grid;
   place-items: center;
-  color: #fecdd3;
-  background: rgba(225, 29, 72, 0.16);
-  border: 1px solid rgba(251, 113, 133, 0.28);
+  color: #fde68a;
+  background: rgba(217, 119, 6, 0.14);
+  border: 1px solid rgba(217, 119, 6, 0.32);
   box-shadow: none;
 }
 
@@ -83,14 +83,14 @@
 }
 
 .nav-links .is-active {
-  color: #fecdd3;
-  background: rgba(225, 29, 72, 0.14);
-  box-shadow: inset 0 -2px 0 rgba(251, 113, 133, 0.5);
+  color: #fde68a;
+  background: rgba(217, 119, 6, 0.12);
+  box-shadow: inset 0 -2px 0 rgba(217, 119, 6, 0.52);
 }
 
 @media (max-width: 720px) {
   .toolbar-inner {
-    width: min(100% - 24px, 1160px);
+    width: min(calc(100vw - 24px), 1160px);
     padding: 10px 0;
     gap: 10px;
     flex-direction: column;

--- a/src/app/components/main-toolbar/main-toolbar.ts
+++ b/src/app/components/main-toolbar/main-toolbar.ts
@@ -2,12 +2,11 @@ import { Component } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-main-toolbar',
-  imports: [RouterModule, MatToolbarModule, MatButtonModule, MatIconModule, MatTooltipModule],
+  imports: [RouterModule, MatToolbarModule, MatButtonModule, MatIconModule],
   templateUrl: './main-toolbar.html',
   styleUrl: './main-toolbar.scss',
 })

--- a/src/app/components/notification-banner/notification-banner.scss
+++ b/src/app/components/notification-banner/notification-banner.scss
@@ -3,37 +3,35 @@
 }
 
 .notification-banner {
-  --notification-border: rgba(59, 130, 246, 0.7);
+  --notification-border: rgba(59, 130, 246, 0.42);
   --notification-accent: #3b82f6;
-  --notification-title: #bfdbfe;
-  --notification-text: var(--app-text-strong);
+  --notification-title: var(--app-text-strong);
+  --notification-text: var(--app-text-subtle);
 
-  padding: 14px 16px;
+  padding: 13px 14px;
   border: 1px solid var(--notification-border);
-  border-left: 5px solid var(--notification-accent);
-  border-radius: var(--app-radius-md);
-  background: transparent;
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--notification-accent) 18%, transparent),
-    0 12px 28px rgba(15, 23, 42, 0.22);
+  border-left: 3px solid var(--notification-accent);
+  border-radius: 8px;
+  background: rgba(7, 10, 19, 0.16);
+  box-shadow: none;
   display: grid;
   gap: 4px;
 }
 
 .notification-banner--warning {
-  --notification-border: rgba(251, 191, 36, 0.72);
-  --notification-accent: #f59e0b;
+  --notification-border: rgba(217, 119, 6, 0.54);
+  --notification-accent: #d97706;
   --notification-title: #fde68a;
 }
 
 .notification-banner--success {
-  --notification-border: rgba(52, 211, 153, 0.72);
+  --notification-border: rgba(52, 211, 153, 0.5);
   --notification-accent: #10b981;
   --notification-title: #a7f3d0;
 }
 
 .notification-banner--info {
-  --notification-border: rgba(96, 165, 250, 0.72);
+  --notification-border: rgba(96, 165, 250, 0.5);
   --notification-accent: #3b82f6;
   --notification-title: #bfdbfe;
 }
@@ -47,7 +45,7 @@
 
 .notification-banner__content {
   color: var(--notification-text);
-  font-size: 0.97rem;
+  font-size: 0.95rem;
   line-height: 1.45;
 }
 

--- a/src/app/components/season-summary-card/season-summary-card.html
+++ b/src/app/components/season-summary-card/season-summary-card.html
@@ -1,5 +1,7 @@
-<section class="summary app-surface">
-  <h3>Season Summary</h3>
+<section class="summary" aria-label="Season summary">
+  <header class="summary-header">
+    <p>Season Overview</p>
+  </header>
   <dl class="facts">
     <div class="fact">
       <dt>Champion</dt>

--- a/src/app/components/season-summary-card/season-summary-card.scss
+++ b/src/app/components/season-summary-card/season-summary-card.scss
@@ -3,78 +3,100 @@
 }
 
 .summary {
-  padding: 18px;
-  overflow: hidden;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 16px clamp(18px, 3vw, 32px);
+  align-items: start;
+  padding: 14px 0;
+  border-top: 1px solid var(--app-border);
+  border-bottom: 1px solid var(--app-border);
 }
 
-h3 {
-  margin: 0 0 12px;
-  font-size: 22px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--app-text-strong);
+.summary-header p {
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 
 .facts {
   margin: 0;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 22px;
 }
 
 .fact {
-  padding: 10px 12px;
-  border-radius: var(--app-radius-sm);
-  border: 1px solid color-mix(in srgb, #38bdf8 16%, var(--app-surface-border) 84%);
-  background: linear-gradient(
-    160deg,
-    color-mix(in srgb, var(--app-surface-bg) 98%, #fff 2%),
-    color-mix(in srgb, var(--app-surface-bg) 90%, #0f172a 10%)
-  );
-  box-shadow: 0 4px 10px rgba(2, 6, 23, 0.1);
+  min-width: max-content;
 }
 
 dt {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  display: inline;
+  margin-right: 6px;
   color: var(--app-text-muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+dt::after {
+  content: ':';
 }
 
 dd {
-  margin: 4px 0 0;
-  color: #f8fbff;
-  font-weight: 600;
+  display: inline;
+  margin: 0;
+  color: var(--app-text-strong);
+  font-weight: 650;
 }
 
 .chip-group {
-  display: flex;
+  display: inline-flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
+  vertical-align: middle;
 }
 
 .chip {
   display: inline-block;
-  padding: 5px 10px;
-  border-radius: var(--app-radius-pill);
-  border: 1px solid transparent;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  padding: 1px 6px;
+  border-radius: 5px;
+  border: 1px solid var(--app-border);
+  color: var(--app-text-strong);
+  font-size: 0.88rem;
+  line-height: 1.35;
 }
 
 .chip-up {
-  color: #ecfdf5;
-  border-color: rgba(52, 211, 153, 0.28);
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.28), rgba(5, 150, 105, 0.16));
+  border-color: rgba(52, 211, 153, 0.36);
+  color: #bbf7d0;
+  background: rgba(16, 185, 129, 0.1);
 }
 
 .chip-down {
-  color: #fff1f2;
-  border-color: rgba(251, 113, 133, 0.28);
-  background: linear-gradient(135deg, rgba(225, 29, 72, 0.28), rgba(190, 24, 93, 0.16));
+  border-color: rgba(251, 113, 133, 0.36);
+  color: #fecdd3;
+  background: rgba(225, 29, 72, 0.1);
 }
 
 @media (max-width: 760px) {
-  .facts {
+  .summary {
     grid-template-columns: 1fr;
+  }
+
+  .fact {
+    min-width: 0;
+    width: 100%;
+  }
+
+  dt,
+  dd {
+    display: block;
+  }
+
+  dt {
+    margin: 0 0 3px;
   }
 }

--- a/src/app/components/season-summary-card/season-summary-card.scss
+++ b/src/app/components/season-summary-card/season-summary-card.scss
@@ -76,9 +76,9 @@ dd {
 }
 
 .chip-down {
-  border-color: rgba(251, 113, 133, 0.36);
-  color: #fecdd3;
-  background: rgba(225, 29, 72, 0.1);
+  border-color: rgba(220, 38, 38, 0.36);
+  color: #fecaca;
+  background: rgba(220, 38, 38, 0.1);
 }
 
 @media (max-width: 760px) {

--- a/src/app/components/team-list/team-list.html
+++ b/src/app/components/team-list/team-list.html
@@ -1,31 +1,30 @@
 <div class="team-list">
-  <h4 class="filter-title">Filter by Letter</h4>
+  <div class="index-header">
+    <h4 class="filter-title">Club Index</h4>
+    <span>{{ filteredTeams().length }} clubs</span>
+  </div>
 
-  <!-- Alphabet filter -->
-  <div class="alphabet-filter">
+  <nav class="alphabet-filter" aria-label="Filter clubs by letter">
     <button
-      *ngFor="let letter of letters()"
-      mat-stroked-button
-      color="primary"
-      (click)="selectLetter(letter)"
-      type="button"
-      class="letter-button app-pill-control"
-      [class.letter-button--selected]="selectedLetter() === letter"
-      [class.is-active]="selectedLetter() === letter"
-    >
-      {{ letter }}
-    </button>
-    <button
-      mat-stroked-button
       (click)="selectLetter('')"
       type="button"
-      class="letter-button app-pill-control"
+      class="letter-button"
       [class.letter-button--selected]="!selectedLetter()"
-      [class.is-active]="!selectedLetter()"
+      [attr.aria-pressed]="!selectedLetter()"
     >
       All
     </button>
-  </div>
+    <button
+      *ngFor="let letter of letters()"
+      (click)="selectLetter(letter)"
+      type="button"
+      class="letter-button"
+      [class.letter-button--selected]="selectedLetter() === letter"
+      [attr.aria-pressed]="selectedLetter() === letter"
+    >
+      {{ letter }}
+    </button>
+  </nav>
 
   <!-- Teams table -->
   <div class="table-wrap">

--- a/src/app/components/team-list/team-list.html
+++ b/src/app/components/team-list/team-list.html
@@ -31,14 +31,26 @@
     <div class="team-container app-data-shell">
       <table mat-table [dataSource]="filteredTeams()" class="team-table">
         <ng-container matColumnDef="team">
-          <th mat-header-cell *matHeaderCellDef class="team-header team-col app-data-head">Team</th>
+          <th
+            mat-header-cell
+            *matHeaderCellDef
+            scope="col"
+            class="team-header team-col app-data-head"
+          >
+            Team
+          </th>
           <td mat-cell *matCellDef="let team" class="team-cell team-col app-data-cell">
             <span class="team-name" matTooltip="Team overview page coming soon">{{ team }}</span>
           </td>
         </ng-container>
 
         <ng-container matColumnDef="ext">
-          <th mat-header-cell *matHeaderCellDef class="team-header ext-col app-data-head">
+          <th
+            mat-header-cell
+            *matHeaderCellDef
+            scope="col"
+            class="team-header ext-col app-data-head"
+          >
             <span class="header-inline">
               External Links
               <mat-icon>open_in_new</mat-icon>

--- a/src/app/components/team-list/team-list.scss
+++ b/src/app/components/team-list/team-list.scss
@@ -1,6 +1,11 @@
 .team-list {
   display: grid;
   gap: 16px;
+  min-width: 0;
+}
+
+.team-list > * {
+  min-width: 0;
 }
 
 .index-header {
@@ -31,6 +36,7 @@
   align-items: baseline;
   gap: 4px 12px;
   padding: 0;
+  max-width: 100%;
 }
 
 .letter-button {
@@ -53,16 +59,19 @@
 }
 
 .letter-button--selected {
-  color: #fecdd3;
-  background: rgba(225, 29, 72, 0.14);
-  box-shadow: inset 0 -2px 0 rgba(251, 113, 133, 0.55);
+  color: #fde68a;
+  background: rgba(217, 119, 6, 0.12);
+  box-shadow: inset 0 -2px 0 rgba(217, 119, 6, 0.58);
 }
 
 .table-wrap {
   margin-top: 2px;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .team-container {
+  max-width: 100%;
   overflow: auto;
 }
 
@@ -102,7 +111,7 @@
 }
 
 .team-row:hover .team-cell:first-child {
-  box-shadow: inset 3px 0 0 rgba(56, 189, 248, 0.42);
+  box-shadow: inset 3px 0 0 rgba(217, 119, 6, 0.48);
 }
 
 .team-name {
@@ -127,12 +136,14 @@
 }
 
 .links-cell a {
-  color: #fda4af;
+  color: var(--app-text-subtle);
   text-decoration: none;
 }
 
 .links-cell a:hover {
+  color: var(--app-text-strong);
   text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .links-cell a:focus-visible {

--- a/src/app/components/team-list/team-list.scss
+++ b/src/app/components/team-list/team-list.scss
@@ -1,6 +1,20 @@
 .team-list {
   display: grid;
-  gap: 14px;
+  gap: 16px;
+}
+
+.index-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--app-border);
+  padding-bottom: 8px;
+}
+
+.index-header span {
+  color: var(--app-text-muted);
+  font-size: 0.9rem;
 }
 
 .filter-title {
@@ -14,15 +28,34 @@
 .alphabet-filter {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  padding: 12px;
+  align-items: baseline;
+  gap: 4px 12px;
+  padding: 0;
 }
 
 .letter-button {
-  border-radius: var(--app-radius-pill);
+  min-width: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--app-text-subtle);
+  padding: 3px 4px;
+  font: inherit;
+  font-weight: 650;
+  line-height: 1.35;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.letter-button:hover {
+  color: var(--app-text-strong);
+  text-decoration: underline;
 }
 
 .letter-button--selected {
+  color: #fecdd3;
+  background: rgba(225, 29, 72, 0.14);
+  box-shadow: inset 0 -2px 0 rgba(251, 113, 133, 0.55);
 }
 
 .table-wrap {

--- a/src/app/components/team-list/team-list.scss
+++ b/src/app/components/team-list/team-list.scss
@@ -67,19 +67,21 @@
 .table-wrap {
   margin-top: 2px;
   max-width: 100%;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .team-container {
+  width: 100%;
   max-width: 100%;
   overflow: auto;
 }
 
 .team-table {
   width: 100%;
-  min-width: 840px;
+  min-width: 760px;
   border-collapse: separate;
   border-spacing: 0;
+  background: transparent;
 }
 
 .team-head-row {
@@ -89,33 +91,33 @@
 }
 
 .team-header {
-  padding: 12px 14px;
+  padding: 13px 10px;
   font-size: 11px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--app-text-muted);
+  color: var(--app-text-subtle);
 }
 
 .team-col {
-  width: 52%;
+  width: 44%;
 }
 
 .ext-col {
-  width: 48%;
+  width: 56%;
   text-align: right;
 }
 
 .team-cell {
-  padding: 13px 14px;
+  padding: 12px 10px;
   color: color-mix(in srgb, var(--app-text-subtle) 96%, var(--app-text-strong) 4%);
 }
 
-.team-row:hover .team-cell:first-child {
-  box-shadow: inset 3px 0 0 rgba(217, 119, 6, 0.48);
+.team-row:hover .team-cell {
+  background: rgba(148, 163, 184, 0.08);
 }
 
 .team-name {
-  color: #f8fbff;
+  color: var(--app-text-strong);
   font-weight: 600;
 }
 
@@ -128,7 +130,14 @@
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 4px;
+  gap: 6px;
+}
+
+.header-inline mat-icon {
+  width: 15px;
+  height: 15px;
+  font-size: 15px;
+  color: var(--app-text-muted);
 }
 
 .links-cell {
@@ -136,8 +145,9 @@
 }
 
 .links-cell a {
-  color: var(--app-text-subtle);
+  color: color-mix(in srgb, var(--app-text-subtle) 88%, var(--app-text-strong) 12%);
   text-decoration: none;
+  font-weight: 650;
 }
 
 .links-cell a:hover {
@@ -163,14 +173,18 @@
 
 @media (max-width: 980px) {
   .team-table {
-    min-width: 700px;
+    min-width: 680px;
   }
 }
 
 @media (max-width: 760px) {
+  .team-container {
+    border-radius: var(--app-radius-lg);
+  }
+
   .team-header,
   .team-cell {
-    padding: 10px 9px;
+    padding: 10px 8px;
   }
 
   .team-header {

--- a/src/app/components/team-list/team-list.ts
+++ b/src/app/components/team-list/team-list.ts
@@ -1,7 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { Component, computed, EventEmitter, Input, Output, signal } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -15,14 +13,7 @@ import {
   selector: 'app-team-list',
   templateUrl: './team-list.html',
   styleUrls: ['./team-list.scss'],
-  imports: [
-    CommonModule,
-    MatButtonModule,
-    MatTableModule,
-    FormsModule,
-    MatIconModule,
-    MatTooltipModule,
-  ],
+  imports: [CommonModule, MatTableModule, MatIconModule, MatTooltipModule],
 })
 export class TeamList {
   @Input() teams: string[] = [];

--- a/src/app/pages/home/home.html
+++ b/src/app/pages/home/home.html
@@ -1,52 +1,56 @@
 <div class="home app-page-shell">
-  <section class="hero app-surface">
+  <section class="hero">
     <header class="app-page-header">
-      <p class="app-page-eyebrow">Football Data Atlas</p>
-      <h1 class="app-page-title">Where English Football History Stays Searchable</h1>
+      <p class="app-page-eyebrow">English Football Archive</p>
+      <h1 class="app-page-title">Explore 137 seasons of English football history.</h1>
       <p class="app-page-lede">
-        From 1888 to today, inspect clubs, tables, and long-run patterns in one archive.
+        FootyStats brings league tables, club histories, promotion paths, and long-run patterns into
+        one searchable reference for the English game.
       </p>
     </header>
 
-    <div class="stats">
-      <div class="stat app-panel">
-        <span class="value">{{ seasonsCount() || '100+' }}</span>
-        <span class="label">Seasons</span>
-      </div>
-      <div class="stat app-panel">
-        <span class="value">{{ teamsCount() || '50+' }}</span>
-        <span class="label">Clubs Tracked</span>
-      </div>
-      <div class="stat app-panel">
-        <span class="value">3</span>
-        <span class="label">Primary Tiers</span>
-      </div>
+    <div class="archive-meta" aria-label="Archive coverage">
+      <span>
+        <strong>{{ seasonsCount() || '100+' }}</strong>
+        seasons
+      </span>
+      <span>
+        <strong>{{ teamsCount() || '50+' }}</strong>
+        clubs
+      </span>
+      <span>
+        <strong>3</strong>
+        primary tiers
+      </span>
     </div>
 
     <div class="cta-row">
-      <a mat-flat-button routerLink="/tables">Browse Season Tables</a>
+      <a mat-flat-button routerLink="/tables">Browse Tables</a>
       <a mat-stroked-button routerLink="/teams">Explore Clubs</a>
-      <span matTooltip="Coming soon">
-        <button mat-stroked-button disabled>View Rankings</button>
-      </span>
+      <a mat-stroked-button routerLink="/movement">Track Movement</a>
     </div>
   </section>
 
-  <section class="feature-grid">
-    <article class="feature app-panel">
-      <mat-icon>table_chart</mat-icon>
-      <h2>Historic League Tables</h2>
-      <p>Season-by-season standings from league formation to the modern era.</p>
+  <section class="archive-sections" aria-label="Archive pathways">
+    <article class="archive-section">
+      <p class="section-kicker">Tables</p>
+      <h2>Season records from the Football League era to today</h2>
+      <p>
+        Read each campaign as a preserved table, with standings, scoring, and relegation context.
+      </p>
+      <a routerLink="/tables">Open table archive</a>
     </article>
-    <article class="feature app-panel">
-      <mat-icon>sports_soccer</mat-icon>
-      <h2>Club History</h2>
-      <p>Track promotion, relegation, and performance shifts across decades.</p>
+    <article class="archive-section">
+      <p class="section-kicker">Clubs</p>
+      <h2>A directory of clubs across eras</h2>
+      <p>Browse every tracked club and jump to outside references for deeper research.</p>
+      <a routerLink="/teams">Browse club index</a>
     </article>
-    <article class="feature app-panel">
-      <mat-icon>trending_up</mat-icon>
-      <h2>Fast Comparison</h2>
-      <p>Scan key stats quickly with focused cards and cleaner table views.</p>
+    <article class="archive-section">
+      <p class="section-kicker">Movement</p>
+      <h2>Promotion and relegation paths over time</h2>
+      <p>Compare how clubs move through the pyramid across selected season windows.</p>
+      <a routerLink="/movement">Explore movement</a>
     </article>
   </section>
 </div>

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -42,6 +42,12 @@
 
 .cta-row a {
   border-radius: 8px;
+  --mdc-filled-button-container-color: #d97706;
+  --mdc-filled-button-label-text-color: #111827;
+  --mdc-outlined-button-label-text-color: var(--app-text-strong);
+  --mdc-outlined-button-outline-color: var(--app-border);
+  --mat-outlined-button-state-layer-color: var(--app-text-strong);
+  --mat-filled-button-state-layer-color: #111827;
 }
 
 .archive-sections {
@@ -81,13 +87,15 @@
 .archive-section a {
   margin-top: 16px;
   display: inline-flex;
-  color: #fecdd3;
+  color: var(--app-text-strong);
   text-decoration: none;
   font-weight: 650;
 }
 
 .archive-section a:hover {
+  color: #fde68a;
   text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 @media (max-width: 900px) {

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -1,81 +1,97 @@
 .home {
   display: grid;
-  gap: 22px;
+  gap: clamp(30px, 5vw, 58px);
 }
 
 .hero {
-  padding: clamp(20px, 3vw, 34px);
+  padding: clamp(8px, 2vw, 18px) 0 clamp(12px, 3vw, 28px);
+  border-bottom: 1px solid var(--app-border);
 }
 
-.stats {
-  margin-top: 22px;
-  display: grid;
-  gap: 10px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+.app-page-header {
+  max-width: 860px;
 }
 
-.stat {
-  padding: 14px;
+.archive-meta {
+  margin-top: clamp(22px, 4vw, 36px);
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.value {
-  font-size: clamp(24px, 3.2vw, 34px);
-  font-weight: 700;
-  color: var(--app-accent);
-}
-
-.label {
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  flex-wrap: wrap;
+  gap: 10px 24px;
   color: var(--app-text-muted);
+  font-size: 0.98rem;
+}
+
+.archive-meta span {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
+}
+
+.archive-meta strong {
+  color: var(--app-text-strong);
+  font-size: clamp(1.25rem, 2vw, 1.65rem);
+  line-height: 1;
 }
 
 .cta-row {
-  margin-top: 20px;
+  margin-top: clamp(24px, 4vw, 40px);
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
 }
 
-.cta-row a,
-.cta-row button {
-  border-radius: var(--app-radius-pill);
+.cta-row a {
+  border-radius: 8px;
 }
 
-.feature-grid {
+.archive-sections {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  gap: clamp(18px, 2.5vw, 28px);
 }
 
-.feature {
-  padding: 18px;
+.archive-section {
+  padding-top: 18px;
+  border-top: 1px solid var(--app-border);
 }
 
-.feature mat-icon {
-  width: 30px;
-  height: 30px;
-  font-size: 30px;
-  color: var(--app-accent);
+.section-kicker {
+  margin: 0 0 10px;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--app-text-muted);
 }
 
-.feature h2 {
-  margin: 10px 0 6px;
-  font-size: 17px;
-}
-
-.feature p {
+.archive-section h2 {
   margin: 0;
+  max-width: 22ch;
+  color: var(--app-text-strong);
+  font-size: clamp(1.25rem, 2vw, 1.65rem);
+  line-height: 1.18;
+  font-weight: 650;
+}
+
+.archive-section p:not(.section-kicker) {
+  margin: 12px 0 0;
   color: var(--app-text-subtle);
+  line-height: 1.55;
+}
+
+.archive-section a {
+  margin-top: 16px;
+  display: inline-flex;
+  color: #fecdd3;
+  text-decoration: none;
+  font-weight: 650;
+}
+
+.archive-section a:hover {
+  text-decoration: underline;
 }
 
 @media (max-width: 900px) {
-  .stats,
-  .feature-grid {
+  .archive-sections {
     grid-template-columns: 1fr;
   }
 }

--- a/src/app/pages/home/home.ts
+++ b/src/app/pages/home/home.ts
@@ -2,8 +2,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, computed, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
 import { LeagueStore } from '@app/store/league.store';
 
@@ -11,7 +9,7 @@ import { LeagueStore } from '@app/store/league.store';
   selector: 'app-home',
   templateUrl: './home.html',
   styleUrls: ['./home.scss'],
-  imports: [CommonModule, MatButtonModule, RouterLink, MatIconModule, MatTooltipModule],
+  imports: [CommonModule, MatButtonModule, RouterLink],
 })
 export class Home {
   private store = inject(LeagueStore);

--- a/src/app/pages/movement-explorer/movement-explorer.html
+++ b/src/app/pages/movement-explorer/movement-explorer.html
@@ -46,7 +46,7 @@
               </span>
             </span>
             <span class="quick-pick-trigger-icon" aria-hidden="true">
-              {{ quickPickMenuOpen() ? '−' : '+' }}
+              {{ quickPickMenuOpen() ? '-' : '+' }}
             </span>
           </button>
 
@@ -86,9 +86,10 @@
         </div>
       </div>
       <label class="search-field">
+        <span class="field-label">Search clubs</span>
         <input
           type="text"
-          placeholder="Search clubs directly..."
+          placeholder="Start typing a club name"
           [value]="clubSearchTerm()"
           (input)="onClubSearchInput($any($event.target).value)"
           [disabled]="selectedTeamIds().length >= maxSelectedTeams"
@@ -111,7 +112,12 @@
         <div class="selected-label">Selected clubs</div>
         <div class="selected-chips">
           @for (team of selectedTeams(); track team.id) {
-          <button class="chip" type="button" (click)="removeTeam(team.id)">
+          <button
+            class="chip"
+            type="button"
+            (click)="removeTeam(team.id)"
+            [attr.aria-label]="'Remove ' + team.name"
+          >
             {{ team.name }}
             <span aria-hidden="true">x</span>
           </button>

--- a/src/app/pages/movement-explorer/movement-explorer.scss
+++ b/src/app/pages/movement-explorer/movement-explorer.scss
@@ -6,27 +6,8 @@
   margin-top: 0;
 }
 
-.eyebrow {
-  margin: 0;
-  font-size: 11px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--app-text-muted);
-}
-
-h1 {
-  margin: 10px 0 8px;
-  font-size: clamp(1.45rem, 2.6vw, 2rem);
-  line-height: 1.2;
-}
-
-.lede {
-  margin: 0;
-  color: var(--app-text-subtle);
-}
-
 .page-note {
-  margin-top: 14px;
+  margin-top: 18px;
 }
 
 .page-note p {
@@ -34,30 +15,37 @@ h1 {
 }
 
 .config-toolbar {
-  margin-top: 12px;
+  margin-top: 18px;
   display: flex;
   justify-content: flex-end;
 }
 
 .config-toggle {
   border: 1px solid var(--app-border);
-  background: color-mix(in srgb, var(--app-bg) 84%, #fff 16%);
+  border-radius: 8px;
+  padding: 8px 12px;
+  background: transparent;
   color: var(--app-text-subtle);
-  border-radius: 999px;
-  padding: 7px 12px;
+  font: inherit;
+  font-weight: 650;
   cursor: pointer;
 }
 
+.config-toggle:hover {
+  color: var(--app-text-strong);
+  border-color: rgba(148, 163, 184, 0.38);
+}
+
 .controls {
-  margin-top: 18px;
+  margin-top: 22px;
   display: grid;
-  gap: 14px;
-  grid-template-columns: 1.3fr 1fr;
+  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.75fr);
+  gap: 18px;
 }
 
 .club-picker,
 .timeline-panel {
-  padding: 14px;
+  padding: clamp(16px, 2vw, 20px);
 }
 
 .picker-head,
@@ -65,36 +53,30 @@ h1 {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  margin-bottom: 10px;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--app-border);
 }
 
 .picker-head h2,
 .timeline-head h2 {
   margin: 0;
+  color: var(--app-text-strong);
   font-size: 1.05rem;
+  line-height: 1.2;
 }
 
 .picker-head span,
 .timeline-head span {
-  font-size: 0.88rem;
   color: var(--app-text-muted);
-}
-
-.search-field input {
-  width: 100%;
-  height: 44px;
-  border-radius: 12px;
-  border: 1px solid var(--app-border);
-  background: color-mix(in srgb, var(--app-bg) 86%, #fff 14%);
-  color: var(--app-text-strong);
-  padding: 0 12px;
-  font-size: 1rem;
+  font-size: 0.9rem;
 }
 
 .quick-pick-block {
-  margin-bottom: 16px;
-  padding-bottom: 14px;
-  border-bottom: 1px solid color-mix(in srgb, var(--app-border) 72%, #fff 28%);
+  margin-bottom: 18px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--app-border);
 }
 
 .quick-pick-shell {
@@ -103,49 +85,48 @@ h1 {
 
 .quick-pick-trigger {
   width: 100%;
+  min-height: 58px;
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: flex-start;
-  gap: 12px;
-  border: 1px solid color-mix(in srgb, #38bdf8 20%, var(--app-border) 80%);
-  border-radius: 14px;
+  gap: 16px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
   padding: 12px 14px;
-  background: linear-gradient(
-    145deg,
-    color-mix(in srgb, var(--app-surface-bg) 96%, #fff 4%),
-    color-mix(in srgb, var(--app-surface-bg) 88%, #0f172a 12%)
-  );
+  background: rgba(7, 10, 19, 0.18);
   color: var(--app-text-strong);
+  font: inherit;
   cursor: pointer;
   text-align: left;
-  box-shadow: 0 5px 14px rgba(2, 6, 23, 0.13);
+}
+
+.quick-pick-trigger:hover {
+  border-color: rgba(148, 163, 184, 0.38);
 }
 
 .quick-pick-trigger-copy {
   display: grid;
-  gap: 2px;
+  gap: 3px;
 }
 
 .quick-pick-trigger-label {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--app-text-strong);
+  font-weight: 700;
 }
 
 .quick-pick-trigger-meta {
   color: var(--app-text-muted);
-  font-size: 0.84rem;
+  font-size: 0.88rem;
 }
 
 .quick-pick-trigger-icon {
   width: 28px;
   height: 28px;
-  border-radius: 999px;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
   display: inline-grid;
   place-items: center;
-  background: color-mix(in srgb, #0ea5e9 14%, transparent 86%);
-  color: #bae6fd;
-  font-size: 1.1rem;
+  color: var(--app-text-subtle);
+  font-weight: 800;
   line-height: 1;
   flex: none;
 }
@@ -156,253 +137,229 @@ h1 {
   left: 0;
   right: 0;
   z-index: 5;
-  padding: 12px;
-  border: 1px solid rgba(56, 189, 248, 0.32);
-  border-radius: 16px;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.98), rgba(17, 24, 39, 0.96));
-  box-shadow:
-    0 12px 24px rgba(2, 6, 23, 0.34),
-    0 0 0 1px rgba(56, 189, 248, 0.06);
-  backdrop-filter: blur(0);
+  padding: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 8px;
+  background: #0b1220;
+  box-shadow: 0 14px 26px rgba(0, 0, 0, 0.28);
 }
 
 .quick-pick-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px 10px;
 }
 
-.quick-pick-tab {
-  border: 1px solid color-mix(in srgb, var(--app-border) 82%, #fff 18%);
-  border-radius: 999px;
-  padding: 7px 11px;
-  background: rgba(255, 255, 255, 0.05);
-  color: #d7deeb;
-  cursor: pointer;
-  transition: 120ms ease;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-}
-
-.quick-pick-tab.is-active {
-  border-color: rgba(125, 211, 252, 0.58);
-  background: linear-gradient(135deg, rgba(14, 165, 233, 0.32), rgba(37, 99, 235, 0.18));
-  color: #eff6ff;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    0 4px 10px rgba(14, 165, 233, 0.1);
-}
-
-.quick-pick-meta {
-  margin-top: 10px;
-  color: var(--app-text-muted);
-  font-size: 0.88rem;
-}
-
-.quick-pick-results {
-  margin-top: 10px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  min-height: 38px;
-}
-
-.quick-pick-empty {
-  margin-top: 10px;
-  color: var(--app-text-muted);
-  font-size: 0.88rem;
-}
-
-.search-results {
-  margin-top: 12px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  min-height: 38px;
-}
-
-.team-option {
+.quick-pick-tab,
+.team-option,
+.preset-btn,
+.chip,
+.clear-btn {
   border: 1px solid var(--app-border);
-  border-radius: 999px;
-  padding: 7px 11px;
+  border-radius: 6px;
+  background: transparent;
   color: var(--app-text-subtle);
-  background: color-mix(in srgb, var(--app-bg) 80%, #fff 20%);
+  font: inherit;
+  font-weight: 650;
   cursor: pointer;
-  transition: 120ms ease;
 }
 
-.team-option:hover:not(:disabled) {
-  border-color: color-mix(in srgb, #0284c7 55%, var(--app-border) 45%);
+.quick-pick-tab,
+.team-option,
+.preset-btn {
+  padding: 7px 10px;
+}
+
+.quick-pick-tab:hover,
+.team-option:hover:not(:disabled),
+.preset-btn:hover,
+.clear-btn:hover,
+.chip:hover {
+  border-color: rgba(148, 163, 184, 0.42);
   color: var(--app-text-strong);
 }
 
-.team-option:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+.quick-pick-tab.is-active,
+.preset-btn.is-active {
+  border-color: rgba(217, 119, 6, 0.58);
+  background: rgba(217, 119, 6, 0.12);
+  color: #fde68a;
 }
 
-.selected-chips {
+.quick-pick-meta,
+.quick-pick-empty {
+  margin-top: 12px;
+  color: var(--app-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.quick-pick-results,
+.search-results,
+.selected-chips,
+.preset-row {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
+.quick-pick-results,
+.search-results {
+  margin-top: 12px;
+  min-height: 38px;
+}
+
+.team-option:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.search-field {
+  display: grid;
+  gap: 7px;
+}
+
+.field-label {
+  color: var(--app-text-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.search-field input {
+  width: 100%;
+  height: 42px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: rgba(7, 10, 19, 0.22);
+  color: var(--app-text-strong);
+  padding: 0 12px;
+  font: inherit;
+}
+
+.search-field input::placeholder {
+  color: color-mix(in srgb, var(--app-text-muted) 74%, transparent);
+}
+
+.search-field input:focus-visible {
+  outline: 2px solid var(--app-focus-ring);
+  outline-offset: 2px;
+}
+
 .selected-block {
-  margin-top: 14px;
-  padding-top: 12px;
-  border-top: 1px solid color-mix(in srgb, var(--app-border) 72%, #fff 28%);
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--app-border);
 }
 
 .selected-label {
-  margin-bottom: 8px;
-  font-size: 0.84rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  margin-bottom: 10px;
   color: var(--app-text-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .chip {
-  border: 1px solid rgba(56, 189, 248, 0.42);
-  background: linear-gradient(135deg, rgba(14, 165, 233, 0.22), rgba(29, 78, 216, 0.14));
-  color: #f8fbff;
-  border-radius: 999px;
-  padding: 7px 11px;
+  padding: 7px 9px 7px 10px;
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  cursor: pointer;
-  box-shadow:
-    0 4px 10px rgba(2, 132, 199, 0.1),
-    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  background: rgba(15, 23, 42, 0.48);
+  color: var(--app-text-strong);
 }
 
 .chip span {
-  opacity: 0.92;
+  color: var(--app-text-muted);
+  font-weight: 800;
 }
 
 .clear-btn {
   margin-top: 12px;
-  border: 1px solid color-mix(in srgb, #38bdf8 40%, var(--app-border) 60%);
-  background: color-mix(in srgb, #0ea5e9 12%, transparent 88%);
-  color: #dbeafe;
-  border-radius: 8px;
-  padding: 6px 10px;
-  cursor: pointer;
+  padding: 7px 10px;
 }
 
 .years-row {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
-  color: var(--app-text-subtle);
-  font-size: 0.94rem;
 }
 
 .years-row > div {
-  flex: 1;
-  padding: 10px 12px;
-  border: 1px solid color-mix(in srgb, var(--app-border) 82%, #fff 18%);
-  border-radius: 12px;
-  background: linear-gradient(
-    145deg,
-    color-mix(in srgb, var(--app-surface-bg) 96%, #fff 4%),
-    color-mix(in srgb, var(--app-surface-bg) 88%, #0f172a 12%)
-  );
-  box-shadow: 0 3px 8px rgba(2, 6, 23, 0.1);
+  min-height: 74px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 12px;
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  background: rgba(7, 10, 19, 0.18);
+  color: var(--app-text-strong);
+  font-size: 1.15rem;
+  font-weight: 750;
 }
 
 .years-row strong {
-  display: block;
-  margin-bottom: 4px;
   color: var(--app-text-muted);
-  font-size: 0.78rem;
-  letter-spacing: 0.06em;
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .slider-row {
-  margin-top: 10px;
+  margin-top: 16px;
   display: grid;
-  gap: 10px;
+  gap: 14px;
 }
 
 .slider-row label {
   display: grid;
-  gap: 4px;
+  gap: 7px;
   color: var(--app-text-muted);
-  font-size: 0.84rem;
+  font-size: 0.88rem;
+  font-weight: 650;
 }
 
 .slider-row input[type='range'] {
   width: 100%;
-  accent-color: #e11d48;
+  accent-color: #d97706;
   cursor: pointer;
 }
 
 .preset-row {
-  margin-top: 12px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  margin-top: 16px;
 }
 
-.preset-btn {
-  border: 1px solid color-mix(in srgb, var(--app-border) 82%, #fff 18%);
-  background: rgba(255, 255, 255, 0.04);
-  color: #d7deeb;
-  border-radius: 999px;
-  padding: 7px 12px;
-  cursor: pointer;
-  transition: 120ms ease;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-}
-
-.preset-btn.is-active {
-  border-color: rgba(251, 113, 133, 0.58);
-  color: #fff1f2;
-  background: linear-gradient(135deg, rgba(225, 29, 72, 0.3), rgba(190, 24, 93, 0.18));
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    0 4px 10px rgba(225, 29, 72, 0.12);
+.empty,
+.legend,
+.chart-wrap {
+  margin-top: 18px;
 }
 
 .empty {
-  margin-top: 16px;
-  padding: 20px;
+  padding: 24px;
   color: var(--app-text-subtle);
   text-align: center;
 }
 
 .legend {
-  margin-top: 16px;
   padding: 12px 14px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px 16px;
-  align-items: center;
 }
 
 .movement-key-panel {
+  display: flex;
   justify-content: flex-end;
 }
 
 .legend-item {
   display: inline-flex;
+  flex-wrap: wrap;
   gap: 8px;
   align-items: center;
-  color: var(--app-text-subtle);
+  color: var(--app-text-muted);
   font-size: 0.9rem;
-}
-
-.swatch {
-  width: 13px;
-  height: 13px;
-  border-radius: 999px;
-  flex: none;
-}
-
-.movement-keys {
-  margin-left: auto;
-  gap: 8px;
 }
 
 .dot {
@@ -413,7 +370,7 @@ h1 {
 }
 
 .dot.plain {
-  background: #93c5fd;
+  background: #60a5fa;
 }
 
 .dot.promoted,
@@ -429,29 +386,34 @@ h1 {
 }
 
 .chart-wrap {
-  margin-top: 14px;
-  padding: 12px;
+  padding: 14px;
   overflow: hidden;
 }
 
 .movement-chart {
   width: 100%;
-  height: 720px;
-  min-height: 560px;
+  height: 680px;
+  min-height: 520px;
   display: block;
 }
 
-@media (max-width: 860px) {
+@media (max-width: 900px) {
   .controls {
     grid-template-columns: 1fr;
   }
 
-  .movement-keys {
-    margin-left: 0;
+  .movement-key-panel {
+    justify-content: flex-start;
   }
 
   .movement-chart {
     height: 620px;
     min-height: 480px;
+  }
+}
+
+@media (max-width: 560px) {
+  .years-row {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/app/pages/movement-explorer/movement-explorer.ts
+++ b/src/app/pages/movement-explorer/movement-explorer.ts
@@ -42,16 +42,17 @@ interface ClubQuickPickResolvedGroup extends ClubQuickPickGroup {
 }
 
 const TEAM_COLOR_POOL = [
-  '#dc2626',
-  '#2563eb',
-  '#059669',
-  '#7c3aed',
   '#d97706',
-  '#db2777',
+  '#059669',
+  '#2563eb',
   '#0891b2',
+  '#be123c',
   '#65a30d',
   '#4f46e5',
-  '#be123c',
+  '#b45309',
+  '#7c3aed',
+  '#0f766e',
+  '#64748b',
 ];
 
 const TIER_LABELS: Record<number, string> = {
@@ -349,10 +350,10 @@ export class MovementExplorer {
       animation: false,
       backgroundColor: 'transparent',
       grid: {
-        left: 220,
+        left: 184,
         right: 40,
-        top: 88,
-        bottom: 122,
+        top: 72,
+        bottom: 108,
         containLabel: false,
       },
       legend: {
@@ -360,7 +361,7 @@ export class MovementExplorer {
         left: 18,
         textStyle: {
           color: '#d7deeb',
-          fontSize: 18,
+          fontSize: 14,
           fontWeight: 600,
         },
       },
@@ -374,8 +375,8 @@ export class MovementExplorer {
         boundaryGap: false,
         axisLabel: {
           color: '#c5d0e4',
-          fontSize: 18,
-          margin: 20,
+          fontSize: 13,
+          margin: 16,
           hideOverlap: true,
         },
         axisLine: {
@@ -391,9 +392,9 @@ export class MovementExplorer {
         inverse: true,
         axisLabel: {
           color: '#c5d0e4',
-          fontSize: 17,
+          fontSize: 13,
           fontWeight: 700,
-          margin: 18,
+          margin: 14,
           formatter: (value: number) => this.tierLabel(value),
         },
         axisLine: { show: false },
@@ -409,15 +410,15 @@ export class MovementExplorer {
           bottom: 48,
           filterMode: 'none',
           backgroundColor: 'rgba(15, 23, 42, 0.75)',
-          fillerColor: 'rgba(225, 29, 72, 0.28)',
+          fillerColor: 'rgba(217, 119, 6, 0.24)',
           borderColor: 'rgba(148, 163, 184, 0.42)',
           handleStyle: {
-            color: '#f43f5e',
-            borderColor: '#fb7185',
+            color: '#d97706',
+            borderColor: '#f59e0b',
           },
           textStyle: {
             color: '#d7deeb',
-            fontSize: 14,
+            fontSize: 12,
           },
         },
       ],

--- a/src/app/pages/teams/teams.scss
+++ b/src/app/pages/teams/teams.scss
@@ -24,7 +24,6 @@
 
 h1 {
   margin: 5px 0 0;
-  font-size: 22px;
 }
 
 .lede {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -14,7 +14,7 @@ $dark-theme: m3-theme.$dark-theme;
 
   color-scheme: light;
   --app-bg-gradient: linear-gradient(125deg, #fff8f3 0%, #fffdf8 36%, #f6fbff 100%);
-  --app-bg-spot-1: radial-gradient(circle at 12% 12%, rgba(251, 113, 133, 0.14), transparent 24%);
+  --app-bg-spot-1: radial-gradient(circle at 12% 12%, rgba(217, 119, 6, 0.12), transparent 24%);
   --app-bg-spot-2: radial-gradient(circle at 82% 18%, rgba(251, 191, 36, 0.14), transparent 26%);
   --app-bg-spot-3: radial-gradient(circle at 50% 80%, rgba(59, 130, 246, 0.12), transparent 28%);
 
@@ -46,9 +46,9 @@ $dark-theme: m3-theme.$dark-theme;
   --app-text-subtle: #374151;
   --app-text-muted: #6b7280;
   --app-text-inverse: #ffffff;
-  --app-accent: #e11d48;
-  --app-accent-soft: #ffe4ea;
-  --app-focus-ring: #f43f5e;
+  --app-accent: #d97706;
+  --app-accent-soft: #fef3c7;
+  --app-focus-ring: #f59e0b;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -70,8 +70,8 @@ $dark-theme: m3-theme.$dark-theme;
     --app-text-strong: #f3f4f6;
     --app-text-subtle: #d1d5db;
     --app-text-muted: #b7c4d4;
-    --app-accent-soft: rgba(225, 29, 72, 0.22);
-    --app-focus-ring: #fb7185;
+    --app-accent-soft: rgba(217, 119, 6, 0.2);
+    --app-focus-ring: #f59e0b;
   }
 }
 
@@ -80,6 +80,12 @@ $dark-theme: m3-theme.$dark-theme;
 html,
 body {
   height: 100%;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 html {
@@ -102,6 +108,7 @@ body {
   margin: 0;
   font-family: Roboto, 'Helvetica Neue', sans-serif;
   color: var(--app-text-strong);
+  overflow-x: clip;
   background:
     var(--app-bg-spot-1), var(--app-bg-spot-2), var(--app-bg-spot-3), var(--app-bg-gradient);
   background-repeat: no-repeat;
@@ -155,7 +162,7 @@ body {
 }
 
 .app-page-shell {
-  width: min(1160px, calc(100% - 24px));
+  width: min(1160px, calc(100vw - 24px));
   margin: 22px auto 40px;
   padding: clamp(16px, 2.4vw, 26px);
 }
@@ -197,9 +204,9 @@ body {
 }
 
 .app-pill-control.is-active {
-  color: #fff1f2;
-  border-color: rgba(251, 113, 133, 0.38);
-  background: rgba(225, 29, 72, 0.18);
+  color: #fde68a;
+  border-color: rgba(217, 119, 6, 0.42);
+  background: rgba(217, 119, 6, 0.14);
   box-shadow: none;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -27,8 +27,8 @@ $dark-theme: m3-theme.$dark-theme;
   --app-space-7: 32px;
 
   --app-radius-sm: 10px;
-  --app-radius-md: 14px;
-  --app-radius-lg: 22px;
+  --app-radius-md: 12px;
+  --app-radius-lg: 16px;
   --app-radius-pill: 999px;
 
   --app-elevation-1: 0 4px 12px rgba(15, 23, 42, 0.05);
@@ -36,11 +36,11 @@ $dark-theme: m3-theme.$dark-theme;
   --app-elevation-3: 0 14px 34px rgba(15, 23, 42, 0.1);
 
   --app-surface-radius: var(--app-radius-lg);
-  --app-surface-border: 1px solid rgba(253, 186, 116, 0.24);
-  --app-surface-bg: rgba(255, 255, 255, 0.88);
-  --app-surface-shadow: var(--app-elevation-2);
-  --app-surface-blur: 10px;
-  --app-border: rgba(253, 186, 116, 0.24);
+  --app-surface-border: 1px solid rgba(148, 163, 184, 0.26);
+  --app-surface-bg: rgba(255, 255, 255, 0.92);
+  --app-surface-shadow: none;
+  --app-surface-blur: 0;
+  --app-border: rgba(148, 163, 184, 0.26);
 
   --app-text-strong: #111827;
   --app-text-subtle: #374151;
@@ -56,17 +56,17 @@ $dark-theme: m3-theme.$dark-theme;
     @include mat.all-component-colors($dark-theme);
     @include mat.color-variants-backwards-compatibility($dark-theme);
     color-scheme: dark;
-    --app-bg-gradient: linear-gradient(130deg, #111827 0%, #131c2e 42%, #0f172a 100%);
-    --app-bg-spot-1: radial-gradient(circle at 12% 12%, rgba(244, 63, 94, 0.14), transparent 28%);
-    --app-bg-spot-2: radial-gradient(circle at 82% 18%, rgba(245, 158, 11, 0.14), transparent 30%);
-    --app-bg-spot-3: radial-gradient(circle at 50% 80%, rgba(59, 130, 246, 0.12), transparent 32%);
+    --app-bg-gradient: #0b1220;
+    --app-bg-spot-1: none;
+    --app-bg-spot-2: none;
+    --app-bg-spot-3: none;
     --app-elevation-1: 0 4px 12px rgba(0, 0, 0, 0.18);
     --app-elevation-2: 0 8px 20px rgba(0, 0, 0, 0.22);
     --app-elevation-3: 0 14px 32px rgba(0, 0, 0, 0.26);
-    --app-surface-border: 1px solid rgba(251, 113, 133, 0.14);
+    --app-surface-border: 1px solid rgba(148, 163, 184, 0.18);
     --app-surface-bg: rgba(15, 23, 42, 0.72);
     --app-surface-blur: 4px;
-    --app-border: rgba(251, 113, 133, 0.14);
+    --app-border: rgba(148, 163, 184, 0.2);
     --app-text-strong: #f3f4f6;
     --app-text-subtle: #d1d5db;
     --app-text-muted: #b7c4d4;
@@ -142,24 +142,16 @@ body {
 .app-surface {
   border-radius: var(--app-surface-radius);
   border: var(--app-surface-border);
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--app-surface-bg) 98%, #fff 2%),
-    color-mix(in srgb, var(--app-surface-bg) 92%, #0f172a 8%)
-  );
+  background: var(--app-surface-bg);
   box-shadow: var(--app-surface-shadow);
-  backdrop-filter: blur(var(--app-surface-blur));
+  backdrop-filter: none;
 }
 
 .app-panel {
   border-radius: var(--app-radius-md);
   border: var(--app-surface-border);
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--app-surface-bg) 98%, #fff 2%),
-    color-mix(in srgb, var(--app-surface-bg) 92%, #111827 8%)
-  );
-  box-shadow: var(--app-elevation-1);
+  background: color-mix(in srgb, var(--app-surface-bg) 82%, transparent);
+  box-shadow: none;
 }
 
 .app-page-shell {
@@ -182,71 +174,61 @@ body {
 
 .app-page-header .app-page-title {
   margin: 8px 0 8px;
-  font-size: clamp(1.6rem, 2.3vw, 2rem);
-  line-height: 1.16;
-  letter-spacing: -0.015em;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1.04;
+  letter-spacing: 0;
   color: var(--app-text-strong);
 }
 
 .app-page-header .app-page-lede {
   margin: 0;
-  max-width: 64ch;
-  font-size: 1rem;
-  line-height: 1.42;
+  max-width: 72ch;
+  font-size: clamp(1.05rem, 1.7vw, 1.22rem);
+  line-height: 1.55;
   color: var(--app-text-subtle);
 }
 
 .app-pill-control {
-  border: 1px solid color-mix(in srgb, var(--app-border) 82%, #fff 18%);
+  border: 1px solid transparent;
   border-radius: var(--app-radius-pill);
-  background: rgba(255, 255, 255, 0.04);
+  background: transparent;
   color: #d7deeb;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  box-shadow: none;
 }
 
 .app-pill-control.is-active {
   color: #fff1f2;
-  border-color: rgba(251, 113, 133, 0.58);
-  background: linear-gradient(135deg, rgba(225, 29, 72, 0.3), rgba(190, 24, 93, 0.18));
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    0 4px 10px rgba(225, 29, 72, 0.12);
+  border-color: rgba(251, 113, 133, 0.38);
+  background: rgba(225, 29, 72, 0.18);
+  box-shadow: none;
 }
 
 .app-data-shell {
-  border-radius: var(--app-radius-lg);
+  border-radius: 10px;
   overflow: auto;
-  border: 1px solid color-mix(in srgb, #38bdf8 14%, var(--app-surface-border) 86%);
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--app-surface-bg) 98%, transparent),
-    color-mix(in srgb, var(--app-surface-bg) 94%, transparent)
-  );
-  box-shadow: 0 6px 14px rgba(2, 6, 23, 0.12);
-  backdrop-filter: blur(var(--app-surface-blur));
+  border: 1px solid var(--app-border);
+  background: rgba(7, 10, 19, 0.48);
+  box-shadow: none;
+  backdrop-filter: none;
 }
 
 .app-data-head {
   color: var(--app-text-muted);
   border-bottom: 1px solid color-mix(in srgb, var(--app-surface-border) 72%, transparent);
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--app-surface-bg) 98%, transparent),
-    color-mix(in srgb, var(--app-surface-bg) 94%, transparent)
-  );
+  background: rgba(7, 10, 19, 0.82);
 }
 
 .app-data-cell {
   border-bottom: 1px solid color-mix(in srgb, var(--app-surface-border) 50%, transparent);
-  background: color-mix(in srgb, var(--app-surface-bg) 34%, transparent);
+  background: rgba(7, 10, 19, 0.36);
 }
 
 .app-data-row:nth-child(even) .app-data-cell {
-  background: color-mix(in srgb, var(--app-surface-bg) 40%, transparent);
+  background: rgba(15, 23, 42, 0.36);
 }
 
 .app-data-row:hover .app-data-cell {
-  background: color-mix(in srgb, var(--app-accent-soft) 26%, transparent);
+  background: rgba(148, 163, 184, 0.08);
 }
 
 a:focus-visible,


### PR DESCRIPTION
## Summary
- Sets up repo-local AI Central integration and steering context.
- Refreshes FootyStats toward a flatter archive-style design system.
- Refines the Teams page table and letter filter to better match the new UI direction.

## What Changed
- Added AI Central link setup, repo steering files, `AGENTS.md`, and audit documentation.
- Reworked global theme, header, footer, home/archive, tables, teams, and movement views.
- Aligned the Clubs table with the league table styling.
- Updated the Teams letter filter into a compact but more visible control strip with clearer active and hover states.
- Improved table header semantics with explicit `scope="col"` where relevant.

## Validation
- `pnpm test`
- `pnpm lint`
- `pnpm test -- src/app/components/team-list/team-list.spec.ts src/app/pages/teams/teams.spec.ts`
- Browser checked `/dashboard`, `/tables`, `/teams`, and `/movement`.
- Browser checked Teams letter filter: selecting exact `A` showed 16 clubs and kept page width contained.

## Scope Notes
- `pnpm build` still exits `134` from the existing esbuild deadlock before Angular diagnostics.
- `pnpm lint` passes with existing Angular cache warnings.