### PR TITLE
Polish Movement explorer chart workflows

### DIFF
--- a/src/app/pages/movement-explorer/movement-explorer.html
+++ b/src/app/pages/movement-explorer/movement-explorer.html
@@ -238,15 +238,30 @@
         </div>
       </section>
 
-      <div class="legend-item movement-keys" aria-label="Chart legend">
-        <span class="dot promoted"></span>
-        <span>Promotion marker</span>
-        <span class="dot relegated"></span>
-        <span>Relegation marker</span>
-        <span class="dot plain"></span>
-        <span>Team line</span>
-        <span class="dot wartime"></span>
-        <span>Official league suspended</span>
+      <div class="chart-tools">
+        <div class="detail-toggle" aria-label="Chart detail mode">
+          @for (mode of chartDetailModes; track mode.id) {
+          <button
+            type="button"
+            [class.is-active]="chartDetailMode() === mode.id"
+            (click)="setChartDetailMode(mode.id)"
+          >
+            {{ mode.label }}
+          </button>
+          }
+        </div>
+        <div class="legend-item movement-keys" aria-label="Chart legend">
+          <span class="dot plain"></span>
+          <span>Club path</span>
+          @if (chartDetailMode() === 'events') {
+          <span class="dot promoted"></span>
+          <span>Promoted</span>
+          <span class="dot relegated"></span>
+          <span>Relegated</span>
+          }
+          <span class="dot wartime"></span>
+          <span>League suspended</span>
+        </div>
       </div>
     </div>
 

--- a/src/app/pages/movement-explorer/movement-explorer.html
+++ b/src/app/pages/movement-explorer/movement-explorer.html
@@ -6,14 +6,23 @@
       Pick up to 10 clubs and a season window to compare how they move through the English pyramid.
     </p>
   </header>
-  <app-notification-banner class="page-note" title="Data Coverage Warning" variant="warning">
-    <p>
+  <section class="research-note" aria-label="Data coverage note">
+    <strong>Research note</strong>
+    <span>
       Tier 1 and Tier 2 are the most complete. Data for lower tiers becomes much less reliable
       before the 1990s, so older promotion and relegation paths may be incomplete.
-    </p>
-  </app-notification-banner>
+    </span>
+  </section>
 
   <div class="config-toolbar">
+    <button
+      type="button"
+      class="config-toggle"
+      (click)="toggleChartSetupsPanel()"
+      [attr.aria-expanded]="!chartSetupsCollapsed()"
+    >
+      {{ chartSetupsCollapsed() ? 'Show Setups' : 'Hide Setups' }}
+    </button>
     <button
       type="button"
       class="config-toggle"
@@ -24,7 +33,30 @@
     </button>
   </div>
 
-  @if (!configCollapsed()) {
+  @if (!chartSetupsCollapsed()) {
+  <section class="chart-setups app-panel" aria-label="Quick chart setups">
+    <div class="chart-setups-head">
+      <div>
+        <h2>Chart Setups</h2>
+        <p>Quick comparisons for rivalries, eras, and clubs with dramatic movement.</p>
+      </div>
+    </div>
+    <div class="setup-grid">
+      @for (setup of chartSetups(); track setup.id) {
+      <button
+        type="button"
+        class="setup-card"
+        [class.is-active]="activeChartSetupId() === setup.id"
+        (click)="applyChartSetup(setup.id)"
+      >
+        <span class="setup-kicker">{{ setup.era }} / {{ setup.teamCount }} clubs</span>
+        <span class="setup-title">{{ setup.label }}</span>
+        <span class="setup-copy">{{ setup.description }}</span>
+      </button>
+      }
+    </div>
+  </section>
+  } @if (!configCollapsed()) {
   <div class="controls">
     <section class="club-picker app-panel">
       <div class="picker-head">
@@ -95,6 +127,7 @@
           [disabled]="selectedTeamIds().length >= maxSelectedTeams"
         />
       </label>
+      @if (hasClubSearchTerm()) {
       <div class="search-results">
         @for (team of filteredTeamOptions(); track team.id) {
         <button
@@ -107,7 +140,7 @@
         </button>
         }
       </div>
-      @if (selectedTeamIds().length) {
+      } @if (selectedTeamIds().length) {
       <div class="selected-block">
         <div class="selected-label">Selected clubs</div>
         <div class="selected-chips">
@@ -186,18 +219,37 @@
   } @else if (!teamSeries().length) {
   <div class="empty app-panel">No data in the selected season window for the chosen clubs.</div>
   } @else {
-  <div class="legend app-panel movement-key-panel">
-    <div class="legend-item movement-keys">
-      <span class="dot promoted"></span>
-      <span>Promotion marker</span>
-      <span class="dot relegated"></span>
-      <span>Relegation marker</span>
-      <span class="dot plain"></span>
-      <span>Team line</span>
-    </div>
-  </div>
-
   <div class="chart-wrap app-panel">
+    <div class="chart-header">
+      <section class="chart-context" aria-label="Current chart filters">
+        <div class="chart-context-main">
+          <span class="context-label">Current view</span>
+          <h2>{{ chartContextTitle() }}</h2>
+          <p>
+            {{ selectedSeasonRangeLabel() }} / {{ selectedSeasonCount() }} {{ selectedSeasonCount()
+            === 1 ? 'season' : 'seasons' }} / {{ selectedTeamIds().length }} {{
+            selectedTeamIds().length === 1 ? 'club' : 'clubs' }}
+          </p>
+        </div>
+        <div class="chart-context-clubs" aria-label="Selected clubs">
+          @for (teamName of selectedTeamNames(); track teamName) {
+          <span>{{ teamName }}</span>
+          }
+        </div>
+      </section>
+
+      <div class="legend-item movement-keys" aria-label="Chart legend">
+        <span class="dot promoted"></span>
+        <span>Promotion marker</span>
+        <span class="dot relegated"></span>
+        <span>Relegation marker</span>
+        <span class="dot plain"></span>
+        <span>Team line</span>
+        <span class="dot wartime"></span>
+        <span>Official league suspended</span>
+      </div>
+    </div>
+
     <div
       echarts
       class="movement-chart"

--- a/src/app/pages/movement-explorer/movement-explorer.scss
+++ b/src/app/pages/movement-explorer/movement-explorer.scss
@@ -501,6 +501,47 @@
   text-align: center;
 }
 
+.chart-tools {
+  flex: 0 1 460px;
+  display: grid;
+  justify-items: end;
+  align-content: start;
+  gap: 10px;
+}
+
+.detail-toggle {
+  align-self: start;
+  display: inline-flex;
+  align-items: center;
+  padding: 3px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: rgba(7, 10, 19, 0.22);
+}
+
+.detail-toggle button {
+  min-width: 72px;
+  height: auto;
+  border: 0;
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: transparent;
+  color: var(--app-text-muted);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.detail-toggle button:hover {
+  color: var(--app-text-strong);
+}
+
+.detail-toggle button.is-active {
+  background: rgba(217, 119, 6, 0.16);
+  color: #fde68a;
+}
+
 .legend-item {
   flex: 0 1 auto;
   display: inline-flex;
@@ -561,6 +602,11 @@
   .chart-header {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .chart-tools {
+    width: 100%;
+    justify-items: start;
   }
 
   .chart-context-clubs {

--- a/src/app/pages/movement-explorer/movement-explorer.scss
+++ b/src/app/pages/movement-explorer/movement-explorer.scss
@@ -6,18 +6,31 @@
   margin-top: 0;
 }
 
-.page-note {
+.research-note {
   margin-top: 18px;
+  border-left: 2px solid rgba(217, 119, 6, 0.62);
+  padding: 10px 0 10px 14px;
+  display: grid;
+  gap: 3px;
+  color: var(--app-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.45;
 }
 
-.page-note p {
-  margin: 0;
+.research-note strong {
+  color: #fde68a;
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .config-toolbar {
   margin-top: 18px;
   display: flex;
+  gap: 10px;
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .config-toggle {
@@ -34,6 +47,85 @@
 .config-toggle:hover {
   color: var(--app-text-strong);
   border-color: rgba(148, 163, 184, 0.38);
+}
+
+.chart-setups {
+  margin-top: 18px;
+  padding: clamp(16px, 2vw, 20px);
+}
+
+.chart-setups-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--app-border);
+}
+
+.chart-setups-head h2 {
+  margin: 0;
+  color: var(--app-text-strong);
+  font-size: 1.05rem;
+  line-height: 1.2;
+}
+
+.chart-setups-head p {
+  margin: 5px 0 0;
+  color: var(--app-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.setup-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.setup-card {
+  min-height: 132px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 12px;
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  background: rgba(7, 10, 19, 0.18);
+  color: var(--app-text-subtle);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.setup-card:hover {
+  border-color: rgba(148, 163, 184, 0.42);
+  color: var(--app-text-strong);
+}
+
+.setup-card.is-active {
+  border-color: rgba(217, 119, 6, 0.58);
+  background: rgba(217, 119, 6, 0.1);
+}
+
+.setup-kicker {
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.setup-title {
+  color: var(--app-text-strong);
+  font-weight: 780;
+  line-height: 1.25;
+}
+
+.setup-copy {
+  color: var(--app-text-muted);
+  font-size: 0.88rem;
+  line-height: 1.4;
 }
 
 .controls {
@@ -333,9 +425,74 @@
 }
 
 .empty,
-.legend,
 .chart-wrap {
   margin-top: 18px;
+}
+
+.chart-wrap {
+  padding: 14px;
+  overflow: hidden;
+}
+
+.chart-header {
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--app-border);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.chart-context {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: grid;
+  gap: 10px;
+}
+
+.chart-context-main {
+  min-width: 220px;
+}
+
+.context-label {
+  display: block;
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.chart-context h2 {
+  margin: 4px 0 0;
+  color: var(--app-text-strong);
+  font-size: 1.05rem;
+  line-height: 1.25;
+}
+
+.chart-context p {
+  margin: 5px 0 0;
+  color: var(--app-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.35;
+}
+
+.chart-context-clubs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.chart-context-clubs span {
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  padding: 5px 8px;
+  background: rgba(7, 10, 19, 0.18);
+  color: var(--app-text-subtle);
+  font-size: 0.84rem;
+  font-weight: 650;
+  line-height: 1.2;
 }
 
 .empty {
@@ -344,16 +501,8 @@
   text-align: center;
 }
 
-.legend {
-  padding: 12px 14px;
-}
-
-.movement-key-panel {
-  display: flex;
-  justify-content: flex-end;
-}
-
 .legend-item {
+  flex: 0 1 auto;
   display: inline-flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -373,6 +522,13 @@
   background: #60a5fa;
 }
 
+.dot.wartime {
+  width: 18px;
+  border-radius: 3px;
+  border: 1px solid rgba(245, 158, 11, 0.42);
+  background: rgba(245, 158, 11, 0.18);
+}
+
 .dot.promoted,
 .movement-dot.promoted {
   fill: #16a34a;
@@ -385,12 +541,8 @@
   background: #dc2626;
 }
 
-.chart-wrap {
-  padding: 14px;
-  overflow: hidden;
-}
-
 .movement-chart {
+  margin-top: 12px;
   width: 100%;
   height: 680px;
   min-height: 520px;
@@ -398,11 +550,20 @@
 }
 
 @media (max-width: 900px) {
+  .setup-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .controls {
     grid-template-columns: 1fr;
   }
 
-  .movement-key-panel {
+  .chart-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .chart-context-clubs {
     justify-content: flex-start;
   }
 
@@ -413,6 +574,18 @@
 }
 
 @media (max-width: 560px) {
+  .config-toolbar {
+    justify-content: stretch;
+  }
+
+  .config-toggle {
+    flex: 1 1 140px;
+  }
+
+  .setup-grid {
+    grid-template-columns: 1fr;
+  }
+
   .years-row {
     grid-template-columns: 1fr;
   }

--- a/src/app/pages/movement-explorer/movement-explorer.ts
+++ b/src/app/pages/movement-explorer/movement-explorer.ts
@@ -6,6 +6,8 @@ import {
   DataZoomComponent,
   GridComponent,
   LegendComponent,
+  MarkAreaComponent,
+  MarkPointComponent,
   TooltipComponent,
 } from 'echarts/components';
 import type { EChartsCoreOption } from 'echarts/core';
@@ -13,8 +15,9 @@ import * as echarts from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { NgxEchartsDirective, provideEchartsCore } from 'ngx-echarts';
 import { ActivatedRoute, Router } from '@angular/router';
-import { NotificationBannerComponent } from '@app/components/notification-banner/notification-banner';
 import { LeagueStore } from '@app/store/league.store';
+import { buildClubIdentityTeamIndex } from '@app/utils/club-aliases';
+import { getWartimeSuspensionRanges } from '@app/utils/wartime-suspensions';
 
 interface TeamSeriesPoint {
   season: number;
@@ -41,6 +44,16 @@ interface ClubQuickPickResolvedGroup extends ClubQuickPickGroup {
   teams: { id: number; name: string }[];
 }
 
+interface MovementChartSetup {
+  id: string;
+  label: string;
+  era: string;
+  description: string;
+  teamNames: string[];
+  startSeason: number | null;
+  endSeason: number | null;
+}
+
 const TEAM_COLOR_POOL = [
   '#d97706',
   '#059669',
@@ -64,6 +77,124 @@ const TIER_LABELS: Record<number, string> = {
   6: 'National League North',
   7: 'National League South',
 };
+
+const DEFAULT_STARTER_TEAM_NAMES = [
+  'Arsenal',
+  'Chelsea',
+  'Liverpool',
+  'Manchester City',
+  'Manchester United',
+  'Tottenham Hotspur',
+] as const;
+
+const DEFAULT_CHART_SETUP_ID = 'big-six-all-time';
+
+const MOVEMENT_CHART_SETUPS: MovementChartSetup[] = [
+  {
+    id: DEFAULT_CHART_SETUP_ID,
+    label: 'Big Six, full archive',
+    era: 'All seasons',
+    description: 'Modern heavyweights across the full recorded league archive.',
+    teamNames: [...DEFAULT_STARTER_TEAM_NAMES],
+    startSeason: null,
+    endSeason: null,
+  },
+  {
+    id: 'north-west-rivalries',
+    label: 'North West rivalries',
+    era: '1890 onward',
+    description: 'Liverpool, Everton, Manchester United, and Manchester City over the long run.',
+    teamNames: ['Liverpool', 'Everton', 'Manchester United', 'Manchester City'],
+    startSeason: 1890,
+    endSeason: null,
+  },
+  {
+    id: 'north-london',
+    label: 'North London',
+    era: '1893 onward',
+    description:
+      'Arsenal and Tottenham through early league entry, promotion, and modern stability.',
+    teamNames: ['Arsenal', 'Tottenham Hotspur'],
+    startSeason: 1893,
+    endSeason: null,
+  },
+  {
+    id: 'manchester',
+    label: 'Manchester divide',
+    era: '1890 onward',
+    description: 'United and City from Newton Heath and Ardwick roots to the Premier League era.',
+    teamNames: ['Manchester United', 'Manchester City'],
+    startSeason: 1890,
+    endSeason: null,
+  },
+  {
+    id: 'premier-league-powers',
+    label: 'Premier League powers',
+    era: '1992 onward',
+    description: 'The familiar Premier League contenders from the competition reset onward.',
+    teamNames: [
+      'Arsenal',
+      'Chelsea',
+      'Liverpool',
+      'Manchester City',
+      'Manchester United',
+      'Tottenham Hotspur',
+      'Newcastle United',
+    ],
+    startSeason: 1992,
+    endSeason: null,
+  },
+  {
+    id: 'leeds-rise-fall',
+    label: 'Leeds rise and fall',
+    era: '1960-2004',
+    description: 'Leeds against major rivals through ascent, title contention, and relegation.',
+    teamNames: ['Leeds United', 'Manchester United', 'Liverpool', 'Chelsea'],
+    startSeason: 1960,
+    endSeason: 2004,
+  },
+  {
+    id: 'outsider-champions',
+    label: 'Outsider champions',
+    era: '1988 onward',
+    description: 'Blackburn and Leicester beside the clubs that shaped their title-era context.',
+    teamNames: ['Blackburn Rovers', 'Leicester City', 'Manchester City', 'Chelsea'],
+    startSeason: 1988,
+    endSeason: null,
+  },
+  {
+    id: 'midlands-old-powers',
+    label: 'Midlands old powers',
+    era: 'All seasons',
+    description: 'Villa, Wolves, Albion, Birmingham, Derby, and Forest across the pyramid.',
+    teamNames: [
+      'Aston Villa',
+      'Wolverhampton Wanderers',
+      'West Bromwich Albion',
+      'Birmingham',
+      'Derby County',
+      'Nottingham Forest',
+    ],
+    startSeason: null,
+    endSeason: null,
+  },
+  {
+    id: 'fallen-giants',
+    label: 'Fallen giants',
+    era: '1960 onward',
+    description: 'Historic names with long arcs away from the top flight.',
+    teamNames: [
+      'Sunderland',
+      'Sheffield Wednesday',
+      'Ipswich Town',
+      'Bolton Wanderers',
+      'Preston North End',
+      'Derby County',
+    ],
+    startSeason: 1960,
+    endSeason: null,
+  },
+];
 
 const CLUB_QUICK_PICK_GROUPS: ClubQuickPickGroup[] = [
   {
@@ -121,12 +252,14 @@ echarts.use([
   TooltipComponent,
   LegendComponent,
   DataZoomComponent,
+  MarkAreaComponent,
+  MarkPointComponent,
   CanvasRenderer,
 ]);
 
 @Component({
   selector: 'app-movement-explorer',
-  imports: [CommonModule, NgxEchartsDirective, NotificationBannerComponent],
+  imports: [CommonModule, NgxEchartsDirective],
   templateUrl: './movement-explorer.html',
   styleUrl: './movement-explorer.scss',
   providers: [provideEchartsCore({ echarts })],
@@ -152,6 +285,8 @@ export class MovementExplorer {
   selectedEndSeason = signal<number | null>(null);
   activePreset = signal<string>('last-20');
   configCollapsed = signal<boolean>(false);
+  chartSetupsCollapsed = signal<boolean>(true);
+  activeChartSetupId = signal<string>(DEFAULT_CHART_SETUP_ID);
   private applyingUrlState = false;
   private lastSyncedQueryState = '';
   private hasAppliedInitialUrlState = signal<boolean>(false);
@@ -189,6 +324,8 @@ export class MovementExplorer {
       .slice(0, 14);
   });
 
+  hasClubSearchTerm = computed(() => Boolean(this.clubSearchTerm().trim()));
+
   clubQuickPickGroups = computed<ClubQuickPickResolvedGroup[]>(() => {
     const teams = this.teams();
     const selectedIds = new Set(this.selectedTeamIds());
@@ -209,7 +346,60 @@ export class MovementExplorer {
       null
   );
 
+  chartSetups = computed(() =>
+    MOVEMENT_CHART_SETUPS.map((setup) => ({
+      ...setup,
+      teamCount: this.getTeamIdsForNames(setup.teamNames).length,
+    })).filter((setup) => setup.teamCount > 0)
+  );
+
+  activeChartSetup = computed(
+    () => MOVEMENT_CHART_SETUPS.find((setup) => setup.id === this.activeChartSetupId()) ?? null
+  );
+
+  chartContextTitle = computed(() => this.activeChartSetup()?.label ?? 'Custom comparison');
+
+  selectedTeamNames = computed(() =>
+    this.selectedTeamIds()
+      .map((teamId) => this.store.getTeamById(teamId)?.name)
+      .filter((teamName): teamName is string => Boolean(teamName))
+  );
+
+  selectedSeasonRangeLabel = computed(() => {
+    const start = this.selectedStartSeason();
+    const end = this.selectedEndSeason();
+
+    if (start === null || end === null) {
+      return 'No season range selected';
+    }
+
+    return start === end ? String(start) : `${start}-${end}`;
+  });
+
   selectedSeasonCount = computed(() => this.selectedRange().length);
+
+  visibleTierBounds = computed(() => {
+    const tierValues = this.teamSeries().flatMap((series) =>
+      series.points.map((point) => point.tier)
+    );
+    const allTiers = this.tierLevels();
+    const globalMaxTier = allTiers.length ? Math.max(...allTiers) : 7;
+
+    if (!tierValues.length) {
+      return {
+        min: 1,
+        max: globalMaxTier,
+      };
+    }
+
+    const minVisibleTier = Math.min(...tierValues);
+    const maxVisibleTier = Math.max(...tierValues);
+
+    return {
+      min: Math.max(1, minVisibleTier - 1),
+      max: Math.min(globalMaxTier, maxVisibleTier + 1),
+    };
+  });
 
   selectedRange = computed(() => {
     const allSeasons = this.seasons();
@@ -240,15 +430,16 @@ export class MovementExplorer {
 
   teamSeries = computed<TeamSeries[]>(() => {
     const selected = this.selectedTeamIds();
-    const selectedIds = new Set(selected);
     const range = new Set(this.selectedRange());
     if (!selected.length || !range.size) {
       return [];
     }
 
+    const teamIdToSelectedId = buildClubIdentityTeamIndex(selected, this.teams());
     const dataByTeam = new Map<number, TeamSeriesPoint[]>();
     this.entries().forEach((entry) => {
-      if (!selectedIds.has(entry.teamId)) {
+      const selectedTeamId = teamIdToSelectedId.get(entry.teamId);
+      if (selectedTeamId === undefined) {
         return;
       }
       if (!range.has(entry.season)) {
@@ -260,11 +451,11 @@ export class MovementExplorer {
         return;
       }
 
-      if (!dataByTeam.has(entry.teamId)) {
-        dataByTeam.set(entry.teamId, []);
+      if (!dataByTeam.has(selectedTeamId)) {
+        dataByTeam.set(selectedTeamId, []);
       }
 
-      dataByTeam.get(entry.teamId)!.push({
+      dataByTeam.get(selectedTeamId)!.push({
         season: entry.season,
         tier: tierNumber,
         wasPromoted: entry.wasPromoted,
@@ -291,9 +482,36 @@ export class MovementExplorer {
 
   chartOptions = computed<EChartsCoreOption>(() => {
     const seasons = this.selectedRange();
-    const tiers = this.tierLevels();
-    const maxTier = tiers.length ? Math.max(...tiers) : 7;
+    const tierBounds = this.visibleTierBounds();
     const series = this.teamSeries();
+    const wartimeSuspensionRanges = getWartimeSuspensionRanges(seasons);
+    const wartimeMarkAreas = wartimeSuspensionRanges.map((range) => [
+      {
+        name: range.label,
+        xAxis: String(range.startSeason),
+        itemStyle: {
+          color: 'rgba(245, 158, 11, 0.12)',
+          borderColor: 'rgba(245, 158, 11, 0.32)',
+          borderWidth: 1,
+        },
+        label: {
+          show: true,
+          color: '#fde68a',
+          fontSize: 12,
+          fontWeight: 700,
+          formatter: range.label,
+          position: 'insideTop',
+        },
+        emphasis: {
+          label: {
+            color: '#fef3c7',
+          },
+        },
+      },
+      {
+        xAxis: String(range.endSeason),
+      },
+    ]);
 
     if (!seasons.length || !series.length) {
       return {
@@ -304,7 +522,7 @@ export class MovementExplorer {
       };
     }
 
-    const chartSeries = series.map((team) => {
+    const chartSeries = series.map((team, index) => {
       const pointsBySeason = new Map(team.points.map((point) => [point.season, point]));
       const lineData: (number | null)[] = seasons.map(
         (season) => pointsBySeason.get(season)?.tier ?? null
@@ -343,6 +561,18 @@ export class MovementExplorer {
           silent: true,
           z: 6,
         },
+        ...(index === 0 && wartimeMarkAreas.length
+          ? {
+              markArea: {
+                silent: false,
+                tooltip: {
+                  formatter: (params: { name?: string }) =>
+                    `${params.name ?? 'Wartime suspension'}: no official league table`,
+                },
+                data: wartimeMarkAreas,
+              },
+            }
+          : {}),
       };
     });
 
@@ -386,8 +616,8 @@ export class MovementExplorer {
       },
       yAxis: {
         type: 'value',
-        min: 1,
-        max: maxTier,
+        min: tierBounds.min,
+        max: tierBounds.max,
         interval: 1,
         inverse: true,
         axisLabel: {
@@ -460,7 +690,9 @@ export class MovementExplorer {
         query.get('start'),
         query.get('end'),
         query.get('preset'),
-        query.get('collapsed')
+        query.get('collapsed'),
+        query.get('setup'),
+        ['teams', 'start', 'end', 'preset', 'collapsed', 'setup'].some((param) => query.has(param))
       );
       this.hasAppliedInitialUrlState.set(true);
     });
@@ -475,6 +707,7 @@ export class MovementExplorer {
       const end = this.selectedEndSeason();
       const preset = this.activePreset();
       const collapsed = this.configCollapsed();
+      const setup = this.activeChartSetupId();
 
       const nextQuery: Record<string, string | null> = {
         teams: teams || null,
@@ -482,6 +715,7 @@ export class MovementExplorer {
         end: end === null ? null : String(end),
         preset: preset || null,
         collapsed: collapsed ? '1' : null,
+        setup: setup || null,
       };
 
       const nextQueryState = JSON.stringify(nextQuery);
@@ -510,6 +744,7 @@ export class MovementExplorer {
     }
     this.selectedTeamIds.set([...selected, teamId]);
     this.clubSearchTerm.set('');
+    this.activeChartSetupId.set('');
   }
 
   addQuickPickTeam(teamId: number) {
@@ -518,10 +753,12 @@ export class MovementExplorer {
 
   removeTeam(teamId: number) {
     this.selectedTeamIds.set(this.selectedTeamIds().filter((id) => id !== teamId));
+    this.activeChartSetupId.set('');
   }
 
   clearSelectedTeams() {
     this.selectedTeamIds.set([]);
+    this.activeChartSetupId.set('');
   }
 
   onClubSearchInput(value: string) {
@@ -555,6 +792,34 @@ export class MovementExplorer {
     this.configCollapsed.set(!this.configCollapsed());
   }
 
+  toggleChartSetupsPanel() {
+    this.chartSetupsCollapsed.set(!this.chartSetupsCollapsed());
+  }
+
+  applyChartSetup(setupId: string) {
+    const setup = MOVEMENT_CHART_SETUPS.find((candidate) => candidate.id === setupId);
+    if (!setup) {
+      return;
+    }
+
+    const min = this.minSeason();
+    const max = this.maxSeason();
+    const start = Math.max(min, Math.min(setup.startSeason ?? min, max));
+    const end = Math.max(start, Math.min(setup.endSeason ?? max, max));
+    const selectedTeamIds = this.getTeamIdsForNames(setup.teamNames).slice(
+      0,
+      this.maxSelectedTeams
+    );
+
+    this.selectedTeamIds.set(selectedTeamIds);
+    this.selectedStartSeason.set(start);
+    this.selectedEndSeason.set(end);
+    this.activePreset.set(start === min && end === max ? 'all' : '');
+    this.activeClubQuickPick.set(setup.id === DEFAULT_CHART_SETUP_ID ? 'big-six' : 'common');
+    this.activeChartSetupId.set(setup.id);
+    this.configCollapsed.set(true);
+  }
+
   onStartSeasonInput(rawValue: string) {
     const parsed = Number.parseInt(rawValue, 10);
     if (!Number.isFinite(parsed)) {
@@ -566,6 +831,7 @@ export class MovementExplorer {
     const currentEnd = this.selectedEndSeason() ?? max;
     this.selectedStartSeason.set(Math.min(clamped, currentEnd));
     this.activePreset.set('');
+    this.activeChartSetupId.set('');
   }
 
   onEndSeasonInput(rawValue: string) {
@@ -579,6 +845,7 @@ export class MovementExplorer {
     const currentStart = this.selectedStartSeason() ?? min;
     this.selectedEndSeason.set(Math.max(clamped, currentStart));
     this.activePreset.set('');
+    this.activeChartSetupId.set('');
   }
 
   setPreset(presetId: string) {
@@ -593,6 +860,7 @@ export class MovementExplorer {
       this.selectedStartSeason.set(min);
       this.selectedEndSeason.set(max);
       this.activePreset.set(presetId);
+      this.activeChartSetupId.set('');
       return;
     }
 
@@ -609,6 +877,7 @@ export class MovementExplorer {
     this.selectedStartSeason.set(Math.max(min, max - size + 1));
     this.selectedEndSeason.set(max);
     this.activePreset.set(presetId);
+    this.activeChartSetupId.set('');
   }
 
   tierLabel(tier: number): string {
@@ -625,7 +894,9 @@ export class MovementExplorer {
     startRaw: string | null,
     endRaw: string | null,
     presetRaw: string | null,
-    collapsedRaw: string | null
+    collapsedRaw: string | null,
+    setupRaw: string | null,
+    hasQueryState: boolean
   ) {
     this.applyingUrlState = true;
     try {
@@ -635,12 +906,22 @@ export class MovementExplorer {
         .map((value) => Number.parseInt(value, 10))
         .filter((value) => Number.isFinite(value) && validTeamIds.has(value))
         .slice(0, this.maxSelectedTeams);
-      this.selectedTeamIds.set(parsedTeams);
+      this.selectedTeamIds.set(hasQueryState ? parsedTeams : this.getDefaultSelectedTeamIds());
 
       const min = this.minSeason();
       const max = this.maxSeason();
       const parsedStart = Number.parseInt(startRaw ?? '', 10);
       const parsedEnd = Number.parseInt(endRaw ?? '', 10);
+
+      if (!hasQueryState) {
+        this.selectedStartSeason.set(min);
+        this.selectedEndSeason.set(max);
+        this.activePreset.set('all');
+        this.activeClubQuickPick.set('big-six');
+        this.activeChartSetupId.set(DEFAULT_CHART_SETUP_ID);
+        this.configCollapsed.set(true);
+        return;
+      }
 
       if (Number.isFinite(parsedStart)) {
         this.selectedStartSeason.set(Math.max(min, Math.min(parsedStart, max)));
@@ -658,9 +939,24 @@ export class MovementExplorer {
       if (presetRaw && this.availablePresets.some((preset) => preset.id === presetRaw)) {
         this.activePreset.set(presetRaw);
       }
+      this.activeChartSetupId.set(
+        setupRaw && MOVEMENT_CHART_SETUPS.some((setup) => setup.id === setupRaw) ? setupRaw : ''
+      );
       this.configCollapsed.set(collapsedRaw === '1');
     } finally {
       this.applyingUrlState = false;
     }
+  }
+
+  private getDefaultSelectedTeamIds(): number[] {
+    return this.getTeamIdsForNames([...DEFAULT_STARTER_TEAM_NAMES]);
+  }
+
+  private getTeamIdsForNames(teamNames: readonly string[]): number[] {
+    const teamByName = new Map(this.teams().map((team) => [team.name, team.id]));
+
+    return teamNames
+      .map((teamName) => teamByName.get(teamName))
+      .filter((teamId): teamId is number => teamId !== undefined);
   }
 }

--- a/src/app/pages/movement-explorer/movement-explorer.ts
+++ b/src/app/pages/movement-explorer/movement-explorer.ts
@@ -54,6 +54,8 @@ interface MovementChartSetup {
   endSeason: number | null;
 }
 
+type ChartDetailMode = 'path' | 'events';
+
 const TEAM_COLOR_POOL = [
   '#d97706',
   '#059669',
@@ -276,6 +278,10 @@ export class MovementExplorer {
     { id: 'last-50', label: 'Last 50' },
     { id: 'all', label: 'All Time' },
   ] as const;
+  readonly chartDetailModes: { id: ChartDetailMode; label: string }[] = [
+    { id: 'path', label: 'Path' },
+    { id: 'events', label: 'Events' },
+  ];
 
   selectedTeamIds = signal<number[]>([]);
   clubSearchTerm = signal<string>('');
@@ -286,6 +292,7 @@ export class MovementExplorer {
   activePreset = signal<string>('last-20');
   configCollapsed = signal<boolean>(false);
   chartSetupsCollapsed = signal<boolean>(true);
+  chartDetailMode = signal<ChartDetailMode>('path');
   activeChartSetupId = signal<string>(DEFAULT_CHART_SETUP_ID);
   private applyingUrlState = false;
   private lastSyncedQueryState = '';
@@ -485,6 +492,10 @@ export class MovementExplorer {
     const tierBounds = this.visibleTierBounds();
     const series = this.teamSeries();
     const wartimeSuspensionRanges = getWartimeSuspensionRanges(seasons);
+    const showMovementEvents = this.chartDetailMode() === 'events';
+    const isDenseComparison = series.length >= 5 || seasons.length >= 45;
+    const pathOpacity = isDenseComparison ? 0.64 : 0.88;
+    const pathWidth = isDenseComparison ? 2 : 2.4;
     const wartimeMarkAreas = wartimeSuspensionRanges.map((range) => [
       {
         name: range.label,
@@ -533,8 +544,8 @@ export class MovementExplorer {
         .map((point) => ({
           coord: [String(point.season), point.tier],
           symbol: 'circle',
-          symbolSize: 12,
-          itemStyle: { color: '#16a34a' },
+          symbolSize: 9,
+          itemStyle: { color: '#16a34a', borderColor: '#0f172a', borderWidth: 1 },
         }));
 
       const relegatedMarkers = team.points
@@ -542,8 +553,8 @@ export class MovementExplorer {
         .map((point) => ({
           coord: [String(point.season), point.tier],
           symbol: 'diamond',
-          symbolSize: 12,
-          itemStyle: { color: '#dc2626' },
+          symbolSize: 9,
+          itemStyle: { color: '#dc2626', borderColor: '#0f172a', borderWidth: 1 },
         }));
 
       return {
@@ -551,15 +562,24 @@ export class MovementExplorer {
         type: 'line',
         data: lineData,
         connectNulls: false,
-        showSymbol: true,
-        symbolSize: 6,
-        lineStyle: { width: 2.6, color: team.color },
-        itemStyle: { color: team.color },
-        emphasis: { focus: 'series' },
+        step: 'end',
+        showSymbol: false,
+        symbol: 'circle',
+        symbolSize: 5,
+        lineStyle: { width: pathWidth, color: team.color, opacity: pathOpacity },
+        itemStyle: { color: team.color, opacity: pathOpacity },
+        emphasis: {
+          focus: 'series',
+          lineStyle: { width: 3.4, opacity: 1 },
+          itemStyle: { opacity: 1 },
+        },
         markPoint: {
-          data: [...promotedMarkers, ...relegatedMarkers],
+          data: showMovementEvents ? [...promotedMarkers, ...relegatedMarkers] : [],
           silent: true,
           z: 6,
+          itemStyle: {
+            opacity: 0.82,
+          },
         },
         ...(index === 0 && wartimeMarkAreas.length
           ? {
@@ -598,6 +618,11 @@ export class MovementExplorer {
       tooltip: {
         trigger: 'axis',
         axisPointer: { type: 'line' },
+        backgroundColor: 'rgba(7, 10, 19, 0.94)',
+        borderColor: 'rgba(148, 163, 184, 0.28)',
+        textStyle: {
+          color: '#d7deeb',
+        },
       },
       xAxis: {
         type: 'category',
@@ -794,6 +819,10 @@ export class MovementExplorer {
 
   toggleChartSetupsPanel() {
     this.chartSetupsCollapsed.set(!this.chartSetupsCollapsed());
+  }
+
+  setChartDetailMode(mode: ChartDetailMode) {
+    this.chartDetailMode.set(mode);
   }
 
   applyChartSetup(setupId: string) {

--- a/src/app/utils/club-aliases.spec.ts
+++ b/src/app/utils/club-aliases.spec.ts
@@ -1,0 +1,33 @@
+import { buildClubIdentityTeamIndex, getClubIdentityNames } from './club-aliases';
+
+describe('club aliases', () => {
+  it.each([
+    ['Arsenal', ['Arsenal', 'Woolwich Arsenal']],
+    ['Woolwich Arsenal', ['Arsenal', 'Woolwich Arsenal']],
+    ['Manchester City', ['Manchester City', 'Ardwick']],
+    ['Ardwick', ['Manchester City', 'Ardwick']],
+    ['Manchester United', ['Manchester United', 'Newton Heath']],
+    ['Newton Heath', ['Manchester United', 'Newton Heath']],
+  ])('returns shared identity names for %s', (clubName, expectedNames) => {
+    expect(getClubIdentityNames(clubName)).toEqual(expectedNames);
+  });
+
+  it('returns the club name when no historical alias is configured', () => {
+    expect(getClubIdentityNames('Chelsea')).toEqual(['Chelsea']);
+  });
+
+  it('maps historical aliases back to the selected modern club id', () => {
+    const index = buildClubIdentityTeamIndex(
+      [2],
+      [
+        { id: 1, name: 'Woolwich Arsenal' },
+        { id: 2, name: 'Arsenal' },
+        { id: 3, name: 'Chelsea' },
+      ]
+    );
+
+    expect(index.get(1)).toBe(2);
+    expect(index.get(2)).toBe(2);
+    expect(index.has(3)).toBe(false);
+  });
+});

--- a/src/app/utils/club-aliases.ts
+++ b/src/app/utils/club-aliases.ts
@@ -1,0 +1,44 @@
+const CLUB_IDENTITY_GROUPS = [
+  ['Arsenal', 'Woolwich Arsenal'],
+  ['Manchester City', 'Ardwick'],
+  ['Manchester United', 'Newton Heath'],
+] as const;
+
+export interface ClubIdentityTeam {
+  id: number;
+  name: string;
+}
+
+export function getClubIdentityNames(clubName: string): readonly string[] {
+  return (
+    CLUB_IDENTITY_GROUPS.find((group) => (group as readonly string[]).includes(clubName)) ?? [
+      clubName,
+    ]
+  );
+}
+
+export function buildClubIdentityTeamIndex(
+  selectedTeamIds: readonly number[],
+  teams: readonly ClubIdentityTeam[]
+): Map<number, number> {
+  const teamById = new Map(teams.map((team) => [team.id, team]));
+  const teamIdToSelectedId = new Map<number, number>();
+
+  selectedTeamIds.forEach((selectedTeamId) => {
+    const selectedTeam = teamById.get(selectedTeamId);
+    if (!selectedTeam) {
+      return;
+    }
+
+    const identityNames = new Set(getClubIdentityNames(selectedTeam.name));
+    teams
+      .filter((team) => identityNames.has(team.name))
+      .forEach((team) => {
+        if (!teamIdToSelectedId.has(team.id)) {
+          teamIdToSelectedId.set(team.id, selectedTeamId);
+        }
+      });
+  });
+
+  return teamIdToSelectedId;
+}

--- a/src/app/utils/wartime-suspensions.spec.ts
+++ b/src/app/utils/wartime-suspensions.spec.ts
@@ -1,0 +1,36 @@
+import { getWartimeSuspensionRanges } from './wartime-suspensions';
+
+describe('wartime suspensions', () => {
+  it('returns no ranges when the selected seasons avoid wartime gaps', () => {
+    expect(getWartimeSuspensionRanges([2020, 2021, 2022])).toEqual([]);
+  });
+
+  it('returns complete wartime ranges when all suspended seasons are selected', () => {
+    expect(getWartimeSuspensionRanges([1914, 1915, 1916, 1917, 1918, 1919])).toEqual([
+      expect.objectContaining({
+        startSeason: 1915,
+        endSeason: 1918,
+        label: 'First World War',
+      }),
+    ]);
+
+    expect(
+      getWartimeSuspensionRanges([1938, 1939, 1940, 1941, 1942, 1943, 1944, 1945, 1946])
+    ).toEqual([
+      expect.objectContaining({
+        startSeason: 1939,
+        endSeason: 1945,
+        label: 'Second World War',
+      }),
+    ]);
+  });
+
+  it('clips wartime ranges to the selected season window', () => {
+    expect(getWartimeSuspensionRanges([1917, 1918, 1919])).toEqual([
+      expect.objectContaining({
+        startSeason: 1917,
+        endSeason: 1918,
+      }),
+    ]);
+  });
+});

--- a/src/app/utils/wartime-suspensions.ts
+++ b/src/app/utils/wartime-suspensions.ts
@@ -1,0 +1,45 @@
+export interface WartimeSuspensionRange {
+  startSeason: number;
+  endSeason: number;
+  label: string;
+  description: string;
+}
+
+const WARTIME_SUSPENSION_RANGES: readonly WartimeSuspensionRange[] = [
+  {
+    startSeason: 1915,
+    endSeason: 1918,
+    label: 'First World War',
+    description: 'Official Football League competition was suspended.',
+  },
+  {
+    startSeason: 1939,
+    endSeason: 1945,
+    label: 'Second World War',
+    description: 'Official league tables were abandoned or replaced by wartime competitions.',
+  },
+] as const;
+
+export function getWartimeSuspensionRanges(seasons: readonly number[]): WartimeSuspensionRange[] {
+  if (!seasons.length) {
+    return [];
+  }
+
+  const selectedSeasons = new Set(seasons);
+
+  return WARTIME_SUSPENSION_RANGES.map((range) => {
+    const includedSeasons = Array.from(selectedSeasons)
+      .filter((season) => season >= range.startSeason && season <= range.endSeason)
+      .sort((a, b) => a - b);
+
+    if (!includedSeasons.length) {
+      return null;
+    }
+
+    return {
+      ...range,
+      startSeason: includedSeasons[0],
+      endSeason: includedSeasons[includedSeasons.length - 1],
+    };
+  }).filter((range): range is WartimeSuspensionRange => range !== null);
+}


### PR DESCRIPTION
## Summary
- Improves the Movement explorer defaults, presets, historical continuity, and dense chart readability.

## What Changed
- Default `/movement` to an all-time Big Six comparison with filters collapsed.
- Add curated chart setups for rivalries, eras, fallen giants, and club arcs.
- Preserve setup/filter state in the URL for reloadable and shareable chart views.
- Add Big Six alias continuity for older club names.
- Add wartime suspension ranges and chart bands for missing official league years.
- Add a compact `Path / Events` chart mode so dense comparisons are readable by default.
- Use stepped season paths and muted dense-series styling to reduce visual clutter.

## Validation
- `pnpm exec tsc -p tsconfig.app.json --noEmit`
- `pnpm exec tsc -p tsconfig.spec.json --noEmit`
- `pnpm lint`
- `pnpm test`

## Scope Notes
- `pnpm lint` passes with existing warnings from generated Angular cache files.
- `pnpm build` was previously observed failing immediately after `Building...` without an Angular diagnostic and was not resolved in this PR.