### PR TITLE
Added Report Data Issue feature

### DIFF
--- a/docs/data-issue-reporting.md
+++ b/docs/data-issue-reporting.md
@@ -1,0 +1,55 @@
+# Data Issue Reporting
+
+FootyStats lets users report data problems without needing a GitHub account. The in-app report form sends directly through Web3Forms, so the app can collect reports without adding a backend endpoint.
+
+## Web3Forms Setup
+
+Web3Forms requires a public access key. Add the project key in:
+
+```ts
+src/environments/environment.ts
+```
+
+```ts
+export const environment = {
+  web3FormsAccessKey: 'YOUR_WEB3FORMS_ACCESS_KEY',
+};
+```
+
+The browser submits reports to `https://api.web3forms.com/submit`. Web3Forms treats the access key as a public form identifier, not a secret.
+
+## User-Friendly Template
+
+The dialog asks for one main answer and a few optional helpers:
+
+- What should we fix?
+- Correct value or source
+- Club, season, and league context
+- Email for follow-up
+
+The generated Web3Forms message still includes the richer context for maintainers:
+
+```text
+Data issue report
+
+What should we fix?
+<Short description of the incorrect, missing, duplicated, or confusing data>
+
+Correct value or source
+<Correct value, source link, book/newspaper reference, screenshot note, or anything helpful>
+
+Issue type: <Data looks wrong | Missing season or club | Duplicate or confusing club identity | Source or coverage question>
+Page or feature: <Where the user reported from>
+Link or screen: <App route or context>
+Club or team: <Club/team if known>
+Season or year: <Season if known>
+League or competition: <League/tier if known>
+
+Reporter email: <Optional>
+```
+
+## Current Entry Points
+
+- Site footer: generic data report.
+- League table archive: prefilled with the selected season and competition.
+- Club profile: prefilled with the current club and latest visible season context.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -18,6 +18,7 @@ const config: Config = {
   testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
   moduleNameMapper: {
     '^@app/(.*)$': '<rootDir>/src/app/$1',
+    '^@env/(.*)$': '<rootDir>/src/environments/$1',
   },
 };
 

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -52,6 +52,11 @@
           >
             Source
           </a>
+          <app-data-issue-report-dialog
+            triggerLabel="Report data issue"
+            triggerStyle="link"
+            [context]="footerIssueContext"
+          />
         </div>
       </nav>
     </div>

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -109,6 +109,10 @@
   line-height: 1.75;
 }
 
+.footer-link-group app-data-issue-report-dialog {
+  display: block;
+}
+
 .footer-link-group a:hover {
   color: var(--app-text-strong);
   text-decoration: underline;

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,16 +1,21 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { DataIssueReportDialog } from './components/data-issue-report-dialog/data-issue-report-dialog';
 import { MainToolbar } from './components/main-toolbar/main-toolbar';
 import { DataLoaderService } from './store/services/hydrate-store-json';
 
 @Component({
   selector: 'app-root',
-  imports: [MainToolbar, RouterModule],
+  imports: [MainToolbar, RouterModule, DataIssueReportDialog],
   templateUrl: './app.html',
   styleUrl: './app.scss',
 })
 export class App implements OnInit {
   protected readonly title = signal('Footy Stats - English Football Data');
+  protected readonly footerIssueContext = {
+    pageTitle: 'FootyStats',
+    sourcePath: 'Site footer',
+  };
   private dataLoader = inject(DataLoaderService);
 
   ngOnInit() {

--- a/src/app/components/data-issue-report-dialog/data-issue-report-dialog.html
+++ b/src/app/components/data-issue-report-dialog/data-issue-report-dialog.html
@@ -1,0 +1,117 @@
+<button
+  type="button"
+  class="report-trigger"
+  [class.report-trigger--link]="triggerStyle() === 'link'"
+  (click)="open()"
+>
+  {{ triggerLabel() }}
+</button>
+
+@if (isOpen()) {
+<div class="report-backdrop" role="presentation" (click)="close()"></div>
+<section class="report-dialog" role="dialog" aria-modal="true" aria-labelledby="data-report-title">
+  <header class="report-head">
+    <div>
+      <p>Data report</p>
+      <h2 id="data-report-title">Report a data issue</h2>
+    </div>
+    <button type="button" class="icon-btn" aria-label="Close data report form" (click)="close()">
+      x
+    </button>
+  </header>
+
+  <div class="report-body">
+    <label class="wide-field">
+      <span>
+        What should we fix?
+        <em>Required</em>
+      </span>
+      <textarea
+        rows="3"
+        required
+        aria-required="true"
+        placeholder="Example: The 1999 points total looks too high."
+        [value]="form().summary"
+        (input)="updateField('summary', $any($event.target).value)"
+      ></textarea>
+    </label>
+
+    <label class="wide-field">
+      <span>Correct value or source</span>
+      <input
+        type="text"
+        placeholder="Optional: add the right value, source, or link if you have it."
+        [value]="form().source"
+        (input)="updateField('source', $any($event.target).value)"
+      />
+    </label>
+
+    <div class="field-grid">
+      <label>
+        <span>Club</span>
+        <input
+          type="text"
+          [value]="form().clubName || ''"
+          (input)="updateField('clubName', $any($event.target).value)"
+        />
+      </label>
+      <label>
+        <span>Season</span>
+        <input
+          type="number"
+          inputmode="numeric"
+          [value]="form().season || ''"
+          (input)="updateField('season', $any($event.target).value)"
+        />
+      </label>
+      <label>
+        <span>League</span>
+        <input
+          type="text"
+          [value]="form().competition || ''"
+          (input)="updateField('competition', $any($event.target).value)"
+        />
+      </label>
+    </div>
+
+    <div class="contact-row">
+      <label>
+        <span>Your email</span>
+        <input
+          type="email"
+          placeholder="Optional, only if we can follow up."
+          [value]="form().reporterEmail"
+          (input)="updateField('reporterEmail', $any($event.target).value)"
+        />
+      </label>
+    </div>
+  </div>
+
+  <footer class="report-actions">
+    <span>
+      @if (submitState() === 'sent') { Report sent. Thanks for helping improve the data. } @else if
+      (submitState() === 'error') { {{ errorMessage() }} } @else if (submitState() ===
+      'missing-key') { Report submissions need a Web3Forms access key before they can be sent. }
+      @else { Sends this report directly to FootyStats. }
+    </span>
+    <span
+      class="send-action"
+      [matTooltip]="!canSubmit() ? disabledReason() : ''"
+      [matTooltipDisabled]="canSubmit()"
+      [matTooltipShowDelay]="150"
+      [attr.aria-label]="!canSubmit() ? disabledReason() : null"
+    >
+      <button
+        type="button"
+        class="send-link"
+        [class.send-link--disabled]="!canSubmit()"
+        [disabled]="!canSubmit()"
+        (click)="submit()"
+      >
+        @if (submitState() === 'sending') { Sending... } @else if (submitState() === 'sent') { Sent
+        } @else { Send report }
+      </button>
+    </span>
+  </footer>
+</section>
+}

--- a/src/app/components/data-issue-report-dialog/data-issue-report-dialog.scss
+++ b/src/app/components/data-issue-report-dialog/data-issue-report-dialog.scss
@@ -1,0 +1,222 @@
+:host {
+  display: inline-block;
+}
+
+.report-trigger {
+  border: 1px solid rgba(245, 158, 11, 0.42);
+  border-radius: 7px;
+  padding: 8px 11px;
+  background: rgba(245, 158, 11, 0.1);
+  color: #fde68a;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.report-trigger:hover {
+  border-color: rgba(245, 158, 11, 0.68);
+  background: rgba(245, 158, 11, 0.16);
+}
+
+.report-trigger--link {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--app-text-muted);
+  font-size: 0.94rem;
+  font-weight: 650;
+  line-height: 1.75;
+}
+
+.report-trigger--link:hover {
+  background: transparent;
+  color: var(--app-text-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.report-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  background: rgba(2, 6, 23, 0.72);
+}
+
+.report-dialog {
+  position: fixed;
+  z-index: 90;
+  inset: 50% auto auto 50%;
+  width: min(560px, calc(100vw - 32px));
+  max-height: calc(100vh - 56px);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 10px;
+  padding: 16px;
+  overflow: auto;
+  transform: translate(-50%, -50%);
+  background: #0f172a;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.46);
+}
+
+.report-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 13px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--app-border);
+}
+
+.report-head p {
+  margin: 0 0 5px;
+  color: var(--app-text-subtle);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.report-head h2 {
+  margin: 0;
+  color: var(--app-text-strong);
+  font-size: 1.16rem;
+}
+
+.icon-btn {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--app-border);
+  border-radius: 7px;
+  background: rgba(7, 10, 19, 0.32);
+  color: var(--app-text-muted);
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.icon-btn:hover {
+  color: var(--app-text-strong);
+  border-color: rgba(148, 163, 184, 0.42);
+}
+
+.report-body {
+  display: grid;
+  gap: 11px;
+}
+
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.contact-row {
+  max-width: 300px;
+}
+
+label {
+  display: grid;
+  gap: 6px;
+}
+
+label span {
+  color: var(--app-text-muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+label em {
+  color: var(--app-text-subtle);
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 9px 10px;
+  background: rgba(7, 10, 19, 0.32);
+  color: var(--app-text-strong);
+  font: inherit;
+  font-size: 0.94rem;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 86px;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 2px solid var(--app-focus-ring);
+  outline-offset: 2px;
+}
+
+.wide-field {
+  min-width: 0;
+}
+
+.report-actions {
+  margin-top: 13px;
+  padding-top: 11px;
+  border-top: 1px solid var(--app-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.report-actions span {
+  color: var(--app-text-muted);
+  font-size: 0.86rem;
+}
+
+.send-link {
+  flex: 0 0 auto;
+  border: 1px solid rgba(34, 197, 94, 0.42);
+  border-radius: 7px;
+  padding: 8px 11px;
+  background: rgba(34, 197, 94, 0.1);
+  color: #bbf7d0;
+  font: inherit;
+  font-weight: 800;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.send-link:hover {
+  border-color: rgba(34, 197, 94, 0.66);
+  background: rgba(34, 197, 94, 0.16);
+}
+
+.send-link--disabled {
+  border-color: rgba(148, 163, 184, 0.2);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--app-text-subtle);
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .report-dialog {
+    max-height: calc(100vh - 32px);
+    padding: 14px;
+  }
+
+  .field-grid,
+  .report-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .contact-row {
+    max-width: none;
+  }
+}

--- a/src/app/components/data-issue-report-dialog/data-issue-report-dialog.spec.ts
+++ b/src/app/components/data-issue-report-dialog/data-issue-report-dialog.spec.ts
@@ -1,0 +1,69 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { MatTooltip } from '@angular/material/tooltip';
+import { DATA_ISSUE_WEB3FORMS_ENDPOINT } from '@app/utils/data-issue-report';
+import { DataIssueReportDialog } from './data-issue-report-dialog';
+
+describe('DataIssueReportDialog', () => {
+  let component: DataIssueReportDialog;
+  let fixture: ComponentFixture<DataIssueReportDialog>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DataIssueReportDialog],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DataIssueReportDialog);
+    fixture.componentRef.setInput('accessKey', 'test-access-key');
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('opens the report form from the trigger', () => {
+    fixture.nativeElement.querySelector('.report-trigger').click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[role="dialog"]')).toBeTruthy();
+  });
+
+  it('explains why the report button is disabled', () => {
+    component.open();
+    fixture.detectChanges();
+
+    const sendAction = fixture.debugElement.query(By.css('.send-action'));
+    const sendButton = fixture.nativeElement.querySelector('.send-link') as HTMLButtonElement;
+    const tooltip = sendAction.injector.get(MatTooltip);
+
+    expect(sendButton.disabled).toBe(true);
+    expect(tooltip.message).toBe('Add a short description of what should be fixed.');
+    expect(tooltip.disabled).toBe(false);
+  });
+
+  it('submits a data report through Web3Forms', () => {
+    component.open();
+    component.updateField('summary', 'The season total looks wrong.');
+    fixture.detectChanges();
+
+    const sendButton = fixture.nativeElement.querySelector('.send-link') as HTMLButtonElement;
+    sendButton.click();
+
+    const request = httpMock.expectOne(DATA_ISSUE_WEB3FORMS_ENDPOINT);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body['access_key']).toBe('test-access-key');
+    expect(request.request.body['message']).toContain('The season total looks wrong.');
+
+    request.flush({ success: true, message: 'Email sent successfully!' });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Report sent.');
+  });
+});

--- a/src/app/components/data-issue-report-dialog/data-issue-report-dialog.ts
+++ b/src/app/components/data-issue-report-dialog/data-issue-report-dialog.ts
@@ -1,0 +1,153 @@
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { Component, computed, inject, input, signal } from '@angular/core';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { environment } from '@env/environment';
+import {
+  buildDataIssueWeb3FormsPayload,
+  DATA_ISSUE_WEB3FORMS_ENDPOINT,
+  type DataIssueReportContext,
+  type DataIssueReportForm,
+  type Web3FormsResponse,
+} from '@app/utils/data-issue-report';
+
+type SubmitState = 'idle' | 'sending' | 'sent' | 'error' | 'missing-key';
+
+type ReportField =
+  | 'issueType'
+  | 'reporterName'
+  | 'reporterEmail'
+  | 'summary'
+  | 'expectedValue'
+  | 'source'
+  | 'clubName'
+  | 'season'
+  | 'competition';
+
+@Component({
+  selector: 'app-data-issue-report-dialog',
+  imports: [CommonModule, MatTooltipModule],
+  templateUrl: './data-issue-report-dialog.html',
+  styleUrl: './data-issue-report-dialog.scss',
+})
+export class DataIssueReportDialog {
+  triggerLabel = input('Report data issue');
+  triggerStyle = input<'button' | 'link'>('button');
+  context = input<DataIssueReportContext>({});
+  accessKey = input(environment.web3FormsAccessKey);
+
+  private readonly http = inject(HttpClient);
+
+  protected readonly isOpen = signal(false);
+  protected readonly form = signal<DataIssueReportForm>(this.buildInitialForm());
+  protected readonly submitState = signal<SubmitState>('idle');
+  protected readonly errorMessage = signal('');
+  protected readonly isConfigured = computed(() => Boolean(this.accessKey().trim()));
+  protected readonly canSubmit = computed(
+    () =>
+      Boolean(this.form().summary.trim()) && this.isConfigured() && this.submitState() !== 'sending'
+  );
+  protected readonly disabledReason = computed(() => {
+    if (this.submitState() === 'sending') {
+      return 'Sending the report now.';
+    }
+
+    if (!this.isConfigured()) {
+      return 'Report submissions are not configured yet.';
+    }
+
+    if (!this.form().summary.trim()) {
+      return 'Add a short description of what should be fixed.';
+    }
+
+    return '';
+  });
+
+  open() {
+    this.form.set(this.buildInitialForm());
+    this.submitState.set(this.isConfigured() ? 'idle' : 'missing-key');
+    this.errorMessage.set('');
+    this.isOpen.set(true);
+  }
+
+  close() {
+    this.isOpen.set(false);
+  }
+
+  updateField(field: ReportField, value: string) {
+    if (this.submitState() === 'sent' || this.submitState() === 'error') {
+      this.submitState.set(this.isConfigured() ? 'idle' : 'missing-key');
+      this.errorMessage.set('');
+    }
+
+    this.form.update((current) => ({
+      ...current,
+      [field]: field === 'season' ? this.parseSeason(value) : value,
+    }));
+  }
+
+  submit() {
+    if (!this.form().summary.trim()) {
+      return;
+    }
+
+    const accessKey = this.accessKey().trim();
+
+    if (!accessKey) {
+      this.submitState.set('missing-key');
+      return;
+    }
+
+    this.submitState.set('sending');
+    this.errorMessage.set('');
+
+    this.http
+      .post<Web3FormsResponse>(
+        DATA_ISSUE_WEB3FORMS_ENDPOINT,
+        buildDataIssueWeb3FormsPayload(this.form(), accessKey),
+        {
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+      .subscribe({
+        next: (response) => {
+          if (response.success) {
+            this.submitState.set('sent');
+            return;
+          }
+
+          this.submitState.set('error');
+          this.errorMessage.set(response.message || 'The report could not be sent.');
+        },
+        error: () => {
+          this.submitState.set('error');
+          this.errorMessage.set('The report could not be sent. Please try again.');
+        },
+      });
+  }
+
+  private buildInitialForm(): DataIssueReportForm {
+    const context = this.context();
+    return {
+      issueType: 'Data looks wrong',
+      reporterName: '',
+      reporterEmail: '',
+      summary: '',
+      expectedValue: '',
+      source: '',
+      pageTitle: context.pageTitle,
+      sourcePath: context.sourcePath,
+      clubName: context.clubName ?? '',
+      season: context.season,
+      competition: context.competition ?? '',
+    };
+  }
+
+  private parseSeason(value: string): number | undefined {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+}

--- a/src/app/components/league-table/league-table.html
+++ b/src/app/components/league-table/league-table.html
@@ -80,6 +80,19 @@
       </td>
     </ng-container>
 
+    <ng-container matColumnDef="report">
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head report app-data-head">
+        Report
+      </th>
+      <td mat-cell *matCellDef="let element" class="cell report app-data-cell">
+        <app-data-issue-report-dialog
+          triggerLabel="Report"
+          triggerStyle="link"
+          [context]="dataIssueContextForRow(element)"
+        />
+      </td>
+    </ng-container>
+
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr
       mat-row

--- a/src/app/components/league-table/league-table.scss
+++ b/src/app/components/league-table/league-table.scss
@@ -8,7 +8,7 @@
   width: 100%;
   border-collapse: separate;
   border-spacing: 0;
-  min-width: 760px;
+  min-width: 820px;
   background: transparent;
 }
 
@@ -61,6 +61,15 @@
   color: var(--app-text-strong);
 }
 
+.report {
+  width: 72px;
+  text-align: right;
+}
+
+.cell.report {
+  font-size: 0.82rem;
+}
+
 .rank {
   width: 26px;
   height: 26px;
@@ -86,7 +95,7 @@
 
 @media (max-width: 980px) {
   .footy-table {
-    min-width: 680px;
+    min-width: 760px;
   }
 }
 

--- a/src/app/components/league-table/league-table.spec.ts
+++ b/src/app/components/league-table/league-table.spec.ts
@@ -1,3 +1,4 @@
+import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 
@@ -10,7 +11,7 @@ describe('LeagueTable', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LeagueTableComponent],
-      providers: [provideRouter([])],
+      providers: [provideHttpClient(), provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LeagueTableComponent);
@@ -54,5 +55,48 @@ describe('LeagueTable', () => {
     const link = fixture.nativeElement.querySelector('.team-link') as HTMLAnchorElement | null;
     expect(link?.textContent?.trim()).toBe('Manchester United');
     expect(link?.getAttribute('href')).toBe('/teams/manchester%20united');
+  });
+
+  it('prefills row report context from table data', () => {
+    component.leagueTable = [
+      {
+        season: 2025,
+        tier: 'tier1',
+        teamId: 1,
+        teamName: 'Manchester United',
+        clubId: 'manchester united',
+        pos: 1,
+        played: 38,
+        won: 28,
+        drawn: 6,
+        lost: 4,
+        goalsFor: 80,
+        goalsAgainst: 30,
+        goalDifference: 50,
+        goalAverage: null,
+        points: 90,
+        notes: null,
+        wasRelegated: false,
+        wasPromoted: false,
+        isExpansionTeam: false,
+        wasReElected: false,
+        wasReprieved: false,
+      },
+    ];
+
+    fixture.detectChanges();
+    fixture.nativeElement.querySelector('.report-trigger').click();
+    fixture.detectChanges();
+
+    const inputs = Array.from(
+      fixture.nativeElement.querySelectorAll('input')
+    ) as HTMLInputElement[];
+    expect(inputs.map((input) => input.value)).toEqual([
+      '',
+      'Manchester United',
+      '2025',
+      'Premier League',
+      '',
+    ]);
   });
 });

--- a/src/app/components/league-table/league-table.ts
+++ b/src/app/components/league-table/league-table.ts
@@ -1,16 +1,22 @@
-import { Component, Input } from '@angular/core';
+import { Component, inject, Input } from '@angular/core';
 import { MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
+import { DataIssueReportDialog } from '@app/components/data-issue-report-dialog/data-issue-report-dialog';
+import { LeagueTierToStringyPipe } from '@app/pipes/league-tier-to-stringy-pipe';
 import type { LeagueTableView } from '@app/types';
+import type { DataIssueReportContext } from '@app/utils/data-issue-report';
 
 @Component({
   selector: 'app-league-table',
   templateUrl: './league-table.html',
   styleUrls: ['./league-table.scss'],
-  imports: [MatTableModule, RouterLink],
+  imports: [MatTableModule, RouterLink, DataIssueReportDialog],
+  providers: [LeagueTierToStringyPipe],
 })
 export class LeagueTableComponent {
   @Input() leagueTable: LeagueTableView[] = [];
+
+  private leagueLabelPipe = inject(LeagueTierToStringyPipe);
 
   displayedColumns: string[] = [
     'position',
@@ -23,11 +29,22 @@ export class LeagueTableComponent {
     'goalsAgainst',
     'goalDifference',
     'points',
+    'report',
   ];
 
   get sortedTable(): LeagueTableView[] {
     return [...this.leagueTable].sort(
       (a, b) => b.points - a.points || (b.goalDifference ?? 0) - (a.goalDifference ?? 0)
     );
+  }
+
+  dataIssueContextForRow(row: LeagueTableView): DataIssueReportContext {
+    return {
+      pageTitle: 'League table row',
+      sourcePath: `/tables season ${row.season} ${row.tier}`,
+      clubName: row.teamName,
+      season: row.season,
+      competition: this.leagueLabelPipe.transform(row.tier) || row.tier,
+    };
   }
 }

--- a/src/app/components/league-tables-viewer/league-tables-viewer.html
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.html
@@ -36,6 +36,12 @@
         </mat-select>
       </mat-form-field>
       }
+
+      <app-data-issue-report-dialog
+        class="report-field"
+        triggerLabel="Report table issue"
+        [context]="dataIssueContext()"
+      />
     </div>
 
     @if (currentTable(); as tableData) {

--- a/src/app/components/league-tables-viewer/league-tables-viewer.scss
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.scss
@@ -42,6 +42,11 @@
   --mat-select-panel-background-color: #111827;
 }
 
+.report-field {
+  display: block;
+  padding-top: 8px;
+}
+
 :host ::ng-deep .field .mdc-text-field--filled {
   border: 1px solid var(--app-border);
   background: rgba(7, 10, 19, 0.28);

--- a/src/app/components/league-tables-viewer/league-tables-viewer.spec.ts
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.spec.ts
@@ -1,3 +1,4 @@
+import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LeagueStore } from '@app/store/league.store';
 import { LeagueTablesViewerComponent } from './league-tables-viewer';
@@ -9,7 +10,7 @@ describe('LeagueTablesViewer', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LeagueTablesViewerComponent],
-      providers: [LeagueStore],
+      providers: [LeagueStore, provideHttpClient()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LeagueTablesViewerComponent);

--- a/src/app/components/league-tables-viewer/league-tables-viewer.ts
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.ts
@@ -3,9 +3,11 @@ import { Component, computed, effect, inject, signal } from '@angular/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
+import { DataIssueReportDialog } from '@app/components/data-issue-report-dialog/data-issue-report-dialog';
 import { LeagueTierToStringyPipe } from '@app/pipes/league-tier-to-stringy-pipe';
 import { LeagueStore } from '@app/store/league.store';
 import { LeagueTableView } from '@app/types';
+import type { DataIssueReportContext } from '@app/utils/data-issue-report';
 import { LeagueTableComponent } from '../league-table/league-table';
 import { SeasonSummaryCardComponent } from '../season-summary-card/season-summary-card';
 
@@ -21,11 +23,13 @@ import { SeasonSummaryCardComponent } from '../season-summary-card/season-summar
     MatIconModule,
     LeagueTierToStringyPipe,
     SeasonSummaryCardComponent,
+    DataIssueReportDialog,
   ],
   providers: [LeagueTierToStringyPipe],
 })
 export class LeagueTablesViewerComponent {
   store = inject(LeagueStore);
+  private leagueLabelPipe = inject(LeagueTierToStringyPipe);
 
   years: number[] = [];
   leaguesForYear: string[] = [];
@@ -61,6 +65,16 @@ export class LeagueTablesViewerComponent {
   currentLeagueLabel = computed(() => {
     const league = this.selectedLeague();
     return league ?? '';
+  });
+
+  dataIssueContext = computed<DataIssueReportContext>(() => {
+    const league = this.selectedLeague();
+    return {
+      pageTitle: 'League table archive',
+      sourcePath: '/tables',
+      season: this.selectedYear(),
+      competition: league ? this.leagueLabelPipe.transform(league) || league : undefined,
+    };
   });
 
   onYearChange(year: number) {

--- a/src/app/pages/league-table-historic/league-table-historic.spec.ts
+++ b/src/app/pages/league-table-historic/league-table-historic.spec.ts
@@ -1,3 +1,4 @@
+import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LeagueTablesViewerComponent } from '@app/components/league-tables-viewer/league-tables-viewer';
@@ -10,6 +11,7 @@ describe('LeagueTableHistoric', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LeagueTablesViewerComponent, LeagueTableHistoric],
+      providers: [provideHttpClient()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LeagueTableHistoric);

--- a/src/app/pages/team-overview/team-overview.html
+++ b/src/app/pages/team-overview/team-overview.html
@@ -2,7 +2,13 @@
 <div class="loading app-page-shell">Loading club profile...</div>
 } @else if (!club()) {
 <section class="team-overview app-surface app-page-shell">
-  <a class="back-link" routerLink="/teams" queryParamsHandling="preserve">Back to clubs</a>
+  <div class="profile-top-actions">
+    <a class="back-link" routerLink="/teams" queryParamsHandling="preserve">Back to clubs</a>
+    <app-data-issue-report-dialog
+      triggerLabel="Report missing club"
+      [context]="dataIssueContext()"
+    />
+  </div>
   <div class="empty-state app-panel">
     <p class="app-page-eyebrow">Club Profile</p>
     <h1>Club not found</h1>
@@ -11,7 +17,10 @@
 </section>
 } @else {
 <section class="team-overview app-surface app-page-shell">
-  <a class="back-link" routerLink="/teams" queryParamsHandling="preserve">Back to clubs</a>
+  <div class="profile-top-actions">
+    <a class="back-link" routerLink="/teams" queryParamsHandling="preserve">Back to clubs</a>
+    <app-data-issue-report-dialog [context]="dataIssueContext()" />
+  </div>
 
   <header class="profile-header">
     <div>
@@ -207,6 +216,7 @@
         <span>Position</span>
         <span>Record</span>
         <span>Points</span>
+        <span>Report</span>
       </div>
       @for (entry of recentSeasonRows(); track entry.season + entry.tier + entry.teamName) {
       <div class="recent-row">
@@ -216,6 +226,13 @@
         <span>{{ ordinal(entry.pos) }}</span>
         <span>{{ entry.won }}-{{ entry.drawn }}-{{ entry.lost }}</span>
         <span>{{ entry.points }}</span>
+        <span class="recent-report">
+          <app-data-issue-report-dialog
+            triggerLabel="Report"
+            triggerStyle="link"
+            [context]="dataIssueContextForSeason(entry)"
+          />
+        </span>
       </div>
       }
     </div>

--- a/src/app/pages/team-overview/team-overview.scss
+++ b/src/app/pages/team-overview/team-overview.scss
@@ -12,6 +12,13 @@
   gap: 20px;
 }
 
+.profile-top-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .back-link {
   width: fit-content;
   color: var(--app-text-muted);
@@ -366,7 +373,7 @@
 }
 
 .recent-table {
-  min-width: 820px;
+  min-width: 900px;
   display: grid;
   border: 1px solid rgba(148, 163, 184, 0.28);
   border-radius: 8px;
@@ -376,7 +383,7 @@
 
 .recent-row {
   display: grid;
-  grid-template-columns: 0.7fr 1.35fr 1.25fr 0.8fr 0.9fr 0.7fr;
+  grid-template-columns: 0.7fr 1.35fr 1.25fr 0.8fr 0.9fr 0.7fr 0.65fr;
 }
 
 .recent-row span {
@@ -396,6 +403,14 @@
 
 .recent-row:last-child span {
   border-bottom: 0;
+}
+
+.recent-report {
+  text-align: right;
+}
+
+.recent-report app-data-issue-report-dialog {
+  font-size: 0.82rem;
 }
 
 .recent-head span {
@@ -428,6 +443,11 @@
 }
 
 @media (max-width: 620px) {
+  .profile-top-actions {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
   .stat-grid {
     grid-template-columns: 1fr;
   }

--- a/src/app/pages/team-overview/team-overview.ts
+++ b/src/app/pages/team-overview/team-overview.ts
@@ -8,9 +8,11 @@ import type { EChartsCoreOption } from 'echarts/core';
 import * as echarts from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { NgxEchartsDirective, provideEchartsCore } from 'ngx-echarts';
+import { DataIssueReportDialog } from '@app/components/data-issue-report-dialog/data-issue-report-dialog';
 import type { LeagueTableEntry } from '@app/store/league.models';
 import { ClubMetadataStore } from '@app/store/club-metadata.store';
 import { LeagueStore } from '@app/store/league.store';
+import type { DataIssueReportContext } from '@app/utils/data-issue-report';
 import { buildClubDerivedGaps, buildClubDisplayNamePeriods } from '@app/utils/club-identity-ranges';
 import { buildClubPerformanceMilestones } from '@app/utils/club-performance-milestones';
 import { getWartimeSuspensionRanges } from '@app/utils/wartime-suspensions';
@@ -68,7 +70,7 @@ echarts.use([LineChart, GridComponent, TooltipComponent, MarkAreaComponent, Canv
 
 @Component({
   selector: 'app-team-overview',
-  imports: [CommonModule, RouterLink, NgxEchartsDirective],
+  imports: [CommonModule, RouterLink, NgxEchartsDirective, DataIssueReportDialog],
   providers: [provideEchartsCore({ echarts })],
   templateUrl: './team-overview.html',
   styleUrl: './team-overview.scss',
@@ -105,6 +107,11 @@ export class TeamOverview {
 
     return club.derived.lastSeenSeason === this.latestDataSeason() ? 'active' : 'historical';
   });
+  dataIssueContext = computed<DataIssueReportContext>(() => ({
+    pageTitle: 'Club profile',
+    sourcePath: `/teams/${this.clubId()}`,
+    clubName: this.club()?.canonicalName ?? (this.clubId() || undefined),
+  }));
   teamNames = computed(() =>
     Array.from(
       new Set(this.entries().map((entry) => this.leagueStore.getTeamNameById(entry.teamId)))
@@ -168,6 +175,16 @@ export class TeamOverview {
       teamName: this.leagueStore.getTeamNameById(entry.teamId),
     }))
   );
+
+  dataIssueContextForSeason(entry: RecentSeasonRow): DataIssueReportContext {
+    return {
+      pageTitle: 'Club season row',
+      sourcePath: `/teams/${this.clubId()} season ${entry.season}`,
+      clubName: entry.teamName || this.club()?.canonicalName || undefined,
+      season: entry.season,
+      competition: this.tierLabel(entry.tier),
+    };
+  }
   entriesAscending = computed(() =>
     this.entries()
       .slice()

--- a/src/app/utils/data-issue-report.spec.ts
+++ b/src/app/utils/data-issue-report.spec.ts
@@ -1,0 +1,48 @@
+import {
+  buildDataIssueReportMessage,
+  buildDataIssueWeb3FormsPayload,
+  DATA_ISSUE_WEB3FORMS_ENDPOINT,
+} from './data-issue-report';
+
+describe('data issue report helpers', () => {
+  it('builds a Web3Forms payload with contextual subject and message', () => {
+    const payload = buildDataIssueWeb3FormsPayload(
+      {
+        issueType: 'Wrong table value',
+        reporterName: 'Alex',
+        reporterEmail: 'alex@example.com',
+        summary: 'The points total looks wrong.',
+        expectedValue: 'Should be 42 points.',
+        source: 'Club handbook',
+        pageTitle: 'Club profile',
+        sourcePath: '/teams/example-fc',
+        clubName: 'Example FC',
+        season: 1999,
+        competition: 'Championship',
+      },
+      'test-access-key'
+    );
+
+    expect(DATA_ISSUE_WEB3FORMS_ENDPOINT).toBe('https://api.web3forms.com/submit');
+    expect(payload['access_key']).toBe('test-access-key');
+    expect(payload['subject']).toBe('FootyStats data issue: Example FC (1999)');
+    expect(payload['email']).toBe('alex@example.com');
+    expect(payload['message']).toContain('The points total looks wrong.');
+    expect(payload['Correct value or source']).toBe('Should be 42 points.');
+  });
+
+  it('uses friendly fallback text for unknown fields', () => {
+    const message = buildDataIssueReportMessage({
+      issueType: '',
+      reporterName: '',
+      reporterEmail: '',
+      summary: '',
+      expectedValue: '',
+      source: '',
+    });
+
+    expect(message).toContain('What should we fix?\nNot provided');
+    expect(message).toContain('Correct value or source\nNot provided');
+    expect(message).toContain('Reporter email: Not provided');
+  });
+});

--- a/src/app/utils/data-issue-report.ts
+++ b/src/app/utils/data-issue-report.ts
@@ -1,0 +1,81 @@
+export const DATA_ISSUE_WEB3FORMS_ENDPOINT = 'https://api.web3forms.com/submit';
+
+export interface DataIssueReportContext {
+  pageTitle?: string;
+  sourcePath?: string;
+  clubName?: string;
+  season?: number;
+  competition?: string;
+}
+
+export interface DataIssueReportForm extends DataIssueReportContext {
+  issueType: string;
+  reporterName: string;
+  reporterEmail: string;
+  summary: string;
+  expectedValue: string;
+  source: string;
+}
+
+export interface Web3FormsResponse {
+  success: boolean;
+  message?: string;
+}
+
+export function buildDataIssueWeb3FormsPayload(
+  form: DataIssueReportForm,
+  accessKey: string
+): Record<string, string | boolean> {
+  return {
+    access_key: accessKey,
+    subject: buildDataIssueSubject(form),
+    from_name: 'FootyStats data issue report',
+    name: form.reporterName || 'FootyStats visitor',
+    ...(form.reporterEmail ? { email: form.reporterEmail } : {}),
+    message: buildDataIssueReportMessage(form),
+    botcheck: false,
+    'Issue type': form.issueType || 'Not sure',
+    'Page or feature': form.pageTitle || 'Not sure',
+    'Link or screen': form.sourcePath || 'Not sure',
+    'Club or team': form.clubName || 'Not sure',
+    'Season or year': form.season?.toString() || 'Not sure',
+    'League or competition': form.competition || 'Not sure',
+    'Correct value or source': form.expectedValue || form.source || 'Not provided',
+  };
+}
+
+export function buildDataIssueReportMessage(form: DataIssueReportForm): string {
+  return `Data issue report
+
+What should we fix?
+${form.summary || 'Not provided'}
+
+Correct value or source
+${form.expectedValue || form.source || 'Not provided'}
+
+Issue type: ${form.issueType || 'Not sure'}
+Page or feature: ${form.pageTitle || 'Not sure'}
+Link or screen: ${form.sourcePath || 'Not sure'}
+Club or team: ${form.clubName || 'Not sure'}
+Season or year: ${form.season?.toString() || 'Not sure'}
+League or competition: ${form.competition || 'Not sure'}
+
+Reporter name: ${form.reporterName || 'Not provided'}
+Reporter email: ${form.reporterEmail || 'Not provided'}`;
+}
+
+function buildDataIssueSubject(form: DataIssueReportForm): string {
+  if (form.clubName && form.season) {
+    return `FootyStats data issue: ${form.clubName} (${form.season})`;
+  }
+
+  if (form.clubName) {
+    return `FootyStats data issue: ${form.clubName}`;
+  }
+
+  if (form.season && form.competition) {
+    return `FootyStats data issue: ${form.season} ${form.competition}`;
+  }
+
+  return 'FootyStats data issue';
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  web3FormsAccessKey: '2a8d025b-bb66-4ca9-939b-ac6e2639c4ad',
+};


### PR DESCRIPTION
## Summary
- Adds an in-app Web3Forms flow for users to report incorrect or missing football data without needing a GitHub account.
- Adds contextual report entry points across footer, table archive rows, and club profile rows.

## What Changed
- Added reusable `DataIssueReportDialog` with Web3Forms submission, disabled-state tooltip messaging, success/error states, and focused tests.
- Added contextual report links for table rows and club season rows so club, season, and league can be prefilled where appropriate.
- Added footer and page-level data issue entry points.
- Added Web3Forms payload helper and reporting documentation.
- Added environment config for the Web3Forms access key.
- Updated tests/providers for components that render the new report dialog.

## Validation
- `pnpm exec tsc -p tsconfig.app.json --noEmit`
- `pnpm exec tsc -p tsconfig.spec.json --noEmit`
- `pnpm test`
- `pnpm lint`

## Scope Notes
- `pnpm lint` passes with existing generated Angular cache warnings.
- `pnpm build` was attempted and still fails with the existing esbuild deadlock/SIGABRT issue seen outside this feature work.
- Current workspace is on `codex/data-issue-reporting`; this package reflects that branch.