### PR TITLE
Add team overview chart and milestones

### DIFF
--- a/src/app/components/league-table/league-table.html
+++ b/src/app/components/league-table/league-table.html
@@ -11,7 +11,13 @@
       <th mat-header-cell *matHeaderCellDef scope="col" class="head app-data-head">Team</th>
       <td mat-cell *matCellDef="let element" class="cell team app-data-cell">
         @if (element.clubId) {
-        <a class="team-link" [routerLink]="['/teams', element.clubId]">{{ element.teamName }}</a>
+        <a
+          class="team-link"
+          [routerLink]="['/teams', element.clubId]"
+          queryParamsHandling="preserve"
+        >
+          {{ element.teamName }}
+        </a>
         } @else { {{ element.teamName }} }
       </td>
     </ng-container>

--- a/src/app/components/team-list/team-list.html
+++ b/src/app/components/team-list/team-list.html
@@ -41,7 +41,9 @@
           </th>
           <td mat-cell *matCellDef="let team" class="team-cell team-col app-data-cell">
             @if (primaryClubId(team); as clubId) {
-            <a class="team-name" [routerLink]="['/teams', clubId]">{{ team.name }}</a>
+            <a class="team-name" [routerLink]="['/teams', clubId]" queryParamsHandling="preserve">
+              {{ team.name }}
+            </a>
             } @else {
             <span class="team-name" matTooltip="No club metadata available">{{ team.name }}</span>
             }

--- a/src/app/pages/team-overview/team-overview.html
+++ b/src/app/pages/team-overview/team-overview.html
@@ -2,7 +2,7 @@
 <div class="loading app-page-shell">Loading club profile...</div>
 } @else if (!club()) {
 <section class="team-overview app-surface app-page-shell">
-  <a class="back-link" routerLink="/teams">Back to clubs</a>
+  <a class="back-link" routerLink="/teams" queryParamsHandling="preserve">Back to clubs</a>
   <div class="empty-state app-panel">
     <p class="app-page-eyebrow">Club Profile</p>
     <h1>Club not found</h1>
@@ -11,7 +11,7 @@
 </section>
 } @else {
 <section class="team-overview app-surface app-page-shell">
-  <a class="back-link" routerLink="/teams">Back to clubs</a>
+  <a class="back-link" routerLink="/teams" queryParamsHandling="preserve">Back to clubs</a>
 
   <header class="profile-header">
     <div>
@@ -51,6 +51,58 @@
     </div>
   </section>
 
+  <div class="profile-feature-grid">
+    <section
+      class="profile-panel app-panel path-panel"
+      [class.path-panel--compact]="historyDisplayMode() === 'compact'"
+    >
+      <div class="panel-head">
+        <h2>{{ historyPanelTitle() }}</h2>
+        <span>{{ historyPanelMeta() }}</span>
+      </div>
+      @if (historyDisplayMode() === 'compact') {
+      <div class="season-snapshot-list">
+        @for (row of compactSeasonRows(); track row.season + row.tierLabel) {
+        <div>
+          <strong>{{ row.season }}</strong>
+          <span>{{ row.tierLabel }}</span>
+          <span>{{ row.positionLabel }}</span>
+          <span>{{ row.recordLabel }}</span>
+          @if (row.movementLabel) {
+          <em>{{ row.movementLabel }}</em>
+          }
+        </div>
+        }
+      </div>
+      } @else {
+      <div
+        echarts
+        class="path-chart"
+        [class.path-chart--small]="historyDisplayMode() === 'small-chart'"
+        [options]="chartOptions()"
+        [autoResize]="true"
+        aria-label="Club league tier path over time"
+      ></div>
+      }
+    </section>
+
+    <section class="profile-panel app-panel milestone-panel">
+      <div class="panel-head">
+        <h2>Milestones</h2>
+        <span>{{ milestoneCards().length }} notes</span>
+      </div>
+      <div class="milestone-list">
+        @for (milestone of milestoneCards(); track milestone.label) {
+        <div>
+          <span>{{ milestone.label }}</span>
+          <strong>{{ milestone.value }}</strong>
+          <small>{{ milestone.detail }}</small>
+        </div>
+        }
+      </div>
+    </section>
+  </div>
+
   <div class="profile-grid">
     <section class="profile-panel app-panel">
       <div class="panel-head">
@@ -74,7 +126,7 @@
       </div>
       <div class="chip-list">
         @for (alias of club()!.derived.aliases; track alias) {
-        <span>{{ alias }}</span>
+        <a [routerLink]="['/teams']" [queryParams]="{ letter: aliasLetter(alias) }">{{ alias }}</a>
         }
       </div>
       @if (displayNamePeriods().length) {
@@ -110,8 +162,14 @@
         @for (relationship of relationshipRows(); track relationship.clubKey +
         relationship.relationship) {
         <div>
-          <span>{{ relationship.relationship }} / {{ relationship.direction }}</span>
-          <strong>{{ relationship.relatedName }}</strong>
+          <span>{{ relationshipLabel(relationship.relationship, relationship.direction) }}</span>
+          <strong>
+            @if (relationship.relatedClubId) {
+            <a [routerLink]="['/teams', relationship.relatedClubId]" queryParamsHandling="preserve">
+              {{ relationship.relatedName }}
+            </a>
+            } @else { {{ relationship.relatedName }} }
+          </strong>
         </div>
         }
       </div>
@@ -144,14 +202,16 @@
     <div class="recent-table">
       <div class="recent-row recent-head">
         <span>Season</span>
+        <span>Name</span>
         <span>Tier</span>
         <span>Position</span>
         <span>Record</span>
         <span>Points</span>
       </div>
-      @for (entry of recentEntries(); track entry.season + entry.tier) {
+      @for (entry of recentSeasonRows(); track entry.season + entry.tier + entry.teamName) {
       <div class="recent-row">
         <span>{{ entry.season }}</span>
+        <span>{{ entry.teamName }}</span>
         <span>{{ tierLabel(entry.tier) }}</span>
         <span>{{ ordinal(entry.pos) }}</span>
         <span>{{ entry.won }}-{{ entry.drawn }}-{{ entry.lost }}</span>

--- a/src/app/pages/team-overview/team-overview.scss
+++ b/src/app/pages/team-overview/team-overview.scss
@@ -123,6 +123,12 @@
   line-height: 1.3;
 }
 
+.profile-feature-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(300px, 0.8fr);
+  gap: 14px;
+}
+
 .profile-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -154,6 +160,14 @@
   background: rgba(217, 119, 6, 0.76);
 }
 
+.path-panel::before {
+  background: rgba(96, 165, 250, 0.72);
+}
+
+.milestone-panel::before {
+  background: rgba(20, 184, 166, 0.72);
+}
+
 .panel-head {
   display: flex;
   align-items: baseline;
@@ -174,7 +188,8 @@
 .tier-list,
 .relationship-list,
 .gap-list,
-.period-list {
+.period-list,
+.milestone-list {
   display: grid;
   gap: 8px;
 }
@@ -182,7 +197,8 @@
 .tier-row,
 .relationship-list > div,
 .gap-list > div,
-.period-list > div {
+.period-list > div,
+.milestone-list > div {
   min-height: 42px;
   border: 1px solid var(--app-border);
   border-radius: 8px;
@@ -197,7 +213,8 @@
 .tier-row:hover,
 .relationship-list > div:hover,
 .gap-list > div:hover,
-.period-list > div:hover {
+.period-list > div:hover,
+.milestone-list > div:hover {
   border-color: rgba(148, 163, 184, 0.34);
   background: rgba(15, 23, 42, 0.42);
 }
@@ -205,7 +222,8 @@
 .tier-row span,
 .relationship-list span,
 .gap-list span,
-.period-list span {
+.period-list span,
+.milestone-list span {
   color: var(--app-text-muted);
   font-size: 0.9rem;
 }
@@ -228,9 +246,90 @@
 .tier-row strong,
 .relationship-list strong,
 .gap-list strong,
-.period-list strong {
+.period-list strong,
+.milestone-list strong {
   color: var(--app-text-strong);
   font-size: 0.95rem;
+}
+
+.relationship-list a {
+  color: inherit;
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+.relationship-list a:hover {
+  color: #fde68a;
+  text-decoration: underline;
+}
+
+.path-chart {
+  height: 285px;
+  min-height: 285px;
+}
+
+.path-chart--small {
+  height: 190px;
+  min-height: 190px;
+}
+
+.season-snapshot-list {
+  display: grid;
+  gap: 8px;
+}
+
+.season-snapshot-list > div {
+  min-height: 42px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  display: grid;
+  grid-template-columns: 62px minmax(120px, 1fr) 54px 64px auto;
+  align-items: center;
+  gap: 10px;
+  background: rgba(7, 10, 19, 0.2);
+}
+
+.season-snapshot-list > div:hover {
+  border-color: rgba(148, 163, 184, 0.34);
+  background: rgba(15, 23, 42, 0.42);
+}
+
+.season-snapshot-list strong {
+  color: var(--app-text-strong);
+  font-size: 0.95rem;
+}
+
+.season-snapshot-list span {
+  color: var(--app-text-muted);
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.season-snapshot-list em {
+  width: fit-content;
+  border: 1px solid rgba(245, 158, 11, 0.34);
+  border-radius: 999px;
+  padding: 3px 7px;
+  background: rgba(245, 158, 11, 0.1);
+  color: #fde68a;
+  font-size: 0.74rem;
+  font-style: normal;
+  font-weight: 750;
+}
+
+.milestone-list > div {
+  min-height: 74px;
+  align-items: flex-start;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.milestone-list small {
+  color: var(--app-text-muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.35;
 }
 
 .chip-list {
@@ -239,7 +338,8 @@
   gap: 8px;
 }
 
-.chip-list span {
+.chip-list span,
+.chip-list a {
   border: 1px solid var(--app-border);
   border-radius: 6px;
   padding: 6px 8px;
@@ -247,6 +347,14 @@
   color: var(--app-text-strong);
   font-size: 0.88rem;
   font-weight: 650;
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+.chip-list a:hover {
+  border-color: rgba(245, 158, 11, 0.42);
+  color: #fde68a;
+  text-decoration: underline;
 }
 
 .period-list {
@@ -258,7 +366,7 @@
 }
 
 .recent-table {
-  min-width: 720px;
+  min-width: 820px;
   display: grid;
   border: 1px solid rgba(148, 163, 184, 0.28);
   border-radius: 8px;
@@ -268,7 +376,7 @@
 
 .recent-row {
   display: grid;
-  grid-template-columns: 0.8fr 1.5fr 0.9fr 1fr 0.8fr;
+  grid-template-columns: 0.7fr 1.35fr 1.25fr 0.8fr 0.9fr 0.7fr;
 }
 
 .recent-row span {
@@ -301,6 +409,7 @@
 
 @media (max-width: 980px) {
   .profile-header,
+  .profile-feature-grid,
   .profile-grid {
     grid-template-columns: 1fr;
   }
@@ -326,8 +435,13 @@
   .tier-row,
   .relationship-list > div,
   .gap-list > div,
-  .period-list > div {
+  .period-list > div,
+  .season-snapshot-list > div {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .season-snapshot-list > div {
+    display: flex;
   }
 }

--- a/src/app/pages/team-overview/team-overview.spec.ts
+++ b/src/app/pages/team-overview/team-overview.spec.ts
@@ -3,6 +3,27 @@ import { convertToParamMap, ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { TeamOverview } from './team-overview';
 
+jest.mock('echarts/charts', () => ({ LineChart: {} }));
+jest.mock('echarts/components', () => ({
+  GridComponent: {},
+  MarkAreaComponent: {},
+  TooltipComponent: {},
+}));
+jest.mock('echarts/core', () => ({ use: jest.fn() }));
+jest.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+jest.mock('ngx-echarts', () => {
+  const core = jest.requireActual('@angular/core');
+  class MockNgxEchartsDirective {}
+  core.Directive({ selector: '[echarts]' })(MockNgxEchartsDirective);
+  core.Input()(MockNgxEchartsDirective.prototype, 'options');
+  core.Input()(MockNgxEchartsDirective.prototype, 'autoResize');
+
+  return {
+    NgxEchartsDirective: MockNgxEchartsDirective,
+    provideEchartsCore: () => [],
+  };
+});
+
 describe('TeamOverview', () => {
   let component: TeamOverview;
   let fixture: ComponentFixture<TeamOverview>;

--- a/src/app/pages/team-overview/team-overview.ts
+++ b/src/app/pages/team-overview/team-overview.ts
@@ -2,10 +2,18 @@ import { CommonModule } from '@angular/common';
 import { Component, computed, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
+import { LineChart } from 'echarts/charts';
+import { GridComponent, MarkAreaComponent, TooltipComponent } from 'echarts/components';
+import type { EChartsCoreOption } from 'echarts/core';
+import * as echarts from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { NgxEchartsDirective, provideEchartsCore } from 'ngx-echarts';
 import type { LeagueTableEntry } from '@app/store/league.models';
 import { ClubMetadataStore } from '@app/store/club-metadata.store';
 import { LeagueStore } from '@app/store/league.store';
 import { buildClubDerivedGaps, buildClubDisplayNamePeriods } from '@app/utils/club-identity-ranges';
+import { buildClubPerformanceMilestones } from '@app/utils/club-performance-milestones';
+import { getWartimeSuspensionRanges } from '@app/utils/wartime-suspensions';
 
 const TIER_LABELS: Record<string, string> = {
   tier1: 'Premier League',
@@ -17,9 +25,51 @@ const TIER_LABELS: Record<string, string> = {
   tier7: 'National League South',
 };
 
+const RELATIONSHIP_LABELS: Record<string, string> = {
+  merger: 'Merger',
+  phoenix: 'Phoenix club',
+  relocation: 'Relocation',
+  successor: 'Successor',
+  supporterPhoenix: 'Supporter phoenix',
+};
+
+const RELATIONSHIP_DIRECTION_LABELS: Record<string, string> = {
+  formedBySupportersOf: 'formed by supporters of',
+  formedFrom: 'formed from',
+  mergedInto: 'merged into',
+  predecessor: 'predecessor',
+  relocatedFrom: 'relocated from',
+  relocatedTo: 'relocated to',
+  successor: 'successor',
+  supporterFounded: 'supporter founded',
+};
+
+interface MilestoneCard {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+interface CompactSeasonRow {
+  season: number;
+  tierLabel: string;
+  positionLabel: string;
+  recordLabel: string;
+  movementLabel: string | null;
+}
+
+interface RecentSeasonRow extends LeagueTableEntry {
+  teamName: string;
+}
+
+type HistoryDisplayMode = 'compact' | 'small-chart' | 'full-chart';
+
+echarts.use([LineChart, GridComponent, TooltipComponent, MarkAreaComponent, CanvasRenderer]);
+
 @Component({
   selector: 'app-team-overview',
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, RouterLink, NgxEchartsDirective],
+  providers: [provideEchartsCore({ echarts })],
   templateUrl: './team-overview.html',
   styleUrl: './team-overview.scss',
 })
@@ -86,12 +136,14 @@ export class TeamOverview {
   });
   relationshipRows = computed(
     () =>
-      this.club()?.derived.relationships?.map((relationship) => ({
-        ...relationship,
-        relatedName:
-          this.clubMetadataStore.getClubById(relationship.clubKey)?.canonicalName ??
-          relationship.clubKey,
-      })) ?? []
+      this.club()?.derived.relationships?.map((relationship) => {
+        const relatedClub = this.clubMetadataStore.getClubById(relationship.clubKey);
+        return {
+          ...relationship,
+          relatedClubId: relatedClub ? relationship.clubKey : null,
+          relatedName: relatedClub?.canonicalName ?? relationship.clubKey,
+        };
+      }) ?? []
   );
   displayNamePeriods = computed(() =>
     buildClubDisplayNamePeriods(this.club()?.derived.observedNamePeriods ?? [])
@@ -110,9 +162,223 @@ export class TeamOverview {
     return buildClubDerivedGaps(this.club()?.derived.observedNamePeriods ?? []);
   });
   recentEntries = computed(() => this.entries().slice(0, 12));
+  recentSeasonRows = computed<RecentSeasonRow[]>(() =>
+    this.recentEntries().map((entry) => ({
+      ...entry,
+      teamName: this.leagueStore.getTeamNameById(entry.teamId),
+    }))
+  );
+  entriesAscending = computed(() =>
+    this.entries()
+      .slice()
+      .sort((a, b) => a.season - b.season || this.tierRank(a.tier) - this.tierRank(b.tier))
+  );
+  historyDisplayMode = computed<HistoryDisplayMode>(() => {
+    const seasonCount = this.club()?.derived.totalSeasonsSeen ?? this.entries().length;
+    if (seasonCount <= 10) {
+      return 'compact';
+    }
+
+    if (seasonCount <= 20) {
+      return 'small-chart';
+    }
+
+    return 'full-chart';
+  });
+  historyPanelTitle = computed(() =>
+    this.historyDisplayMode() === 'compact' ? 'Season Snapshot' : 'League Path'
+  );
+  historyPanelMeta = computed(() => {
+    const seasonCount = this.club()?.derived.totalSeasonsSeen ?? this.entries().length;
+    return `${seasonCount} ${seasonCount === 1 ? 'season' : 'seasons'}`;
+  });
+  compactSeasonRows = computed<CompactSeasonRow[]>(() =>
+    this.entriesAscending().map((entry) => ({
+      season: entry.season,
+      tierLabel: this.tierLabel(entry.tier),
+      positionLabel: this.ordinal(entry.pos),
+      recordLabel: `${entry.won}-${entry.drawn}-${entry.lost}`,
+      movementLabel: this.movementLabel(entry),
+    }))
+  );
+  performanceMilestones = computed(() => buildClubPerformanceMilestones(this.entries()));
+  milestoneCards = computed<MilestoneCard[]>(() => {
+    const milestones = this.performanceMilestones();
+
+    return [
+      {
+        label: 'First table record',
+        value: this.entryLabel(milestones.firstEntry),
+        detail: 'Earliest season in the current archive data.',
+      },
+      {
+        label: 'Top-flight peak',
+        value: milestones.bestTopFlightEntry
+          ? this.entryLabel(milestones.bestTopFlightEntry)
+          : 'No top-flight data',
+        detail: 'Best recorded finish in the highest available tier.',
+      },
+      {
+        label: 'Longest top-flight run',
+        value: this.runLabel(milestones.longestTopFlightRun),
+        detail: 'Consecutive top-tier table rows; official war gaps do not break the run.',
+      },
+      {
+        label: 'Longest tracked run',
+        value: this.runLabel(milestones.longestTrackedRun),
+        detail: 'Longest continuous spell anywhere in the tracked league pyramid.',
+      },
+      {
+        label: 'Largest non-war gap',
+        value: milestones.longestNonWartimeGap
+          ? `${milestones.longestNonWartimeGap.fromSeason}-${milestones.longestNonWartimeGap.toSeason}`
+          : 'No non-war gaps',
+        detail: milestones.longestNonWartimeGap
+          ? `${milestones.longestNonWartimeGap.seasons} missing seasons between table records.`
+          : 'Only official wartime suspensions or continuous records were found.',
+      },
+      {
+        label: 'Movement seasons',
+        value: `${milestones.promotionSeasons.length} up / ${milestones.relegationSeasons.length} down`,
+        detail: this.movementYearsLabel(milestones.promotionSeasons, milestones.relegationSeasons),
+      },
+    ];
+  });
+  chartOptions = computed<EChartsCoreOption>(() => {
+    const entries = this.entriesAscending();
+    if (!entries.length) {
+      return {
+        animation: false,
+        xAxis: { type: 'category', data: [] },
+        yAxis: { type: 'value' },
+        series: [],
+      };
+    }
+
+    const firstSeason = entries[0].season;
+    const lastSeason = entries.at(-1)!.season;
+    const seasons = Array.from(
+      { length: lastSeason - firstSeason + 1 },
+      (_, index) => firstSeason + index
+    );
+    const entriesBySeason = new Map(entries.map((entry) => [entry.season, entry]));
+    const data = seasons.map((season) => {
+      const entry = entriesBySeason.get(season);
+      return entry ? this.tierNumber(entry.tier) : null;
+    });
+    const tierValues = entries.map((entry) => this.tierNumber(entry.tier));
+    const isSmallChart = this.historyDisplayMode() === 'small-chart';
+    const wartimeMarkAreas = getWartimeSuspensionRanges(seasons).map((range) => [
+      {
+        name: range.label,
+        xAxis: String(range.startSeason),
+        itemStyle: {
+          color: 'rgba(217, 119, 6, 0.14)',
+          borderColor: 'rgba(217, 119, 6, 0.28)',
+          borderWidth: 1,
+        },
+        label: {
+          color: '#fde68a',
+          fontSize: 11,
+        },
+      },
+      {
+        xAxis: String(range.endSeason),
+      },
+    ]);
+
+    return {
+      animation: false,
+      backgroundColor: 'transparent',
+      grid: {
+        left: isSmallChart ? 96 : 110,
+        right: 18,
+        top: 18,
+        bottom: isSmallChart ? 30 : 36,
+        containLabel: false,
+      },
+      tooltip: {
+        trigger: 'axis',
+        backgroundColor: 'rgba(7, 10, 19, 0.94)',
+        borderColor: 'rgba(148, 163, 184, 0.28)',
+        textStyle: {
+          color: '#d7deeb',
+        },
+        formatter: (params: unknown) => this.pathTooltip(params, entriesBySeason),
+      },
+      xAxis: {
+        type: 'category',
+        data: seasons.map((season) => String(season)),
+        boundaryGap: false,
+        axisLabel: {
+          color: '#c5d0e4',
+          hideOverlap: true,
+          fontSize: isSmallChart ? 10 : 11,
+        },
+        axisLine: {
+          lineStyle: { color: 'rgba(148, 163, 184, 0.45)' },
+        },
+        axisTick: { show: false },
+      },
+      yAxis: {
+        type: 'value',
+        inverse: true,
+        min: Math.max(1, Math.min(...tierValues) - 0.25),
+        max: Math.max(...tierValues) + 0.25,
+        interval: 1,
+        axisLabel: {
+          color: '#c5d0e4',
+          fontSize: isSmallChart ? 10 : 11,
+          fontWeight: 700,
+          margin: 12,
+          formatter: (value: number) => this.tierLabel(`tier${value}`),
+        },
+        axisLine: { show: false },
+        splitLine: {
+          lineStyle: { color: 'rgba(148, 163, 184, 0.18)' },
+        },
+      },
+      series: [
+        {
+          name: this.club()?.canonicalName ?? 'Club path',
+          type: 'line',
+          data,
+          step: 'end',
+          connectNulls: false,
+          showSymbol: false,
+          symbolSize: 6,
+          lineStyle: {
+            width: 2.8,
+            color: '#f59e0b',
+          },
+          itemStyle: {
+            color: '#fbbf24',
+          },
+          markArea: {
+            silent: false,
+            tooltip: {
+              formatter: (params: { name?: string }) =>
+                `${params.name ?? 'Official league suspended'}: no official table record`,
+            },
+            data: wartimeMarkAreas,
+          },
+        },
+      ],
+    };
+  });
 
   tierLabel(tier: string): string {
     return TIER_LABELS[tier] ?? tier;
+  }
+
+  aliasLetter(alias: string): string {
+    return alias.trim().charAt(0).toUpperCase();
+  }
+
+  relationshipLabel(relationship: string, direction: string): string {
+    const relationshipLabel = RELATIONSHIP_LABELS[relationship] ?? relationship;
+    const directionLabel = RELATIONSHIP_DIRECTION_LABELS[direction] ?? direction;
+    return `${relationshipLabel} / ${directionLabel}`;
   }
 
   entryLabel(entry: LeagueTableEntry | null): string {
@@ -136,7 +402,70 @@ export class TeamOverview {
     return `${value}${suffixByMod10[value % 10] ?? 'th'}`;
   }
 
+  runLabel(run: { startSeason: number; endSeason: number; rowCount: number } | null): string {
+    if (!run) {
+      return 'No tracked run';
+    }
+
+    return `${run.startSeason}-${run.endSeason} / ${run.rowCount} ${run.rowCount === 1 ? 'season' : 'seasons'}`;
+  }
+
+  private movementLabel(entry: LeagueTableEntry): string | null {
+    if (entry.wasPromoted) {
+      return 'Promoted';
+    }
+
+    if (entry.wasRelegated) {
+      return 'Relegated';
+    }
+
+    if (entry.wasReprieved) {
+      return 'Reprieved';
+    }
+
+    return null;
+  }
+
+  private movementYearsLabel(promoted: readonly number[], relegated: readonly number[]): string {
+    const latestPromotions = promoted.slice(-3).join(', ');
+    const latestRelegations = relegated.slice(-3).join(', ');
+
+    if (!latestPromotions && !latestRelegations) {
+      return 'No promotion or relegation markers in the current table data.';
+    }
+
+    return [
+      latestPromotions ? `Recent promotions: ${latestPromotions}` : null,
+      latestRelegations ? `Recent relegations: ${latestRelegations}` : null,
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join(' / ');
+  }
+
+  private pathTooltip(
+    params: unknown,
+    entriesBySeason: ReadonlyMap<number, LeagueTableEntry>
+  ): string {
+    const point = Array.isArray(params) ? params[0] : params;
+    if (!point || typeof point !== 'object' || !('axisValue' in point)) {
+      return '';
+    }
+
+    const season = Number((point as { axisValue: string }).axisValue);
+    const entry = entriesBySeason.get(season);
+    if (!entry) {
+      return `${season}: no table record`;
+    }
+
+    return `${season}: ${this.tierLabel(entry.tier)}, ${this.ordinal(entry.pos)}, ${entry.points} pts`;
+  }
+
   private tierRank(tier: string): number {
+    const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+    return Number.isFinite(parsed) ? parsed : 99;
+  }
+
+  private tierNumber(tier: string): number {
     const parsed = Number.parseInt(tier.replace('tier', ''), 10);
     return Number.isFinite(parsed) ? parsed : 99;
   }

--- a/src/app/utils/club-performance-milestones.spec.ts
+++ b/src/app/utils/club-performance-milestones.spec.ts
@@ -1,0 +1,68 @@
+import type { LeagueTableEntry } from '@app/store/league.models';
+import { buildClubPerformanceMilestones } from './club-performance-milestones';
+
+describe('buildClubPerformanceMilestones', () => {
+  it('keeps top-flight runs continuous across official wartime suspensions', () => {
+    const milestones = buildClubPerformanceMilestones([
+      tableEntry({ season: 1914, tier: 'tier1', pos: 3 }),
+      tableEntry({ season: 1919, tier: 'tier1', pos: 2 }),
+      tableEntry({ season: 1920, tier: 'tier1', pos: 1 }),
+    ]);
+
+    expect(milestones.longestTopFlightRun).toEqual({
+      startSeason: 1914,
+      endSeason: 1920,
+      seasons: [1914, 1919, 1920],
+      rowCount: 3,
+    });
+    expect(milestones.longestNonWartimeGap).toBeNull();
+  });
+
+  it('reports ordinary missing spans as non-wartime gaps', () => {
+    const milestones = buildClubPerformanceMilestones([
+      tableEntry({ season: 2001, tier: 'tier2', pos: 4 }),
+      tableEntry({ season: 2005, tier: 'tier2', pos: 1, wasPromoted: true }),
+      tableEntry({ season: 2006, tier: 'tier1', pos: 20, wasRelegated: true }),
+    ]);
+
+    expect(milestones.longestTrackedRun).toEqual({
+      startSeason: 2005,
+      endSeason: 2006,
+      seasons: [2005, 2006],
+      rowCount: 2,
+    });
+    expect(milestones.longestNonWartimeGap).toEqual({
+      fromSeason: 2002,
+      toSeason: 2004,
+      seasons: 3,
+    });
+    expect(milestones.promotionSeasons).toEqual([2005]);
+    expect(milestones.relegationSeasons).toEqual([2006]);
+  });
+});
+
+function tableEntry(overrides: Partial<LeagueTableEntry>): LeagueTableEntry {
+  return {
+    season: 2025,
+    tier: 'tier1',
+    teamId: 1,
+    clubId: 'alpha fc',
+    pos: 1,
+    played: 38,
+    won: 20,
+    drawn: 10,
+    lost: 8,
+    goalsFor: 60,
+    goalsAgainst: 40,
+    goalDifference: 20,
+    goalAverage: null,
+    points: 70,
+    notes: null,
+    wasRelegated: false,
+    wasPromoted: false,
+    isExpansionTeam: false,
+    wasReElected: false,
+    wasReprieved: false,
+    ...overrides,
+  };
+}

--- a/src/app/utils/club-performance-milestones.ts
+++ b/src/app/utils/club-performance-milestones.ts
@@ -1,0 +1,140 @@
+import type { LeagueTableEntry } from '@app/store/league.models';
+import { isWartimeSuspensionSpan } from './wartime-suspensions';
+
+export interface ClubSeasonRun {
+  startSeason: number;
+  endSeason: number;
+  seasons: number[];
+  rowCount: number;
+}
+
+export interface ClubSeasonGap {
+  fromSeason: number;
+  toSeason: number;
+  seasons: number;
+}
+
+export interface ClubPerformanceMilestones {
+  firstEntry: LeagueTableEntry | null;
+  bestTopFlightEntry: LeagueTableEntry | null;
+  longestTopFlightRun: ClubSeasonRun | null;
+  longestTrackedRun: ClubSeasonRun | null;
+  longestNonWartimeGap: ClubSeasonGap | null;
+  promotionSeasons: number[];
+  relegationSeasons: number[];
+}
+
+type EntryPredicate = (entry: LeagueTableEntry) => boolean;
+
+export function buildClubPerformanceMilestones(
+  entries: readonly LeagueTableEntry[]
+): ClubPerformanceMilestones {
+  const sortedEntries = entries
+    .slice()
+    .sort((a, b) => a.season - b.season || tierRank(a.tier) - tierRank(b.tier));
+
+  const promotionSeasons = sortedEntries
+    .filter((entry) => entry.wasPromoted)
+    .map((entry) => entry.season);
+  const relegationSeasons = sortedEntries
+    .filter((entry) => entry.wasRelegated)
+    .map((entry) => entry.season);
+
+  return {
+    firstEntry: sortedEntries[0] ?? null,
+    bestTopFlightEntry: sortedEntries
+      .filter((entry) => entry.tier === 'tier1')
+      .reduce<LeagueTableEntry | null>(
+        (best, entry) => (!best || entry.pos < best.pos ? entry : best),
+        null
+      ),
+    longestTopFlightRun: findLongestRun(sortedEntries, (entry) => entry.tier === 'tier1'),
+    longestTrackedRun: findLongestRun(sortedEntries, () => true),
+    longestNonWartimeGap: findLongestNonWartimeGap(sortedEntries),
+    promotionSeasons,
+    relegationSeasons,
+  };
+}
+
+function findLongestRun(
+  entries: readonly LeagueTableEntry[],
+  predicate: EntryPredicate
+): ClubSeasonRun | null {
+  const matchingEntries = entries.filter(predicate);
+  if (!matchingEntries.length) {
+    return null;
+  }
+
+  const runs = matchingEntries.reduce<ClubSeasonRun[]>((acc, entry) => {
+    const currentRun = acc.at(-1);
+    const previousSeason = currentRun?.endSeason;
+
+    if (
+      !currentRun ||
+      previousSeason === undefined ||
+      !isContinuousSeason(previousSeason, entry.season)
+    ) {
+      acc.push({
+        startSeason: entry.season,
+        endSeason: entry.season,
+        seasons: [entry.season],
+        rowCount: 1,
+      });
+      return acc;
+    }
+
+    currentRun.endSeason = entry.season;
+    currentRun.seasons.push(entry.season);
+    currentRun.rowCount += 1;
+    return acc;
+  }, []);
+
+  return runs.reduce((best, run) => {
+    if (run.rowCount !== best.rowCount) {
+      return run.rowCount > best.rowCount ? run : best;
+    }
+
+    return run.endSeason - run.startSeason > best.endSeason - best.startSeason ? run : best;
+  });
+}
+
+function findLongestNonWartimeGap(entries: readonly LeagueTableEntry[]): ClubSeasonGap | null {
+  const gaps = entries
+    .slice(0, -1)
+    .map((entry, index) => {
+      const nextEntry = entries[index + 1];
+      const fromSeason = entry.season + 1;
+      const toSeason = nextEntry.season - 1;
+      if (fromSeason > toSeason || isWartimeSuspensionSpan(fromSeason, toSeason)) {
+        return null;
+      }
+
+      return {
+        fromSeason,
+        toSeason,
+        seasons: toSeason - fromSeason + 1,
+      };
+    })
+    .filter((gap): gap is ClubSeasonGap => gap !== null);
+
+  if (!gaps.length) {
+    return null;
+  }
+
+  return gaps.reduce((longest, gap) => (gap.seasons > longest.seasons ? gap : longest));
+}
+
+function isContinuousSeason(previousSeason: number, nextSeason: number): boolean {
+  if (nextSeason === previousSeason + 1) {
+    return true;
+  }
+
+  const omittedFrom = previousSeason + 1;
+  const omittedTo = nextSeason - 1;
+  return isWartimeSuspensionSpan(omittedFrom, omittedTo);
+}
+
+function tierRank(tier: string): number {
+  const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+  return Number.isFinite(parsed) ? parsed : 99;
+}


### PR DESCRIPTION
## Summary
- Adds a richer team overview experience with a league-path visualization, milestone stats, and small navigation polish.

## What Changed
- Added a team overview `League Path` chart for long-history clubs.
- Added adaptive display behavior:
  - short histories show a compact season snapshot
  - medium histories use a smaller chart
  - long histories keep the full chart
- Added milestone calculations for first record, top-flight peak, longest runs, gaps, and movement seasons.
- Made continuity/phoenix related club names clickable.
- Humanized continuity labels such as `Supporter phoenix / formed by supporters of`.
- Preserved club-directory query params through team links and back links.
- Added alias chip links back to the club directory.
- Added historical row names to Recent Seasons.

## Validation
- `pnpm exec tsc -p tsconfig.app.json --noEmit`
- `pnpm exec tsc -p tsconfig.spec.json --noEmit`
- `pnpm test`
- `pnpm lint`

## Scope Notes
- Current commit: `b51399f Add team overview chart and milestones`
- `pnpm lint` passes with existing generated `.angular/cache` warnings only.
- `pnpm build` was attempted but still aborts with `SIGABRT` immediately after `Building...`, matching the earlier repo behavior.
- Browser checked compact, medium, and long-history team pages plus query-param/navigation polish.