### PR TITLE
Improve mobile layouts across data views

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -137,20 +137,48 @@
   }
 
   .app-footer {
-    padding-inline: 12px;
+    padding: 18px 8px 24px;
   }
 
   .footer-inner {
+    width: min(100%, calc(100vw - 16px));
+    padding-top: 18px;
     grid-template-columns: 1fr;
-    gap: 24px;
+    gap: 18px;
+  }
+
+  .footer-brand {
+    display: grid;
+    grid-template-columns: 36px minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  .footer-mark {
+    width: 36px;
+    height: 36px;
+  }
+
+  .footer-copy {
+    margin-top: 6px;
+    font-size: 0.88rem;
   }
 
   .footer-nav {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 20px;
+    padding-top: 16px;
+    border-top: 1px solid rgba(148, 163, 184, 0.12);
+    grid-template-columns: repeat(auto-fit, minmax(138px, 1fr));
+    gap: 16px;
+  }
+
+  .footer-link-group a {
+    line-height: 1.65;
   }
 
   .footer-bottom {
+    width: min(100%, calc(100vw - 16px));
+    margin-top: 18px;
     flex-direction: column;
+    gap: 6px;
+    font-size: 0.78rem;
   }
 }

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -132,6 +132,14 @@
 }
 
 @media (max-width: 700px) {
+  .app-content {
+    padding: 14px 0 22px;
+  }
+
+  .app-footer {
+    padding-inline: 12px;
+  }
+
   .footer-inner {
     grid-template-columns: 1fr;
     gap: 24px;

--- a/src/app/components/league-table/league-table.html
+++ b/src/app/components/league-table/league-table.html
@@ -1,15 +1,19 @@
 <div class="table-container app-data-shell">
   <table mat-table [dataSource]="sortedTable" class="footy-table">
     <ng-container matColumnDef="position">
-      <th mat-header-cell *matHeaderCellDef scope="col" class="head app-data-head">#</th>
-      <td mat-cell *matCellDef="let element; let i = index" class="cell app-data-cell">
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head position-col app-data-head">
+        #
+      </th>
+      <td mat-cell *matCellDef="let element; let i = index" class="cell position-col app-data-cell">
         <span class="rank" [class.rank-top]="i < 4">{{ i + 1 }}</span>
       </td>
     </ng-container>
 
     <ng-container matColumnDef="teamName">
-      <th mat-header-cell *matHeaderCellDef scope="col" class="head app-data-head">Team</th>
-      <td mat-cell *matCellDef="let element" class="cell team app-data-cell">
+      <th mat-header-cell *matHeaderCellDef scope="col" class="head team team-col app-data-head">
+        Team
+      </th>
+      <td mat-cell *matCellDef="let element" class="cell team team-col app-data-cell">
         @if (element.clubId) {
         <a class="team-link" [routerLink]="['/teams', element.clubId]">{{ element.teamName }}</a>
         } @else { {{ element.teamName }} }

--- a/src/app/components/league-table/league-table.scss
+++ b/src/app/components/league-table/league-table.scss
@@ -2,6 +2,11 @@
   width: 100%;
   max-width: 100%;
   overflow: auto;
+  isolation: isolate;
+  --league-table-sticky-head-bg: #d9dde3;
+  --league-table-sticky-row-bg: #d2d6dc;
+  --league-table-sticky-row-alt-bg: #c8cdd4;
+  --league-table-sticky-row-top-bg: #ead8b8;
 }
 
 .footy-table {
@@ -28,12 +33,54 @@
   color: color-mix(in srgb, var(--app-text-subtle) 96%, var(--app-text-strong) 4%);
 }
 
+.position-col,
+.team-col {
+  position: sticky;
+  z-index: 3;
+  background: var(--league-table-sticky-row-bg);
+  background-clip: padding-box;
+}
+
+.position-col {
+  left: 0;
+  width: 46px;
+  min-width: 46px;
+}
+
+.team-col {
+  left: 46px;
+  width: 190px;
+  min-width: 190px;
+  max-width: 190px;
+  box-shadow: 1px 0 0 rgba(148, 163, 184, 0.16);
+}
+
+.head.position-col,
+.head.team-col {
+  z-index: 5;
+  background: var(--league-table-sticky-head-bg);
+}
+
 .row-top .cell {
   background: rgba(245, 158, 11, 0.08);
 }
 
+.app-data-row:nth-child(even) .position-col,
+.app-data-row:nth-child(even) .team-col {
+  background: var(--league-table-sticky-row-alt-bg);
+}
+
+.row-top .position-col,
+.row-top .team-col {
+  background: var(--league-table-sticky-row-top-bg);
+}
+
 .row-top .cell:first-child {
   box-shadow: inset 3px 0 0 rgba(245, 158, 11, 0.54);
+}
+
+.row-top .team-col {
+  box-shadow: 1px 0 0 rgba(148, 163, 184, 0.16);
 }
 
 .center {
@@ -43,9 +90,13 @@
 .team {
   font-weight: 600;
   color: var(--app-text-strong);
+  white-space: nowrap;
 }
 
 .team-link {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
   color: inherit;
   text-decoration: none;
   text-underline-offset: 3px;
@@ -99,9 +150,22 @@
   }
 }
 
+@media (prefers-color-scheme: dark) {
+  .table-container {
+    --league-table-sticky-head-bg: #0b1220;
+    --league-table-sticky-row-bg: #101827;
+    --league-table-sticky-row-alt-bg: #142033;
+    --league-table-sticky-row-top-bg: #221a10;
+  }
+}
+
 @media (max-width: 760px) {
   .table-container {
     border-radius: var(--app-radius-lg);
+  }
+
+  .footy-table {
+    min-width: 680px;
   }
 
   .head,
@@ -109,8 +173,33 @@
     padding: 10px 8px;
   }
 
+  .position-col {
+    width: 34px;
+    min-width: 34px;
+    max-width: 34px;
+    padding-inline: 5px;
+  }
+
+  .team-col {
+    left: 34px;
+    width: 128px;
+    min-width: 128px;
+    max-width: 128px;
+    padding-inline: 7px;
+  }
+
   .head {
     font-size: 10px;
     letter-spacing: 0.08em;
+  }
+
+  .rank {
+    width: 23px;
+    height: 23px;
+    font-size: 12px;
+  }
+
+  .team {
+    font-size: 0.88rem;
   }
 }

--- a/src/app/components/league-tables-viewer/league-tables-viewer.scss
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.scss
@@ -75,9 +75,15 @@ app-season-summary-card {
 @media (max-width: 760px) {
   .record-tools {
     display: grid;
+    gap: 10px;
+    max-width: none;
   }
 
   .field {
     width: 100%;
+  }
+
+  .report-field {
+    padding-top: 0;
   }
 }

--- a/src/app/components/main-toolbar/main-toolbar.scss
+++ b/src/app/components/main-toolbar/main-toolbar.scss
@@ -72,6 +72,7 @@
   border-radius: 8px;
   background: transparent;
   color: var(--app-text-subtle);
+  min-width: 0;
   min-height: 36px;
   padding-inline: 11px;
   box-shadow: none;
@@ -89,17 +90,55 @@
 }
 
 @media (max-width: 720px) {
+  .main-toolbar {
+    padding: 0;
+  }
+
   .toolbar-inner {
-    width: min(calc(100vw - 24px), 1160px);
-    padding: 10px 0;
-    gap: 10px;
-    flex-direction: column;
-    align-items: flex-start;
+    width: 100%;
+    padding: 8px 12px 9px;
+    gap: 8px;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .brand {
+    flex: 0 0 auto;
+    gap: 8px;
+  }
+
+  .brand-mark {
+    width: 30px;
+    height: 30px;
+    border-radius: 8px;
+  }
+
+  .eyebrow {
+    display: none;
+  }
+
+  .brand-copy {
+    display: none;
   }
 
   .nav-links {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
+    gap: 4px;
+    overflow: visible;
+  }
+
+  .nav-links a,
+  .nav-links button {
     width: 100%;
-    overflow-x: auto;
-    padding-bottom: 4px;
+    min-height: 32px;
+    padding-inline: 4px;
+    justify-content: center;
+    color: #cbd5e1;
+    font-size: 0.78rem;
+    line-height: 1.1;
   }
 }

--- a/src/app/components/team-list/team-list.html
+++ b/src/app/components/team-list/team-list.html
@@ -39,7 +39,12 @@
           >
             Team
           </th>
-          <td mat-cell *matCellDef="let team" class="team-cell team-col app-data-cell">
+          <td
+            mat-cell
+            *matCellDef="let team"
+            class="team-cell team-col app-data-cell"
+            data-label="Team"
+          >
             @if (primaryClubId(team); as clubId) {
             <a class="team-name" [routerLink]="['/teams', clubId]" [state]="teamLinkState()">
               {{ team.name }}
@@ -62,7 +67,12 @@
               <mat-icon>open_in_new</mat-icon>
             </span>
           </th>
-          <td mat-cell *matCellDef="let team" class="team-cell links-cell ext-col app-data-cell">
+          <td
+            mat-cell
+            *matCellDef="let team"
+            class="team-cell links-cell ext-col app-data-cell"
+            data-label="Links"
+          >
             <a [href]="createWikipediaLink(team.name)" target="_blank" rel="noopener noreferrer">
               Wikipedia
             </a>

--- a/src/app/components/team-list/team-list.html
+++ b/src/app/components/team-list/team-list.html
@@ -100,4 +100,33 @@
       </table>
     </div>
   </div>
+
+  <div class="mobile-team-list" aria-label="Clubs">
+    @for (team of filteredTeams(); track team.id) {
+    <article class="mobile-team-card">
+      <div class="mobile-team-main">
+        @if (primaryClubId(team); as clubId) {
+        <a class="team-name" [routerLink]="['/teams', clubId]" [state]="teamLinkState()">
+          {{ team.name }}
+        </a>
+        } @else {
+        <span class="team-name" matTooltip="No club metadata available">{{ team.name }}</span>
+        }
+      </div>
+
+      <details class="mobile-links">
+        <summary>External links</summary>
+        <div>
+          <a [href]="createWikipediaLink(team.name)" target="_blank" rel="noopener noreferrer">
+            Wikipedia
+          </a>
+          <a [href]="createWorldFootballLink(team.name)" target="_blank" rel="noopener noreferrer">
+            WorldFootball
+          </a>
+          <a [href]="create11v11Link(team.name)" target="_blank" rel="noopener noreferrer">11v11</a>
+        </div>
+      </details>
+    </article>
+    }
+  </div>
 </div>

--- a/src/app/components/team-list/team-list.scss
+++ b/src/app/components/team-list/team-list.scss
@@ -210,3 +210,98 @@
     margin: 0 4px;
   }
 }
+
+@media (max-width: 640px) {
+  .index-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .alphabet-filter {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(32px, 1fr));
+    gap: 6px;
+  }
+
+  .letter-button {
+    min-height: 32px;
+    border: 1px solid var(--app-border);
+    padding: 4px 6px;
+    background: rgba(7, 10, 19, 0.14);
+    text-align: center;
+  }
+
+  .letter-button--selected {
+    border-color: rgba(217, 119, 6, 0.52);
+  }
+
+  .team-container {
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+
+  .team-table,
+  .team-table tbody,
+  .team-row,
+  .team-cell {
+    display: block;
+    width: 100%;
+  }
+
+  .team-table {
+    min-width: 0;
+  }
+
+  .team-table tbody {
+    display: grid;
+    gap: 10px;
+  }
+
+  .team-head-row {
+    display: none;
+  }
+
+  .team-row {
+    overflow: hidden;
+    border: 1px solid var(--app-border);
+    border-radius: 8px;
+    background: rgba(7, 10, 19, 0.22);
+  }
+
+  .team-cell {
+    padding: 10px 12px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  }
+
+  .team-cell:last-child {
+    border-bottom: 0;
+  }
+
+  .team-col,
+  .ext-col {
+    width: auto;
+    text-align: left;
+  }
+
+  .team-col {
+    padding: 13px 14px;
+  }
+
+  .ext-col::before {
+    content: attr(data-label);
+    display: block;
+    margin-bottom: 4px;
+    color: var(--app-text-muted);
+    font-size: 0.68rem;
+    font-weight: 750;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .links-cell {
+    line-height: 1.6;
+  }
+}

--- a/src/app/components/team-list/team-list.scss
+++ b/src/app/components/team-list/team-list.scss
@@ -70,6 +70,10 @@
   overflow: auto;
 }
 
+.mobile-team-list {
+  display: none;
+}
+
 .team-container {
   width: 100%;
   max-width: 100%;
@@ -236,72 +240,63 @@
     border-color: rgba(217, 119, 6, 0.52);
   }
 
-  .team-container {
-    overflow: visible;
-    border: 0;
-    border-radius: 0;
-    background: transparent;
+  .table-wrap {
+    display: none;
   }
 
-  .team-table,
-  .team-table tbody,
-  .team-row,
-  .team-cell {
-    display: block;
-    width: 100%;
-  }
-
-  .team-table {
-    min-width: 0;
-  }
-
-  .team-table tbody {
+  .mobile-team-list {
     display: grid;
     gap: 10px;
   }
 
-  .team-head-row {
-    display: none;
-  }
-
-  .team-row {
+  .mobile-team-card {
     overflow: hidden;
     border: 1px solid var(--app-border);
     border-radius: 8px;
     background: rgba(7, 10, 19, 0.22);
   }
 
-  .team-cell {
-    padding: 10px 12px;
+  .mobile-team-main {
+    padding: 13px 14px;
     border-bottom: 1px solid rgba(148, 163, 184, 0.16);
   }
 
-  .team-cell:last-child {
-    border-bottom: 0;
+  .mobile-links {
+    padding: 0 14px;
   }
 
-  .team-col,
-  .ext-col {
-    width: auto;
-    text-align: left;
-  }
-
-  .team-col {
-    padding: 13px 14px;
-  }
-
-  .ext-col::before {
-    content: attr(data-label);
-    display: block;
-    margin-bottom: 4px;
+  .mobile-links summary {
+    min-height: 42px;
+    display: flex;
+    align-items: center;
     color: var(--app-text-muted);
-    font-size: 0.68rem;
     font-weight: 750;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
+    cursor: pointer;
   }
 
-  .links-cell {
-    line-height: 1.6;
+  .mobile-links summary:hover {
+    color: var(--app-text-strong);
+  }
+
+  .mobile-links div {
+    padding: 0 0 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .mobile-links a {
+    border: 1px solid var(--app-border);
+    border-radius: 6px;
+    padding: 6px 8px;
+    color: var(--app-text-subtle);
+    font-size: 0.86rem;
+    font-weight: 650;
+    text-decoration: none;
+  }
+
+  .mobile-links a:hover {
+    border-color: rgba(148, 163, 184, 0.42);
+    color: var(--app-text-strong);
   }
 }

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -103,3 +103,30 @@
     grid-template-columns: 1fr;
   }
 }
+
+@media (max-width: 560px) {
+  .home {
+    gap: 28px;
+  }
+
+  .archive-meta {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .archive-meta span {
+    border-top: 1px solid var(--app-border);
+    padding-top: 8px;
+    display: grid;
+    gap: 3px;
+  }
+
+  .cta-row {
+    display: grid;
+  }
+
+  .cta-row a {
+    width: 100%;
+  }
+}

--- a/src/app/pages/movement-explorer/movement-explorer.scss
+++ b/src/app/pages/movement-explorer/movement-explorer.scss
@@ -638,19 +638,87 @@
 }
 
 @media (max-width: 560px) {
+  .movement-page {
+    padding-inline: 12px;
+  }
+
+  .research-note {
+    margin-top: 14px;
+    padding-left: 10px;
+  }
+
   .config-toolbar {
     justify-content: stretch;
   }
 
   .config-toggle {
     flex: 1 1 140px;
+    min-height: 40px;
   }
 
   .setup-grid {
     grid-template-columns: 1fr;
   }
 
+  .setup-card {
+    min-height: 0;
+  }
+
+  .quick-pick-popover {
+    position: static;
+    margin-top: 8px;
+    box-shadow: none;
+  }
+
+  .quick-pick-tabs,
+  .quick-pick-results,
+  .search-results,
+  .selected-chips,
+  .preset-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
+  }
+
+  .team-option,
+  .preset-btn,
+  .chip,
+  .clear-btn {
+    min-height: 38px;
+    justify-content: center;
+    text-align: center;
+  }
+
   .years-row {
     grid-template-columns: 1fr;
+  }
+
+  .chart-wrap {
+    padding: 10px;
+    overflow-x: auto;
+  }
+
+  .chart-tools {
+    justify-items: stretch;
+  }
+
+  .detail-toggle {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .detail-toggle button {
+    min-width: 0;
+    padding-inline: 6px;
+  }
+
+  .legend-item {
+    font-size: 0.8rem;
+  }
+
+  .movement-chart {
+    min-width: 620px;
+    height: 420px;
+    min-height: 300px;
   }
 }

--- a/src/app/pages/movement-explorer/movement-explorer.scss
+++ b/src/app/pages/movement-explorer/movement-explorer.scss
@@ -694,7 +694,7 @@
 
   .chart-wrap {
     padding: 10px;
-    overflow-x: auto;
+    overflow: hidden;
   }
 
   .chart-tools {
@@ -717,8 +717,8 @@
   }
 
   .movement-chart {
-    min-width: 620px;
-    height: 420px;
+    min-width: 0;
+    height: 300px;
     min-height: 300px;
   }
 }

--- a/src/app/pages/movement-explorer/movement-explorer.ts
+++ b/src/app/pages/movement-explorer/movement-explorer.ts
@@ -309,6 +309,7 @@ export class MovementExplorer {
   chartDetailMode = signal<ChartDetailMode>('path');
   activeChartSetupId = signal<string>(DEFAULT_CHART_SETUP_ID);
   focusedTeamId = signal<number | null>(null);
+  isCompactViewport = signal<boolean>(this.readIsCompactViewport());
   private applyingUrlState = false;
   private lastSyncedQueryState = '';
   private hasAppliedInitialUrlState = signal<boolean>(false);
@@ -427,6 +428,10 @@ export class MovementExplorer {
   });
 
   movementChartHeight = computed(() => {
+    if (this.isCompactViewport()) {
+      return 300;
+    }
+
     const tierBounds = this.visibleTierBounds();
     const tierIntervals = Math.max(1, tierBounds.max - tierBounds.min);
     const preferredHeight =
@@ -523,6 +528,7 @@ export class MovementExplorer {
     const series = this.teamSeries();
     const wartimeSuspensionRanges = getWartimeSuspensionRanges(seasons);
     const showMovementEvents = this.chartDetailMode() === 'events';
+    const isCompactViewport = this.isCompactViewport();
     const isDenseComparison = series.length >= 5 || seasons.length >= 45;
     const showWartimeLabels = !isDenseComparison && seasons.length <= 60;
     const pathOpacity = isDenseComparison ? 0.52 : 0.88;
@@ -640,13 +646,14 @@ export class MovementExplorer {
       animation: false,
       backgroundColor: 'transparent',
       grid: {
-        left: 184,
-        right: 40,
-        top: 60,
-        bottom: 88,
+        left: isCompactViewport ? 58 : 184,
+        right: isCompactViewport ? 14 : 40,
+        top: isCompactViewport ? 16 : 60,
+        bottom: isCompactViewport ? 48 : 88,
         containLabel: false,
       },
       legend: {
+        show: !isCompactViewport,
         top: 14,
         left: 18,
         textStyle: {
@@ -670,8 +677,8 @@ export class MovementExplorer {
         boundaryGap: false,
         axisLabel: {
           color: '#c5d0e4',
-          fontSize: 13,
-          margin: 16,
+          fontSize: isCompactViewport ? 10 : 13,
+          margin: isCompactViewport ? 9 : 16,
           hideOverlap: true,
         },
         axisLine: {
@@ -687,10 +694,11 @@ export class MovementExplorer {
         inverse: true,
         axisLabel: {
           color: '#c5d0e4',
-          fontSize: 13,
+          fontSize: isCompactViewport ? 10 : 13,
           fontWeight: 700,
-          margin: 12,
-          formatter: (value: number) => this.tierLabel(value),
+          margin: isCompactViewport ? 7 : 12,
+          formatter: (value: number) =>
+            isCompactViewport ? this.compactTierLabel(value) : this.tierLabel(value),
         },
         axisLine: { show: false },
         splitLine: {
@@ -701,8 +709,8 @@ export class MovementExplorer {
         {
           type: 'slider',
           xAxisIndex: 0,
-          height: 24,
-          bottom: 48,
+          height: isCompactViewport ? 18 : 24,
+          bottom: isCompactViewport ? 14 : 48,
           filterMode: 'none',
           backgroundColor: 'rgba(15, 23, 42, 0.75)',
           fillerColor: 'rgba(217, 119, 6, 0.24)',
@@ -713,7 +721,7 @@ export class MovementExplorer {
           },
           textStyle: {
             color: '#d7deeb',
-            fontSize: 12,
+            fontSize: isCompactViewport ? 10 : 12,
           },
         },
       ],
@@ -857,6 +865,11 @@ export class MovementExplorer {
     }
   }
 
+  @HostListener('window:resize')
+  onWindowResize() {
+    this.isCompactViewport.set(this.readIsCompactViewport());
+  }
+
   toggleConfigPanel() {
     this.configCollapsed.set(!this.configCollapsed());
   }
@@ -960,6 +973,14 @@ export class MovementExplorer {
 
   tierLabel(tier: number): string {
     return TIER_LABELS[tier] ?? `Tier ${tier}`;
+  }
+
+  private compactTierLabel(tier: number): string {
+    return `T${tier}`;
+  }
+
+  private readIsCompactViewport(): boolean {
+    return typeof window !== 'undefined' && window.matchMedia('(max-width: 560px)').matches;
   }
 
   private tierToNumber(tier: string): number | null {

--- a/src/app/pages/team-overview/team-overview.html
+++ b/src/app/pages/team-overview/team-overview.html
@@ -268,13 +268,13 @@
       </div>
       @for (entry of recentSeasonRows(); track entry.season + entry.tier + entry.teamName) {
       <div class="recent-row">
-        <span>{{ entry.season }}</span>
-        <span>{{ entry.teamName }}</span>
-        <span>{{ tierLabel(entry.tier) }}</span>
-        <span>{{ ordinal(entry.pos) }}</span>
-        <span>{{ entry.won }}-{{ entry.drawn }}-{{ entry.lost }}</span>
-        <span>{{ entry.points }}</span>
-        <span class="recent-report">
+        <span data-label="Season">{{ entry.season }}</span>
+        <span data-label="Name">{{ entry.teamName }}</span>
+        <span data-label="Tier">{{ tierLabel(entry.tier) }}</span>
+        <span data-label="Position">{{ ordinal(entry.pos) }}</span>
+        <span data-label="Record">{{ entry.won }}-{{ entry.drawn }}-{{ entry.lost }}</span>
+        <span data-label="Points">{{ entry.points }}</span>
+        <span class="recent-report" data-label="Data issue">
           <app-data-issue-report-dialog
             triggerLabel="Flag issue"
             triggerStyle="link"

--- a/src/app/pages/team-overview/team-overview.html
+++ b/src/app/pages/team-overview/team-overview.html
@@ -132,7 +132,7 @@
             [attr.aria-expanded]="milestonesExpanded()"
             (click)="toggleMilestones()"
           >
-            {{ milestonesExpanded() ? 'Collapse' : 'Show all' }}
+            {{ milestonesExpanded() ? 'Hide notes' : 'Show all notes' }}
           </button>
           }
         </div>

--- a/src/app/pages/team-overview/team-overview.html
+++ b/src/app/pages/team-overview/team-overview.html
@@ -284,6 +284,25 @@
       </div>
       }
     </div>
+    <div class="mobile-recent-list" aria-label="Recent seasons">
+      @for (entry of recentSeasonRows(); track entry.season + entry.tier + entry.teamName) {
+      <article class="mobile-recent-card">
+        <div class="mobile-recent-main">
+          <strong>{{ entry.season }}</strong>
+          <span>{{ entry.teamName }}</span>
+        </div>
+        <div class="mobile-recent-facts">
+          <span>{{ tierLabel(entry.tier) }} / {{ ordinal(entry.pos) }}</span>
+          <span>{{ entry.won }}-{{ entry.drawn }}-{{ entry.lost }} / {{ entry.points }} pts</span>
+        </div>
+        <app-data-issue-report-dialog
+          triggerLabel="Flag issue"
+          triggerStyle="link"
+          [context]="dataIssueContextForSeason(entry)"
+        />
+      </article>
+      }
+    </div>
   </section>
 </section>
 }

--- a/src/app/pages/team-overview/team-overview.scss
+++ b/src/app/pages/team-overview/team-overview.scss
@@ -595,6 +595,20 @@
     gap: 6px;
   }
 
+  .milestone-panel .panel-head {
+    flex-direction: row;
+  }
+
+  .milestone-panel--collapsed {
+    max-height: 258px;
+  }
+
+  .panel-toggle {
+    border: 1px solid rgba(245, 158, 11, 0.42);
+    border-radius: 6px;
+    padding: 5px 8px;
+  }
+
   .stat-grid {
     grid-template-columns: 1fr;
   }

--- a/src/app/pages/team-overview/team-overview.scss
+++ b/src/app/pages/team-overview/team-overview.scss
@@ -602,14 +602,37 @@
   .tier-row,
   .relationship-list > div,
   .gap-list > div,
-  .period-list > div,
-  .season-snapshot-list > div {
+  .period-list > div {
     align-items: flex-start;
     flex-direction: column;
   }
 
+  .season-snapshot-list {
+    gap: 6px;
+  }
+
   .season-snapshot-list > div {
-    display: flex;
+    min-height: 0;
+    padding: 9px 10px;
+    display: grid;
+    grid-template-columns: 54px 1fr;
+    gap: 4px 10px;
+  }
+
+  .season-snapshot-list strong {
+    grid-row: span 2;
+    align-self: center;
+    font-size: 0.92rem;
+  }
+
+  .season-snapshot-list span {
+    font-size: 0.8rem;
+    line-height: 1.25;
+  }
+
+  .season-snapshot-list em {
+    grid-column: 1 / -1;
+    margin-top: 2px;
   }
 
   .recent-panel {
@@ -620,11 +643,11 @@
     min-width: 0;
     border: 0;
     border-radius: 0;
-    gap: 10px;
+    gap: 8px;
     background: transparent;
   }
 
-  .recent-head {
+  .recent-row.recent-head {
     display: none;
   }
 
@@ -632,29 +655,44 @@
     border: 1px solid var(--app-border);
     border-radius: 8px;
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px 12px;
+    padding: 11px 12px;
     overflow: hidden;
     background: rgba(7, 10, 19, 0.22);
   }
 
   .recent-row span {
     min-width: 0;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+    padding: 0;
+    border-bottom: 0;
     display: grid;
-    gap: 3px;
+    gap: 2px;
+    color: var(--app-text-strong);
+    font-size: 0.9rem;
+    font-weight: 650;
+    background: transparent !important;
   }
 
   .recent-row span::before {
     content: attr(data-label);
     color: var(--app-text-muted);
-    font-size: 0.66rem;
+    font-size: 0.62rem;
     font-weight: 750;
     letter-spacing: 0.08em;
     text-transform: uppercase;
   }
 
+  .recent-row span:nth-child(3),
+  .recent-row span:nth-child(4),
+  .recent-row span:nth-child(5),
+  .recent-row span:nth-child(6) {
+    border-top: 1px solid rgba(148, 163, 184, 0.16);
+  }
+
   .recent-report {
     grid-column: 1 / -1;
+    border-top: 1px solid rgba(148, 163, 184, 0.16);
     border-bottom: 0;
     text-align: left;
   }

--- a/src/app/pages/team-overview/team-overview.scss
+++ b/src/app/pages/team-overview/team-overview.scss
@@ -513,6 +513,10 @@
   background: rgba(7, 10, 19, 0.18);
 }
 
+.mobile-recent-list {
+  display: none;
+}
+
 .recent-row {
   display: grid;
   grid-template-columns: 0.7fr 1.35fr 1.25fr 0.8fr 0.9fr 0.7fr 0.82fr;
@@ -595,8 +599,12 @@
     grid-template-columns: 1fr;
   }
 
+  .stat-cell {
+    overflow: visible;
+  }
+
   .compact-snapshot-summary {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(3, 1fr);
   }
 
   .tier-row,
@@ -613,20 +621,19 @@
 
   .season-snapshot-list > div {
     min-height: 0;
-    padding: 9px 10px;
+    padding: 8px 9px;
     display: grid;
-    grid-template-columns: 54px 1fr;
-    gap: 4px 10px;
+    grid-template-columns: 46px minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 7px;
   }
 
   .season-snapshot-list strong {
-    grid-row: span 2;
-    align-self: center;
     font-size: 0.92rem;
   }
 
   .season-snapshot-list span {
-    font-size: 0.8rem;
+    font-size: 0.78rem;
     line-height: 1.25;
   }
 
@@ -640,60 +647,50 @@
   }
 
   .recent-table {
-    min-width: 0;
-    border: 0;
-    border-radius: 0;
-    gap: 8px;
-    background: transparent;
-  }
-
-  .recent-row.recent-head {
     display: none;
   }
 
-  .recent-row {
+  .mobile-recent-list {
+    display: grid;
+    gap: 8px;
+  }
+
+  .mobile-recent-card {
     border: 1px solid var(--app-border);
     border-radius: 8px;
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 8px 12px;
-    padding: 11px 12px;
-    overflow: hidden;
+    gap: 8px;
+    padding: 10px;
     background: rgba(7, 10, 19, 0.22);
   }
 
-  .recent-row span {
-    min-width: 0;
-    padding: 0;
-    border-bottom: 0;
-    display: grid;
-    gap: 2px;
+  .mobile-recent-main,
+  .mobile-recent-facts {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  .mobile-recent-main {
+    align-items: baseline;
     color: var(--app-text-strong);
-    font-size: 0.9rem;
-    font-weight: 650;
-    background: transparent !important;
+    font-weight: 760;
   }
 
-  .recent-row span::before {
-    content: attr(data-label);
+  .mobile-recent-main span,
+  .mobile-recent-facts {
+    min-width: 0;
+  }
+
+  .mobile-recent-main span {
+    text-align: right;
+  }
+
+  .mobile-recent-facts {
+    border-top: 1px solid rgba(148, 163, 184, 0.16);
+    padding-top: 8px;
     color: var(--app-text-muted);
-    font-size: 0.62rem;
-    font-weight: 750;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .recent-row span:nth-child(3),
-  .recent-row span:nth-child(4),
-  .recent-row span:nth-child(5),
-  .recent-row span:nth-child(6) {
-    border-top: 1px solid rgba(148, 163, 184, 0.16);
-  }
-
-  .recent-report {
-    grid-column: 1 / -1;
-    border-top: 1px solid rgba(148, 163, 184, 0.16);
-    border-bottom: 0;
-    text-align: left;
+    font-size: 0.84rem;
+    font-weight: 650;
   }
 }

--- a/src/app/pages/team-overview/team-overview.scss
+++ b/src/app/pages/team-overview/team-overview.scss
@@ -569,6 +569,26 @@
   .profile-top-actions {
     align-items: flex-start;
     flex-direction: column;
+    gap: 10px;
+  }
+
+  .team-overview {
+    gap: 16px;
+  }
+
+  .profile-header .app-page-title {
+    font-size: clamp(1.85rem, 11vw, 2.45rem);
+  }
+
+  .profile-panel {
+    padding: 14px;
+  }
+
+  .panel-head,
+  .panel-actions {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
   }
 
   .stat-grid {
@@ -590,5 +610,52 @@
 
   .season-snapshot-list > div {
     display: flex;
+  }
+
+  .recent-panel {
+    overflow: visible;
+  }
+
+  .recent-table {
+    min-width: 0;
+    border: 0;
+    border-radius: 0;
+    gap: 10px;
+    background: transparent;
+  }
+
+  .recent-head {
+    display: none;
+  }
+
+  .recent-row {
+    border: 1px solid var(--app-border);
+    border-radius: 8px;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    overflow: hidden;
+    background: rgba(7, 10, 19, 0.22);
+  }
+
+  .recent-row span {
+    min-width: 0;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+    display: grid;
+    gap: 3px;
+  }
+
+  .recent-row span::before {
+    content: attr(data-label);
+    color: var(--app-text-muted);
+    font-size: 0.66rem;
+    font-weight: 750;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .recent-report {
+    grid-column: 1 / -1;
+    border-bottom: 0;
+    text-align: left;
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -136,6 +136,28 @@ body {
   }
 }
 
+@media (max-width: 640px) {
+  .app-page-shell {
+    width: min(100%, calc(100vw - 16px));
+    margin: 10px auto 28px;
+    padding: 14px;
+  }
+
+  .app-page-header .app-page-title {
+    font-size: clamp(1.9rem, 11vw, 2.45rem);
+    line-height: 1.08;
+  }
+
+  .app-page-header .app-page-lede {
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+
+  .app-data-shell {
+    border-radius: 8px;
+  }
+}
+
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -136,28 +136,6 @@ body {
   }
 }
 
-@media (max-width: 640px) {
-  .app-page-shell {
-    width: min(100%, calc(100vw - 16px));
-    margin: 10px auto 28px;
-    padding: 14px;
-  }
-
-  .app-page-header .app-page-title {
-    font-size: clamp(1.9rem, 11vw, 2.45rem);
-    line-height: 1.08;
-  }
-
-  .app-page-header .app-page-lede {
-    font-size: 1rem;
-    line-height: 1.5;
-  }
-
-  .app-data-shell {
-    border-radius: 8px;
-  }
-}
-
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
@@ -258,6 +236,28 @@ body {
 
 .app-data-row:hover .app-data-cell {
   background: rgba(148, 163, 184, 0.08);
+}
+
+@media (max-width: 640px) {
+  .app-page-shell {
+    width: min(100%, calc(100vw - 16px));
+    margin: 10px auto 28px;
+    padding: 14px;
+  }
+
+  .app-page-header .app-page-title {
+    font-size: clamp(1.9rem, 11vw, 2.45rem);
+    line-height: 1.08;
+  }
+
+  .app-page-header .app-page-lede {
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+
+  .app-data-shell {
+    border-radius: 8px;
+  }
 }
 
 a:focus-visible,


### PR DESCRIPTION
## Summary
- Improves mobile usability across the app shell, data tables, club directory, movement explorer, team overview, and footer.

## What Changed
- Reworked the mobile header and shared page shell sizing.
- Improved league table scrolling with sticky rank/team context and narrower mobile frozen columns.
- Added mobile club cards with expandable external links.
- Compactly reworked movement explorer controls and chart rendering for mobile.
- Refined team overview mobile cards, season snapshots, recent seasons, and milestone toggle behavior.
- Cleaned up mobile footer spacing, link columns, and brand layout.

## Validation
- `pnpm lint`
- `pnpm build`

## Scope Notes
- Focused on responsive layout and mobile usability.
- Graph pages were kept functional and contained rather than fully redesigned.
- Branch is clean and contains commits from `191c97e` through `e47c640`.