### PR TITLE
Add team directory filters

### DIFF
--- a/src/app/components/team-list/team-list.html
+++ b/src/app/components/team-list/team-list.html
@@ -4,6 +4,22 @@
     <span>{{ filteredTeams().length }} clubs</span>
   </div>
 
+  <nav class="category-filter" aria-label="Filter clubs by status or archive category">
+    @for (filter of filterOptions(); track filter.id) {
+    <button
+      (click)="selectFilter(filter.id)"
+      type="button"
+      class="filter-button"
+      [class.filter-button--selected]="selectedFilterSignal() === filter.id"
+      [attr.aria-pressed]="selectedFilterSignal() === filter.id"
+      [attr.title]="filter.description"
+    >
+      <span>{{ filter.label }}</span>
+      <small>{{ filter.count }}</small>
+    </button>
+    }
+  </nav>
+
   <nav class="alphabet-filter" aria-label="Filter clubs by letter">
     <button
       (click)="selectLetter('')"
@@ -27,6 +43,12 @@
   </nav>
 
   <!-- Teams table -->
+  @if (!filteredTeams().length) {
+  <div class="empty-filter-state" role="status">
+    <strong>No clubs match these filters.</strong>
+    <span>Try another archive category or clear the selected letter.</span>
+  </div>
+  } @else {
   <div class="table-wrap">
     <div class="team-container app-data-shell">
       <table mat-table [dataSource]="filteredTeams()" class="team-table">
@@ -52,6 +74,47 @@
             } @else {
             <span class="team-name" matTooltip="No club metadata available">{{ team.name }}</span>
             }
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="status">
+          <th
+            mat-header-cell
+            *matHeaderCellDef
+            scope="col"
+            class="team-header status-col app-data-head"
+          >
+            Status
+          </th>
+          <td
+            mat-cell
+            *matCellDef="let team"
+            class="team-cell status-col app-data-cell"
+            data-label="Status"
+          >
+            <span class="status-pill" [class.status-pill--active]="team.status === 'active'">
+              {{ statusLabel(team) }}
+            </span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="span">
+          <th
+            mat-header-cell
+            *matHeaderCellDef
+            scope="col"
+            class="team-header span-col app-data-head"
+          >
+            Archive Span
+          </th>
+          <td
+            mat-cell
+            *matCellDef="let team"
+            class="team-cell span-col app-data-cell"
+            data-label="Archive span"
+          >
+            <span class="span-label">{{ seasonSpanLabel(team) }}</span>
+            <small>{{ seasonCountLabel(team) }}</small>
           </td>
         </ng-container>
 
@@ -91,10 +154,14 @@
           </td>
         </ng-container>
 
-        <tr mat-header-row *matHeaderRowDef="['team', 'ext']" class="team-head-row"></tr>
+        <tr
+          mat-header-row
+          *matHeaderRowDef="['team', 'status', 'span', 'ext']"
+          class="team-head-row"
+        ></tr>
         <tr
           mat-row
-          *matRowDef="let row; columns: ['team', 'ext']"
+          *matRowDef="let row; columns: ['team', 'status', 'span', 'ext']"
           class="team-row app-data-row"
         ></tr>
       </table>
@@ -112,6 +179,13 @@
         } @else {
         <span class="team-name" matTooltip="No club metadata available">{{ team.name }}</span>
         }
+        <div class="mobile-team-meta">
+          <span class="status-pill" [class.status-pill--active]="team.status === 'active'">
+            {{ statusLabel(team) }}
+          </span>
+          <span>{{ seasonSpanLabel(team) }}</span>
+          <span>{{ seasonCountLabel(team) }}</span>
+        </div>
       </div>
 
       <details class="mobile-links">
@@ -129,4 +203,5 @@
     </article>
     }
   </div>
+  }
 </div>

--- a/src/app/components/team-list/team-list.html
+++ b/src/app/components/team-list/team-list.html
@@ -1,7 +1,14 @@
 <div class="team-list">
   <div class="index-header">
     <h4 class="filter-title">Club Index</h4>
-    <span>{{ filteredTeams().length }} clubs</span>
+    <div class="index-actions">
+      <span>{{ filteredTeams().length }} clubs</span>
+      @if (hasActiveFilters()) {
+      <button type="button" class="clear-filters-button" (click)="clearFilters()">
+        Clear filters
+      </button>
+      }
+    </div>
   </div>
 
   <nav class="category-filter" aria-label="Filter clubs by status or archive category">

--- a/src/app/components/team-list/team-list.scss
+++ b/src/app/components/team-list/team-list.scss
@@ -17,9 +17,39 @@
   padding-bottom: 8px;
 }
 
-.index-header span {
+.index-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.index-actions span {
   color: var(--app-text-muted);
   font-size: 0.9rem;
+}
+
+.clear-filters-button {
+  min-height: 30px;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: rgba(7, 10, 19, 0.18);
+  color: var(--app-text-subtle);
+  padding: 4px 9px;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.clear-filters-button:hover {
+  border-color: rgba(148, 163, 184, 0.42);
+  color: var(--app-text-strong);
+}
+
+.clear-filters-button:focus-visible {
+  outline: 2px solid var(--app-focus-ring);
+  outline-offset: 2px;
 }
 
 .filter-title {
@@ -332,6 +362,15 @@
     align-items: flex-start;
     flex-direction: column;
     gap: 4px;
+  }
+
+  .index-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .clear-filters-button {
+    min-height: 34px;
   }
 
   .category-filter {

--- a/src/app/components/team-list/team-list.scss
+++ b/src/app/components/team-list/team-list.scss
@@ -30,6 +30,65 @@
   color: var(--app-text-muted);
 }
 
+.category-filter {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 8px;
+}
+
+.filter-button {
+  min-width: 0;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: rgba(7, 10, 19, 0.16);
+  color: var(--app-text-subtle);
+  padding: 8px 10px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.filter-button span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.9rem;
+  font-weight: 750;
+}
+
+.filter-button small {
+  min-width: 2ch;
+  color: var(--app-text-muted);
+  font-size: 0.78rem;
+  font-weight: 750;
+  text-align: right;
+}
+
+.filter-button:hover {
+  border-color: rgba(148, 163, 184, 0.42);
+  color: var(--app-text-strong);
+}
+
+.filter-button:focus-visible,
+.letter-button:focus-visible {
+  outline: 2px solid var(--app-focus-ring);
+  outline-offset: 2px;
+}
+
+.filter-button--selected {
+  border-color: rgba(217, 119, 6, 0.56);
+  background: rgba(217, 119, 6, 0.12);
+  color: #fde68a;
+}
+
+.filter-button--selected small {
+  color: color-mix(in srgb, #fde68a 82%, var(--app-text-muted) 18%);
+}
+
 .alphabet-filter {
   display: flex;
   flex-wrap: wrap;
@@ -70,6 +129,20 @@
   overflow: auto;
 }
 
+.empty-filter-state {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: rgba(7, 10, 19, 0.18);
+  padding: 18px;
+  color: var(--app-text-subtle);
+}
+
+.empty-filter-state strong {
+  color: var(--app-text-strong);
+}
+
 .mobile-team-list {
   display: none;
 }
@@ -82,7 +155,7 @@
 
 .team-table {
   width: 100%;
-  min-width: 760px;
+  min-width: 920px;
   border-collapse: separate;
   border-spacing: 0;
   background: transparent;
@@ -103,11 +176,19 @@
 }
 
 .team-col {
-  width: 44%;
+  width: 30%;
+}
+
+.status-col {
+  width: 14%;
+}
+
+.span-col {
+  width: 20%;
 }
 
 .ext-col {
-  width: 56%;
+  width: 36%;
   text-align: right;
 }
 
@@ -136,6 +217,37 @@
   outline: 2px solid var(--app-focus-ring);
   outline-offset: 2px;
   border-radius: 4px;
+}
+
+.status-pill {
+  display: inline-flex;
+  min-height: 26px;
+  align-items: center;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.1);
+  color: var(--app-text-subtle);
+  padding: 3px 9px;
+  font-size: 0.78rem;
+  font-weight: 750;
+  line-height: 1.2;
+}
+
+.status-pill--active {
+  border-color: rgba(34, 197, 94, 0.38);
+  background: rgba(34, 197, 94, 0.12);
+  color: #bbf7d0;
+}
+
+.span-label {
+  display: block;
+  color: var(--app-text-strong);
+  font-weight: 700;
+}
+
+.span-col small {
+  color: var(--app-text-muted);
+  font-weight: 650;
 }
 
 .header-inline {
@@ -185,7 +297,7 @@
 
 @media (max-width: 980px) {
   .team-table {
-    min-width: 680px;
+    min-width: 860px;
   }
 }
 
@@ -220,6 +332,20 @@
     align-items: flex-start;
     flex-direction: column;
     gap: 4px;
+  }
+
+  .category-filter {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .filter-button {
+    min-height: 42px;
+    padding: 8px;
+  }
+
+  .filter-button span {
+    white-space: normal;
+    line-height: 1.15;
   }
 
   .alphabet-filter {
@@ -257,8 +383,20 @@
   }
 
   .mobile-team-main {
+    display: grid;
+    gap: 8px;
     padding: 13px 14px;
     border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  }
+
+  .mobile-team-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px 8px;
+    color: var(--app-text-muted);
+    font-size: 0.82rem;
+    font-weight: 650;
   }
 
   .mobile-links {

--- a/src/app/components/team-list/team-list.spec.ts
+++ b/src/app/components/team-list/team-list.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { TeamDirectoryItem } from '@app/types';
 
 import { TeamList } from './team-list';
 
@@ -20,15 +21,47 @@ describe('TeamList', () => {
     expect(component).toBeTruthy();
   });
 
+  function team(overrides: Partial<TeamDirectoryItem>): TeamDirectoryItem {
+    return {
+      id: 1,
+      name: 'Arsenal',
+      clubIds: ['arsenal'],
+      categories: ['active', 'top-flight', 'current-top-flight', 'long-run'],
+      firstSeenSeason: 1888,
+      lastSeenSeason: 2025,
+      totalSeasonsSeen: 99,
+      status: 'active',
+      ...overrides,
+    };
+  }
+
   it('filters teams from the selected letter input', () => {
     component.teams = [
-      { id: 1, name: 'Arsenal', clubIds: ['arsenal'] },
-      { id: 2, name: 'Chelsea', clubIds: ['chelsea'] },
+      team({ id: 1, name: 'Arsenal', clubIds: ['arsenal'] }),
+      team({ id: 2, name: 'Chelsea', clubIds: ['chelsea'] }),
     ];
 
     component.selectedLetter = 'c';
 
     expect(component.filteredTeams().map((team) => team.name)).toEqual(['Chelsea']);
+  });
+
+  it('filters teams from the selected directory filter input', () => {
+    component.teams = [
+      team({ id: 1, name: 'Arsenal', categories: ['active', 'top-flight'] }),
+      team({
+        id: 2,
+        name: 'Accrington',
+        categories: ['historical', 'top-flight'],
+        status: 'historical',
+        lastSeenSeason: 1892,
+        totalSeasonsSeen: 5,
+      }),
+    ];
+
+    component.selectedFilter = 'historical';
+
+    expect(component.filteredTeams().map((team) => team.name)).toEqual(['Accrington']);
   });
 
   it('emits an empty letter when the active letter is selected again', () => {
@@ -42,9 +75,23 @@ describe('TeamList', () => {
     expect(emittedLetters).toEqual(['']);
   });
 
-  it('stores the selected letter in navigation state for team links', () => {
-    component.selectedLetter = 'a';
+  it('emits the selected directory filter', () => {
+    const emittedFilters: string[] = [];
+    component.filterSelected.subscribe((filter) => emittedFilters.push(filter));
 
-    expect(component.teamLinkState()).toEqual({ teamsReturnLetter: 'A' });
+    component.selectFilter('top-flight');
+
+    expect(component.selectedFilterSignal()).toBe('top-flight');
+    expect(emittedFilters).toEqual(['top-flight']);
+  });
+
+  it('stores the selected filters in navigation state for team links', () => {
+    component.selectedLetter = 'a';
+    component.selectedFilter = 'active';
+
+    expect(component.teamLinkState()).toEqual({
+      teamsReturnLetter: 'A',
+      teamsReturnFilter: 'active',
+    });
   });
 });

--- a/src/app/components/team-list/team-list.spec.ts
+++ b/src/app/components/team-list/team-list.spec.ts
@@ -85,6 +85,19 @@ describe('TeamList', () => {
     expect(emittedFilters).toEqual(['top-flight']);
   });
 
+  it('clears the active letter and directory filter together', () => {
+    const emittedClears: void[] = [];
+    component.selectedLetter = 'a';
+    component.selectedFilter = 'historical';
+    component.filtersCleared.subscribe(() => emittedClears.push(undefined));
+
+    component.clearFilters();
+
+    expect(component.selectedLetterSignal()).toBeNull();
+    expect(component.selectedFilterSignal()).toBe('all');
+    expect(emittedClears).toEqual([undefined]);
+  });
+
   it('stores the selected filters in navigation state for team links', () => {
     component.selectedLetter = 'a';
     component.selectedFilter = 'active';

--- a/src/app/components/team-list/team-list.ts
+++ b/src/app/components/team-list/team-list.ts
@@ -4,7 +4,13 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
-import type { Team } from '@app/store/league.models';
+import {
+  isTeamDirectoryFilter,
+  TEAM_DIRECTORY_FILTERS,
+  type TeamDirectoryCategory,
+  type TeamDirectoryFilter,
+  type TeamDirectoryItem,
+} from '@app/types';
 import {
   build11v11Links,
   buildWikipediaLinks,
@@ -18,26 +24,55 @@ import {
   imports: [CommonModule, MatTableModule, MatIconModule, MatTooltipModule, RouterLink],
 })
 export class TeamList {
-  @Input() teams: Team[] = [];
+  private teamsSignal = signal<TeamDirectoryItem[]>([]);
+
+  @Input() set teams(value: TeamDirectoryItem[] | null) {
+    this.teamsSignal.set(value ?? []);
+  }
+
   @Input() set selectedLetter(value: string | null) {
     const normalized = value?.trim().toUpperCase() || null;
     this.selectedLetterSignal.set(normalized);
   }
+  @Input() set selectedFilter(value: TeamDirectoryFilter | string | null) {
+    this.selectedFilterSignal.set(value && isTeamDirectoryFilter(value) ? value : 'all');
+  }
 
   @Output() letterSelected = new EventEmitter<string>();
+  @Output() filterSelected = new EventEmitter<TeamDirectoryFilter>();
 
   selectedLetterSignal = signal<string | null>(null);
+  selectedFilterSignal = signal<TeamDirectoryFilter>('all');
+
+  filterOptions = computed(() =>
+    TEAM_DIRECTORY_FILTERS.map((filter) => ({
+      ...filter,
+      count:
+        filter.id === 'all'
+          ? this.teamsSignal().length
+          : this.teamsSignal().filter((team) =>
+              team.categories.includes(filter.id as TeamDirectoryCategory)
+            ).length,
+    }))
+  );
 
   letters = computed(() => {
     const letters = Array.from(
-      new Set(this.teams.map((team) => team.name[0].toUpperCase()))
+      new Set(this.categoryFilteredTeams().map((team) => team.name[0].toUpperCase()))
     ).sort();
     return letters;
   });
 
+  categoryFilteredTeams = computed(() => {
+    const filter = this.selectedFilterSignal();
+    const teams = this.teamsSignal();
+    return filter === 'all' ? teams : teams.filter((team) => team.categories.includes(filter));
+  });
+
   filteredTeams = computed(() => {
     const letter = this.selectedLetterSignal();
-    return letter ? this.teams.filter((team) => team.name[0].toUpperCase() === letter) : this.teams;
+    const teams = this.categoryFilteredTeams();
+    return letter ? teams.filter((team) => team.name[0].toUpperCase() === letter) : teams;
   });
 
   selectLetter(letter: string) {
@@ -50,6 +85,11 @@ export class TeamList {
     }
     this.selectedLetterSignal.set(normalized);
     this.letterSelected.emit(normalized);
+  }
+
+  selectFilter(filter: TeamDirectoryFilter) {
+    this.selectedFilterSignal.set(filter);
+    this.filterSelected.emit(filter);
   }
 
   createWikipediaLink(club: string): string {
@@ -65,12 +105,34 @@ export class TeamList {
     return links[club];
   }
 
-  primaryClubId(team: Team): string | null {
+  primaryClubId(team: TeamDirectoryItem): string | null {
     return team.clubIds[0] ?? null;
   }
 
   teamLinkState(): Record<string, string> {
     const letter = this.selectedLetterSignal();
-    return letter ? { teamsReturnLetter: letter } : {};
+    const filter = this.selectedFilterSignal();
+    return {
+      ...(letter ? { teamsReturnLetter: letter } : {}),
+      ...(filter !== 'all' ? { teamsReturnFilter: filter } : {}),
+    };
+  }
+
+  seasonSpanLabel(team: TeamDirectoryItem): string {
+    if (!team.firstSeenSeason || !team.lastSeenSeason) {
+      return 'No seasons';
+    }
+
+    return team.firstSeenSeason === team.lastSeenSeason
+      ? team.firstSeenSeason.toString()
+      : `${team.firstSeenSeason}-${team.lastSeenSeason}`;
+  }
+
+  seasonCountLabel(team: TeamDirectoryItem): string {
+    return `${team.totalSeasonsSeen} ${team.totalSeasonsSeen === 1 ? 'season' : 'seasons'}`;
+  }
+
+  statusLabel(team: TeamDirectoryItem): string {
+    return team.status === 'active' ? 'Active' : 'Historical';
   }
 }

--- a/src/app/components/team-list/team-list.ts
+++ b/src/app/components/team-list/team-list.ts
@@ -40,6 +40,7 @@ export class TeamList {
 
   @Output() letterSelected = new EventEmitter<string>();
   @Output() filterSelected = new EventEmitter<TeamDirectoryFilter>();
+  @Output() filtersCleared = new EventEmitter<void>();
 
   selectedLetterSignal = signal<string | null>(null);
   selectedFilterSignal = signal<TeamDirectoryFilter>('all');
@@ -74,6 +75,9 @@ export class TeamList {
     const teams = this.categoryFilteredTeams();
     return letter ? teams.filter((team) => team.name[0].toUpperCase() === letter) : teams;
   });
+  hasActiveFilters = computed(
+    () => Boolean(this.selectedLetterSignal()) || this.selectedFilterSignal() !== 'all'
+  );
 
   selectLetter(letter: string) {
     const normalized = letter.trim().toUpperCase();
@@ -90,6 +94,12 @@ export class TeamList {
   selectFilter(filter: TeamDirectoryFilter) {
     this.selectedFilterSignal.set(filter);
     this.filterSelected.emit(filter);
+  }
+
+  clearFilters() {
+    this.selectedLetterSignal.set(null);
+    this.selectedFilterSignal.set('all');
+    this.filtersCleared.emit();
   }
 
   createWikipediaLink(club: string): string {

--- a/src/app/pages/team-overview/team-overview.spec.ts
+++ b/src/app/pages/team-overview/team-overview.spec.ts
@@ -57,8 +57,9 @@ describe('TeamOverview', () => {
 
   it('builds a teams back link query param from hidden navigation state', () => {
     component.teamsReturnLetter.set('A');
+    component.teamsReturnFilter.set('top-flight');
 
-    expect(component.backToTeamsQueryParams()).toEqual({ letter: 'A' });
+    expect(component.backToTeamsQueryParams()).toEqual({ letter: 'A', filter: 'top-flight' });
   });
 
   it('labels identity periods ending in the latest tracked season as current', () => {

--- a/src/app/pages/team-overview/team-overview.ts
+++ b/src/app/pages/team-overview/team-overview.ts
@@ -21,6 +21,7 @@ import { DataIssueReportDialog } from '@app/components/data-issue-report-dialog/
 import type { LeagueTableEntry } from '@app/store/league.models';
 import { ClubMetadataStore } from '@app/store/club-metadata.store';
 import { LeagueStore } from '@app/store/league.store';
+import { isTeamDirectoryFilter, type TeamDirectoryFilter } from '@app/types';
 import type { DataIssueReportContext } from '@app/utils/data-issue-report';
 import {
   buildClubDerivedGaps,
@@ -96,6 +97,7 @@ type HistoryDisplayMode = 'compact' | 'small-chart' | 'full-chart';
 
 interface TeamsReturnNavigationState {
   teamsReturnLetter?: unknown;
+  teamsReturnFilter?: unknown;
 }
 
 echarts.use([LineChart, GridComponent, TooltipComponent, MarkAreaComponent, CanvasRenderer]);
@@ -125,9 +127,16 @@ export class TeamOverview implements AfterViewInit, OnDestroy {
   milestonesExpanded = signal(false);
   milestoneCollapsedHeight = signal<number | null>(null);
   teamsReturnLetter = signal(this.readTeamsReturnLetter());
+  teamsReturnFilter = signal<TeamDirectoryFilter>(this.readTeamsReturnFilter());
   backToTeamsQueryParams = computed(() => {
     const letter = this.teamsReturnLetter();
-    return letter ? { letter } : null;
+    const filter = this.teamsReturnFilter();
+    const queryParams = {
+      ...(letter ? { letter } : {}),
+      ...(filter !== 'all' ? { filter } : {}),
+    };
+
+    return Object.keys(queryParams).length ? queryParams : null;
   });
   club = computed(() => this.clubMetadataStore.getClubById(this.clubId()));
   entries = computed(() =>
@@ -330,6 +339,14 @@ export class TeamOverview implements AfterViewInit, OnDestroy {
     const letter = rawLetter.trim().toUpperCase();
 
     return /^[A-Z]$/.test(letter) ? letter : '';
+  }
+
+  private readTeamsReturnFilter(): TeamDirectoryFilter {
+    const state = (this.router.getCurrentNavigation()?.extras.state ??
+      globalThis.history?.state) as TeamsReturnNavigationState | undefined;
+    const filter = typeof state?.teamsReturnFilter === 'string' ? state.teamsReturnFilter : '';
+
+    return isTeamDirectoryFilter(filter) ? filter : 'all';
   }
 
   entriesAscending = computed(() =>

--- a/src/app/pages/teams/teams.html
+++ b/src/app/pages/teams/teams.html
@@ -13,7 +13,9 @@
   <app-team-list
     [teams]="teams()"
     [selectedLetter]="selectedLetter()"
+    [selectedFilter]="selectedFilter()"
     (letterSelected)="onLetterSelected($event)"
+    (filterSelected)="onFilterSelected($event)"
   />
 </section>
 }

--- a/src/app/pages/teams/teams.html
+++ b/src/app/pages/teams/teams.html
@@ -16,6 +16,7 @@
     [selectedFilter]="selectedFilter()"
     (letterSelected)="onLetterSelected($event)"
     (filterSelected)="onFilterSelected($event)"
+    (filtersCleared)="onFiltersCleared()"
   />
 </section>
 }

--- a/src/app/pages/teams/teams.spec.ts
+++ b/src/app/pages/teams/teams.spec.ts
@@ -80,4 +80,17 @@ describe('Teams', () => {
       replaceUrl: true,
     });
   });
+
+  it('clears letter and filter query params together', () => {
+    const navigateSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    component.onFiltersCleared();
+
+    expect(navigateSpy).toHaveBeenCalledWith([], {
+      relativeTo: TestBed.inject(ActivatedRoute),
+      queryParams: { letter: null, filter: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  });
 });

--- a/src/app/pages/teams/teams.spec.ts
+++ b/src/app/pages/teams/teams.spec.ts
@@ -17,8 +17,8 @@ describe('Teams', () => {
         {
           provide: ActivatedRoute,
           useValue: {
-            queryParamMap: of(convertToParamMap({ letter: 'm' })),
-            snapshot: { queryParamMap: convertToParamMap({ letter: 'm' }) },
+            queryParamMap: of(convertToParamMap({ letter: 'm', filter: 'historical' })),
+            snapshot: { queryParamMap: convertToParamMap({ letter: 'm', filter: 'historical' }) },
           },
         },
       ],
@@ -38,6 +38,10 @@ describe('Teams', () => {
     expect(component.selectedLetter()).toBe('M');
   });
 
+  it('reads the selected filter from the route query params', () => {
+    expect(component.selectedFilter()).toBe('historical');
+  });
+
   it('writes the selected letter to the route query params', () => {
     const navigateSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true);
 
@@ -46,6 +50,32 @@ describe('Teams', () => {
     expect(navigateSpy).toHaveBeenCalledWith([], {
       relativeTo: TestBed.inject(ActivatedRoute),
       queryParams: { letter: 'C' },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  });
+
+  it('writes the selected filter to the route query params', () => {
+    const navigateSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    component.onFilterSelected('active');
+
+    expect(navigateSpy).toHaveBeenCalledWith([], {
+      relativeTo: TestBed.inject(ActivatedRoute),
+      queryParams: { filter: 'active' },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  });
+
+  it('clears the filter query param when all teams are selected', () => {
+    const navigateSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    component.onFilterSelected('all');
+
+    expect(navigateSpy).toHaveBeenCalledWith([], {
+      relativeTo: TestBed.inject(ActivatedRoute),
+      queryParams: { filter: null },
       queryParamsHandling: 'merge',
       replaceUrl: true,
     });

--- a/src/app/pages/teams/teams.ts
+++ b/src/app/pages/teams/teams.ts
@@ -2,7 +2,14 @@ import { Component, computed, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TeamList } from '@app/components/team-list/team-list';
+import { ClubMetadataStore } from '@app/store/club-metadata.store';
 import { LeagueStore } from '@app/store/league.store';
+import {
+  isTeamDirectoryFilter,
+  type TeamDirectoryCategory,
+  type TeamDirectoryFilter,
+  type TeamDirectoryItem,
+} from '@app/types';
 
 @Component({
   selector: 'app-teams',
@@ -12,6 +19,7 @@ import { LeagueStore } from '@app/store/league.store';
 })
 export class Teams {
   private store = inject(LeagueStore);
+  private clubMetadataStore = inject(ClubMetadataStore);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
@@ -20,9 +28,51 @@ export class Teams {
   });
 
   // Add a computed signal so it automatically re-evaluates once hydrated
-  teams = computed(() => {
+  teams = computed<TeamDirectoryItem[]>(() => {
     const teams = this.store.getTeams();
-    return teams?.slice().sort((a, b) => a.name.localeCompare(b.name)) ?? [];
+    const latestSeason = this.store.getSeasons().at(-1) ?? null;
+    const tableRows = this.store.getFullTable();
+
+    return (
+      teams
+        ?.map((team) => {
+          const rows = tableRows.filter((row) => row.teamId === team.id);
+          const seasons = Array.from(new Set(rows.map((row) => row.season))).sort((a, b) => a - b);
+          const tiers = new Set(rows.map((row) => row.tier));
+          const latestRows = latestSeason ? rows.filter((row) => row.season === latestSeason) : [];
+          const isActive = latestRows.length > 0;
+          const status: TeamDirectoryItem['status'] = isActive ? 'active' : 'historical';
+          const hasLineage = team.clubIds.some(
+            (clubId) =>
+              (this.clubMetadataStore.getClubById(clubId)?.derived.relationships ?? []).length
+          );
+          const categories: TeamDirectoryCategory[] = [];
+
+          categories.push(isActive ? 'active' : 'historical');
+          if (tiers.has('tier1')) {
+            categories.push('top-flight');
+          }
+          if (latestRows.some((row) => row.tier === 'tier1')) {
+            categories.push('current-top-flight');
+          }
+          if (seasons.length >= 50) {
+            categories.push('long-run');
+          }
+          if (hasLineage) {
+            categories.push('lineage');
+          }
+
+          return {
+            ...team,
+            categories,
+            firstSeenSeason: seasons[0] ?? null,
+            lastSeenSeason: seasons.at(-1) ?? null,
+            totalSeasonsSeen: seasons.length,
+            status,
+          };
+        })
+        .sort((a, b) => a.name.localeCompare(b.name)) ?? []
+    );
   });
 
   selectedLetter = computed(() => {
@@ -31,10 +81,24 @@ export class Teams {
     return /^[A-Z]$/.test(letter) ? letter : '';
   });
 
+  selectedFilter = computed<TeamDirectoryFilter>(() => {
+    const filter = this.queryParamMap().get('filter') ?? 'all';
+    return isTeamDirectoryFilter(filter) ? filter : 'all';
+  });
+
   onLetterSelected(letter: string) {
     void this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { letter: letter || null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  }
+
+  onFilterSelected(filter: TeamDirectoryFilter) {
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { filter: filter === 'all' ? null : filter },
       queryParamsHandling: 'merge',
       replaceUrl: true,
     });

--- a/src/app/pages/teams/teams.ts
+++ b/src/app/pages/teams/teams.ts
@@ -103,4 +103,13 @@ export class Teams {
       replaceUrl: true,
     });
   }
+
+  onFiltersCleared() {
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { letter: null, filter: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  }
 }

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -1,1 +1,2 @@
 export * from './league-table-view.type';
+export * from './team-directory.type';

--- a/src/app/types/team-directory.type.ts
+++ b/src/app/types/team-directory.type.ts
@@ -1,0 +1,54 @@
+import type { Team } from '@app/store/league.models';
+
+export const TEAM_DIRECTORY_FILTERS = [
+  {
+    id: 'all',
+    label: 'All',
+    description: 'Every club name in the archive',
+  },
+  {
+    id: 'active',
+    label: 'Active',
+    description: 'Seen in the latest tracked season',
+  },
+  {
+    id: 'historical',
+    label: 'Historical',
+    description: 'Not seen in the latest tracked season',
+  },
+  {
+    id: 'top-flight',
+    label: 'Top flight',
+    description: 'Has appeared in the top tier',
+  },
+  {
+    id: 'current-top-flight',
+    label: 'Current top flight',
+    description: 'Top-tier club in the latest tracked season',
+  },
+  {
+    id: 'long-run',
+    label: '50+ seasons',
+    description: 'At least 50 tracked league seasons',
+  },
+  {
+    id: 'lineage',
+    label: 'Lineage links',
+    description: 'Has recorded merger, phoenix, or successor metadata',
+  },
+] as const;
+
+export type TeamDirectoryFilter = (typeof TEAM_DIRECTORY_FILTERS)[number]['id'];
+export type TeamDirectoryCategory = Exclude<TeamDirectoryFilter, 'all'>;
+
+export interface TeamDirectoryItem extends Team {
+  categories: TeamDirectoryCategory[];
+  firstSeenSeason: number | null;
+  lastSeenSeason: number | null;
+  totalSeasonsSeen: number;
+  status: 'active' | 'historical';
+}
+
+export function isTeamDirectoryFilter(value: string): value is TeamDirectoryFilter {
+  return TEAM_DIRECTORY_FILTERS.some((filter) => filter.id === value);
+}


### PR DESCRIPTION
## Summary
- Adds URL-backed category filters to the teams archive.
- Adds a clear-filters action for resetting active directory filters.
- Preserves selected directory context when navigating to and from club profiles.

## What Changed
- Added typed team directory filter metadata in `src/app/types/team-directory.type.ts`.
- Added team archive categories for active, historical, top-flight, current top-flight, 50+ seasons, and lineage-linked clubs.
- Updated `TeamList` to render category filter controls, counts, active states, status pills, archive span metadata, and an empty filtered state.
- Added a single `Clear filters` action that clears both `letter` and `filter` query params.
- Updated club profile back-link state to preserve both selected letter and selected filter.
- Added focused tests for filter selection, query param handling, clear behavior, and profile return state.

## Validation
- `pnpm test -- src/app/components/team-list/team-list.spec.ts src/app/pages/teams/teams.spec.ts`
- `pnpm build`
- `pnpm lint`
- `pnpm test`

## Scope Notes
- Does not add the removed `Needs metadata` filter.
- Does not include the admin/dashboard discussion; that remains a separate slice.