### PR TITLE
Kitchen Sink PR

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['**/*.spec.ts'],
+    ignores: ['**/*.spec.ts', 'dist/**', 'out-tsc/**', '.angular/**'],
   },
   {
     files: ['**/*.ts'],

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -2,6 +2,7 @@
   <header class="app-header">
     <app-main-toolbar />
   </header>
+  <app-data-update-banner />
   <main class="app-content">
     <router-outlet />
   </main>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -6,6 +6,19 @@
   <main class="app-content">
     <router-outlet />
   </main>
+
+  @if (showScrollTop()) {
+  <button
+    type="button"
+    class="scroll-top-button"
+    aria-label="Scroll to top"
+    title="Scroll to top"
+    (click)="scrollToTop()"
+  >
+    <mat-icon aria-hidden="true">keyboard_arrow_up</mat-icon>
+  </button>
+  }
+
   <footer class="app-footer">
     <div class="footer-inner">
       <section class="footer-brand" aria-label="FootyStats project">
@@ -30,9 +43,50 @@
       <nav class="footer-nav" aria-label="Footer">
         <div class="footer-link-group">
           <p>Explore</p>
+          <a routerLink="/dashboard">Archive home</a>
           <a routerLink="/tables">Tables</a>
           <a routerLink="/movement">Movement</a>
           <a routerLink="/teams">Clubs</a>
+        </div>
+        <div class="footer-link-group">
+          <p>Profiles</p>
+          <a routerLink="/leagues/tier1">Top flight</a>
+          <a routerLink="/leagues/tier2">Second tier</a>
+          <a routerLink="/leagues/tier3">Third tier</a>
+          <a routerLink="/leagues/tier4">Fourth tier</a>
+        </div>
+        <div class="footer-link-group">
+          <p>Deep Data</p>
+          <a routerLink="/leagues/tier1/deep-stats">Top flight stats</a>
+          <a routerLink="/leagues/tier2/deep-stats">Second tier stats</a>
+          <a routerLink="/leagues/tier3/deep-stats">Third tier stats</a>
+          <a routerLink="/leagues/tier4/deep-stats">Fourth tier stats</a>
+        </div>
+        <div class="footer-link-group footer-link-group--source">
+          <p>Source</p>
+          <a
+            class="footer-icon-link"
+            href="https://github.com/dills122/footy-stats"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <mat-icon aria-hidden="true">code</mat-icon>
+            GitHub repo
+          </a>
+          <a
+            class="footer-icon-link"
+            href="https://github.com/dills122/footy-stats/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <mat-icon aria-hidden="true">bug_report</mat-icon>
+            GitHub issues
+          </a>
+          <app-data-issue-report-dialog
+            triggerLabel="Report data issue"
+            triggerStyle="link"
+            [context]="footerIssueContext"
+          />
         </div>
         <div class="footer-link-group">
           <p>Studio</p>
@@ -46,18 +100,6 @@
           <a href="https://shwimp.studio/" target="_blank" rel="noopener noreferrer">
             Shwimp Studios
           </a>
-          <a
-            href="https://github.com/dills122/footy-stats"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Source
-          </a>
-          <app-data-issue-report-dialog
-            triggerLabel="Report data issue"
-            triggerStyle="link"
-            [context]="footerIssueContext"
-          />
         </div>
       </nav>
     </div>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,7 +1,9 @@
 import type { Routes } from '@angular/router';
 import { Home } from './pages/home/home';
+import { LeagueDeepStats } from './pages/league-deep-stats/league-deep-stats';
 import { LeagueTableHistoric } from './pages/league-table-historic/league-table-historic';
 import { MovementExplorer } from './pages/movement-explorer/movement-explorer';
+import { TeamDeepStats } from './pages/team-deep-stats/team-deep-stats';
 import { TeamOverview } from './pages/team-overview/team-overview';
 import { Teams } from './pages/teams/teams';
 import { TierProfile } from './pages/tier-profile/tier-profile';
@@ -10,7 +12,9 @@ export const routes: Routes = [
   { path: 'dashboard', component: Home },
   { path: 'tables', component: LeagueTableHistoric },
   { path: 'movement', component: MovementExplorer },
+  { path: 'leagues/:tier/deep-stats', component: LeagueDeepStats },
   { path: 'leagues/:tier', component: TierProfile },
+  { path: 'teams/:clubId/deep-stats', component: TeamDeepStats },
   { path: 'teams/:clubId', component: TeamOverview },
   { path: 'teams', component: Teams },
   //   { path: 'matches', component: MatchesComponent },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,11 +4,13 @@ import { LeagueTableHistoric } from './pages/league-table-historic/league-table-
 import { MovementExplorer } from './pages/movement-explorer/movement-explorer';
 import { TeamOverview } from './pages/team-overview/team-overview';
 import { Teams } from './pages/teams/teams';
+import { TierProfile } from './pages/tier-profile/tier-profile';
 
 export const routes: Routes = [
   { path: 'dashboard', component: Home },
   { path: 'tables', component: LeagueTableHistoric },
   { path: 'movement', component: MovementExplorer },
+  { path: 'leagues/:tier', component: TierProfile },
   { path: 'teams/:clubId', component: TeamOverview },
   { path: 'teams', component: Teams },
   //   { path: 'matches', component: MatchesComponent },

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -182,3 +182,20 @@
     font-size: 0.78rem;
   }
 }
+
+@media print {
+  :host,
+  .app-shell {
+    min-height: auto;
+    display: block;
+  }
+
+  .app-content {
+    padding: 0;
+  }
+
+  .app-header,
+  .app-footer {
+    display: none;
+  }
+}

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -22,7 +22,7 @@
 
 .scroll-top-button {
   position: fixed;
-  right: max(18px, calc((100vw - 1160px) / 2));
+  right: clamp(18px, calc((100vw - 1160px) / 2 - 72px), 96px);
   bottom: 22px;
   z-index: 25;
   width: 44px;

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -20,6 +20,39 @@
   padding: 28px clamp(12px, 2vw, 24px) 28px;
 }
 
+.scroll-top-button {
+  position: fixed;
+  right: max(18px, calc((100vw - 1160px) / 2));
+  bottom: 22px;
+  z-index: 25;
+  width: 44px;
+  height: 44px;
+  border: 1px solid rgba(196, 181, 253, 0.44);
+  border-radius: 8px;
+  display: inline-grid;
+  place-items: center;
+  color: var(--app-text-strong);
+  background: rgba(15, 23, 42, 0.92);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.28);
+  cursor: pointer;
+}
+
+.scroll-top-button:hover {
+  border-color: rgba(216, 180, 254, 0.72);
+  background: rgba(30, 41, 59, 0.96);
+}
+
+.scroll-top-button:focus-visible {
+  outline: 3px solid rgba(196, 181, 253, 0.5);
+  outline-offset: 3px;
+}
+
+.scroll-top-button mat-icon {
+  font-size: 28px;
+  width: 28px;
+  height: 28px;
+}
+
 .app-footer {
   padding: 24px clamp(12px, 2vw, 24px) 30px;
 }
@@ -30,8 +63,9 @@
   padding-top: 24px;
   border-top: 1px solid var(--app-border);
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(260px, 1fr) minmax(0, 1.4fr);
   gap: 32px;
+  align-items: start;
 }
 
 .footer-brand {
@@ -87,8 +121,8 @@
 
 .footer-nav {
   display: grid;
-  grid-template-columns: repeat(2, minmax(120px, auto));
-  gap: 32px;
+  grid-template-columns: repeat(5, minmax(112px, 1fr));
+  gap: 20px;
 }
 
 .footer-link-group p {
@@ -101,7 +135,9 @@
 }
 
 .footer-link-group a {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 7px;
   color: var(--app-text-muted);
   text-decoration: none;
   font-size: 0.94rem;
@@ -111,6 +147,19 @@
 
 .footer-link-group app-data-issue-report-dialog {
   display: block;
+  margin-top: 2px;
+}
+
+.footer-icon-link mat-icon {
+  flex: 0 0 auto;
+  width: 17px;
+  height: 17px;
+  font-size: 17px;
+  color: #c4b5fd;
+}
+
+.footer-link-group--source {
+  min-width: 140px;
 }
 
 .footer-link-group a:hover {
@@ -134,6 +183,13 @@
 @media (max-width: 700px) {
   .app-content {
     padding: 14px 0 22px;
+  }
+
+  .scroll-top-button {
+    right: 12px;
+    bottom: 14px;
+    width: 42px;
+    height: 42px;
   }
 
   .app-footer {
@@ -166,7 +222,7 @@
   .footer-nav {
     padding-top: 16px;
     border-top: 1px solid rgba(148, 163, 184, 0.12);
-    grid-template-columns: repeat(auto-fit, minmax(138px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 16px;
   }
 
@@ -195,7 +251,8 @@
   }
 
   .app-header,
-  .app-footer {
+  .app-footer,
+  .scroll-top-button {
     display: none;
   }
 }

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -67,4 +67,32 @@ describe('App', () => {
     await fixture.whenStable();
     expect(checkForUpdatesSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('renders source and view links in the footer', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(element.querySelector('a[href="https://github.com/dills122/footy-stats"]')).toBeTruthy();
+    expect(
+      element.querySelector('a[href="https://github.com/dills122/footy-stats/issues"]')
+    ).toBeTruthy();
+    expect(element.querySelector('a[href="/leagues/tier1/deep-stats"]')?.textContent).toContain(
+      'Top flight stats'
+    );
+  });
+
+  it('shows the scroll-to-top button after scrolling down', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    Object.defineProperty(globalThis, 'scrollY', {
+      configurable: true,
+      value: 640,
+    });
+    fixture.componentInstance['onWindowScroll']();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.scroll-top-button')).toBeTruthy();
+  });
 });

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,15 +1,19 @@
 import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 
 import { App } from './app';
+import { DataUpdateService } from './store/services/data-update.service';
 import { DataLoaderService } from './store/services/hydrate-store-json';
 
 describe('App', () => {
   let loadDataSpy: jest.Mock;
+  let checkForUpdatesSpy: jest.Mock;
 
   beforeEach(async () => {
     loadDataSpy = jest.fn().mockResolvedValue(undefined);
+    checkForUpdatesSpy = jest.fn().mockResolvedValue(undefined);
 
     await TestBed.configureTestingModule({
       imports: [App],
@@ -20,6 +24,22 @@ describe('App', () => {
           provide: DataLoaderService,
           useValue: {
             loadData: loadDataSpy,
+          },
+        },
+        {
+          provide: DataUpdateService,
+          useValue: {
+            activeDataInfo: signal(null),
+            checkStatus: signal('idle'),
+            installStatus: signal('idle'),
+            latestManifest: signal(null),
+            statusMessage: signal(''),
+            hasLocalOverride: signal(false),
+            updateAvailable: signal(false),
+            checkForUpdates: checkForUpdatesSpy,
+            installLatestUpdate: jest.fn(),
+            clearLocalOverride: jest.fn(),
+            dismissAvailableUpdate: jest.fn(),
           },
         },
       ],
@@ -44,5 +64,7 @@ describe('App', () => {
     fixture.detectChanges(); // triggers ngOnInit
 
     expect(loadDataSpy).toHaveBeenCalledTimes(1);
+    await fixture.whenStable();
+    expect(checkForUpdatesSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,4 +1,5 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, HostListener, inject, OnInit, signal } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
 import { RouterModule } from '@angular/router';
 import { DataIssueReportDialog } from './components/data-issue-report-dialog/data-issue-report-dialog';
 import { DataUpdateBannerComponent } from './components/data-update-banner/data-update-banner';
@@ -8,12 +9,19 @@ import { DataLoaderService } from './store/services/hydrate-store-json';
 
 @Component({
   selector: 'app-root',
-  imports: [MainToolbar, RouterModule, DataIssueReportDialog, DataUpdateBannerComponent],
+  imports: [
+    MainToolbar,
+    RouterModule,
+    MatIconModule,
+    DataIssueReportDialog,
+    DataUpdateBannerComponent,
+  ],
   templateUrl: './app.html',
   styleUrl: './app.scss',
 })
 export class App implements OnInit {
   protected readonly title = signal('Footy Stats - English Football Data');
+  protected readonly showScrollTop = signal(false);
   protected readonly footerIssueContext = {
     pageTitle: 'FootyStats',
     sourcePath: 'Site footer',
@@ -23,5 +31,20 @@ export class App implements OnInit {
 
   ngOnInit() {
     void this.dataLoader.loadData().then(() => this.dataUpdates.checkForUpdates());
+  }
+
+  @HostListener('window:scroll')
+  protected onWindowScroll() {
+    this.showScrollTop.set(globalThis.scrollY > 520);
+  }
+
+  protected scrollToTop() {
+    const prefersReducedMotion = globalThis.matchMedia?.(
+      '(prefers-reduced-motion: reduce)'
+    ).matches;
+    globalThis.scrollTo({
+      top: 0,
+      behavior: prefersReducedMotion ? 'auto' : 'smooth',
+    });
   }
 }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,12 +1,14 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { DataIssueReportDialog } from './components/data-issue-report-dialog/data-issue-report-dialog';
+import { DataUpdateBannerComponent } from './components/data-update-banner/data-update-banner';
 import { MainToolbar } from './components/main-toolbar/main-toolbar';
+import { DataUpdateService } from './store/services/data-update.service';
 import { DataLoaderService } from './store/services/hydrate-store-json';
 
 @Component({
   selector: 'app-root',
-  imports: [MainToolbar, RouterModule, DataIssueReportDialog],
+  imports: [MainToolbar, RouterModule, DataIssueReportDialog, DataUpdateBannerComponent],
   templateUrl: './app.html',
   styleUrl: './app.scss',
 })
@@ -17,8 +19,9 @@ export class App implements OnInit {
     sourcePath: 'Site footer',
   };
   private dataLoader = inject(DataLoaderService);
+  private dataUpdates = inject(DataUpdateService);
 
   ngOnInit() {
-    this.dataLoader.loadData(); // async, store will hydrate in background
+    void this.dataLoader.loadData().then(() => this.dataUpdates.checkForUpdates());
   }
 }

--- a/src/app/components/data-update-banner/data-update-banner.html
+++ b/src/app/components/data-update-banner/data-update-banner.html
@@ -1,0 +1,53 @@
+@if (shouldShow()) {
+<section
+  class="data-update-banner"
+  [class.data-update-banner--active]="dataUpdates.hasLocalOverride()"
+  [class.data-update-banner--error]="
+    dataUpdates.checkStatus() === 'error' || dataUpdates.installStatus() === 'error'
+  "
+  aria-live="polite"
+>
+  <div class="data-update-copy">
+    @if (dataUpdates.updateAvailable() && dataUpdates.latestManifest(); as manifest) {
+    <strong>New archive data available</strong>
+    <span>
+      {{ manifest.version }} generated {{ manifest.generatedAt | date: 'mediumDate' }} can replace
+      the shipped data locally.
+    </span>
+    } @else if (dataUpdates.hasLocalOverride() && dataUpdates.activeDataInfo(); as activeData) {
+    <strong>Using local archive data</strong>
+    <span>
+      {{ activeData.version }} installed {{ activeData.installedAt | date: 'mediumDate' }} from the
+      verified data bundle.
+    </span>
+    } @else if (dataUpdates.installStatus() === 'installed') {
+    <strong>Archive data updated</strong>
+    <span>The newest verified data bundle is now active in this browser.</span>
+    } @else {
+    <strong>Data update unavailable</strong>
+    <span>{{ dataUpdates.statusMessage() || 'Could not check for a newer data bundle.' }}</span>
+    }
+  </div>
+
+  <div class="data-update-actions">
+    @if (dataUpdates.updateAvailable()) {
+    <button type="button" class="primary-action" [disabled]="isBusy()" (click)="installUpdate()">
+      @if (currentStatus() === 'downloading') { Downloading } @else if (currentStatus() ===
+      'verifying') { Verifying } @else { Update data }
+    </button>
+    <button
+      type="button"
+      class="quiet-action"
+      [disabled]="isBusy()"
+      (click)="dataUpdates.dismissAvailableUpdate()"
+    >
+      Not now
+    </button>
+    } @else if (dataUpdates.hasLocalOverride()) {
+    <button type="button" class="quiet-action" [disabled]="isBusy()" (click)="clearOverride()">
+      Use shipped data
+    </button>
+    }
+  </div>
+</section>
+}

--- a/src/app/components/data-update-banner/data-update-banner.html
+++ b/src/app/components/data-update-banner/data-update-banner.html
@@ -8,24 +8,17 @@
   aria-live="polite"
 >
   <div class="data-update-copy">
-    @if (dataUpdates.updateAvailable() && dataUpdates.latestManifest(); as manifest) {
-    <strong>New archive data available</strong>
-    <span>
-      {{ manifest.version }} generated {{ manifest.generatedAt | date: 'mediumDate' }} can replace
-      the shipped data locally.
-    </span>
-    } @else if (dataUpdates.hasLocalOverride() && dataUpdates.activeDataInfo(); as activeData) {
-    <strong>Using local archive data</strong>
-    <span>
-      {{ activeData.version }} installed {{ activeData.installedAt | date: 'mediumDate' }} from the
-      verified data bundle.
-    </span>
+    @if (dataUpdates.updateAvailable()) {
+    <strong>New data set available</strong>
+    <span>Ready to refresh the archive?</span>
     } @else if (dataUpdates.installStatus() === 'installed') {
-    <strong>Archive data updated</strong>
-    <span>The newest verified data bundle is now active in this browser.</span>
+    <strong>Data refreshed</strong>
+    <span>The latest archive is now active.</span>
     } @else {
-    <strong>Data update unavailable</strong>
-    <span>{{ dataUpdates.statusMessage() || 'Could not check for a newer data bundle.' }}</span>
+    <strong>Update check failed</strong>
+    <span>
+      {{ dataUpdates.statusMessage() || 'The site could not check for newer tables right now.' }}
+    </span>
     }
   </div>
 
@@ -33,7 +26,7 @@
     @if (dataUpdates.updateAvailable()) {
     <button type="button" class="primary-action" [disabled]="isBusy()" (click)="installUpdate()">
       @if (currentStatus() === 'downloading') { Downloading } @else if (currentStatus() ===
-      'verifying') { Verifying } @else { Update data }
+      'verifying') { Verifying } @else { Refresh data }
     </button>
     <button
       type="button"
@@ -45,7 +38,7 @@
     </button>
     } @else if (dataUpdates.hasLocalOverride()) {
     <button type="button" class="quiet-action" [disabled]="isBusy()" (click)="clearOverride()">
-      Use shipped data
+      Use original data
     </button>
     }
   </div>

--- a/src/app/components/data-update-banner/data-update-banner.scss
+++ b/src/app/components/data-update-banner/data-update-banner.scss
@@ -1,0 +1,108 @@
+:host {
+  display: block;
+}
+
+.data-update-banner {
+  width: min(1160px, calc(100vw - 24px));
+  margin: 14px auto 0;
+  padding: 12px 14px;
+  border: 1px solid rgba(96, 165, 250, 0.38);
+  border-left: 3px solid #3b82f6;
+  border-radius: 8px;
+  background: rgba(7, 10, 19, 0.78);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+}
+
+.data-update-banner--active {
+  border-color: rgba(52, 211, 153, 0.42);
+  border-left-color: #10b981;
+}
+
+.data-update-banner--error {
+  border-color: rgba(217, 119, 6, 0.54);
+  border-left-color: #d97706;
+}
+
+.data-update-copy {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.data-update-copy strong {
+  color: var(--app-text-strong);
+  font-size: 0.84rem;
+}
+
+.data-update-copy span {
+  color: var(--app-text-muted);
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.data-update-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.data-update-actions button {
+  min-height: 36px;
+  border-radius: 7px;
+  padding: 0 12px;
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.data-update-actions button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.primary-action {
+  border: 1px solid rgba(216, 180, 254, 0.55);
+  color: #1f1140;
+  background: #c4b5fd;
+}
+
+.primary-action:hover:not(:disabled) {
+  background: #ddd6fe;
+}
+
+.quiet-action {
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  color: var(--app-text-strong);
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.quiet-action:hover:not(:disabled) {
+  border-color: rgba(248, 250, 252, 0.42);
+}
+
+@media (max-width: 700px) {
+  .data-update-banner {
+    width: min(100%, calc(100vw - 16px));
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .data-update-actions {
+    justify-content: stretch;
+  }
+
+  .data-update-actions button {
+    flex: 1 1 130px;
+  }
+}
+
+@media print {
+  :host {
+    display: none;
+  }
+}

--- a/src/app/components/data-update-banner/data-update-banner.ts
+++ b/src/app/components/data-update-banner/data-update-banner.ts
@@ -1,10 +1,8 @@
 import { Component, computed, inject } from '@angular/core';
-import { DatePipe } from '@angular/common';
 import { DataUpdateService } from '@app/store/services/data-update.service';
 
 @Component({
   selector: 'app-data-update-banner',
-  imports: [DatePipe],
   templateUrl: './data-update-banner.html',
   styleUrl: './data-update-banner.scss',
 })
@@ -24,7 +22,6 @@ export class DataUpdateBannerComponent {
   protected readonly shouldShow = computed(
     () =>
       this.dataUpdates.updateAvailable() ||
-      this.dataUpdates.hasLocalOverride() ||
       this.dataUpdates.installStatus() === 'installed' ||
       this.dataUpdates.checkStatus() === 'error' ||
       this.dataUpdates.installStatus() === 'error'

--- a/src/app/components/data-update-banner/data-update-banner.ts
+++ b/src/app/components/data-update-banner/data-update-banner.ts
@@ -1,0 +1,40 @@
+import { Component, computed, inject } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { DataUpdateService } from '@app/store/services/data-update.service';
+
+@Component({
+  selector: 'app-data-update-banner',
+  imports: [DatePipe],
+  templateUrl: './data-update-banner.html',
+  styleUrl: './data-update-banner.scss',
+})
+export class DataUpdateBannerComponent {
+  protected readonly dataUpdates = inject(DataUpdateService);
+  protected readonly currentStatus = computed(() => {
+    const installStatus = this.dataUpdates.installStatus();
+    if (installStatus !== 'idle') {
+      return installStatus;
+    }
+
+    return this.dataUpdates.checkStatus();
+  });
+  protected readonly isBusy = computed(() =>
+    ['checking', 'downloading', 'verifying'].includes(this.currentStatus())
+  );
+  protected readonly shouldShow = computed(
+    () =>
+      this.dataUpdates.updateAvailable() ||
+      this.dataUpdates.hasLocalOverride() ||
+      this.dataUpdates.installStatus() === 'installed' ||
+      this.dataUpdates.checkStatus() === 'error' ||
+      this.dataUpdates.installStatus() === 'error'
+  );
+
+  protected async installUpdate() {
+    await this.dataUpdates.installLatestUpdate();
+  }
+
+  protected async clearOverride() {
+    await this.dataUpdates.clearLocalOverride();
+  }
+}

--- a/src/app/components/league-table/league-table.html
+++ b/src/app/components/league-table/league-table.html
@@ -97,6 +97,7 @@
       *matRowDef="let row; columns: displayedColumns; let i = index"
       class="app-data-row"
       [class.row-top]="i < 4"
+      [style.--row-index]="i"
     ></tr>
   </table>
 </div>

--- a/src/app/components/league-table/league-table.scss
+++ b/src/app/components/league-table/league-table.scss
@@ -1,7 +1,8 @@
 .table-container {
   width: 100%;
   max-width: 100%;
-  overflow: auto;
+  overflow-x: auto;
+  overflow-y: hidden;
   isolation: isolate;
   --league-table-sticky-head-bg: #d9dde3;
   --league-table-sticky-row-bg: #d2d6dc;
@@ -63,6 +64,11 @@
 
 .row-top .cell {
   background: rgba(245, 158, 11, 0.08);
+}
+
+.app-data-row {
+  animation: table-row-reveal 260ms ease-out both;
+  animation-delay: calc(var(--row-index, 0) * 18ms);
 }
 
 .app-data-row:nth-child(even) .position-col,
@@ -144,6 +150,18 @@
   border-bottom: 0;
 }
 
+@keyframes table-row-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @media (max-width: 980px) {
   .footy-table {
     min-width: 760px;
@@ -201,5 +219,11 @@
 
   .team {
     font-size: 0.88rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-data-row {
+    animation: none;
   }
 }

--- a/src/app/components/league-table/league-table.scss
+++ b/src/app/components/league-table/league-table.scss
@@ -227,3 +227,63 @@
     animation: none;
   }
 }
+
+@media print {
+  .table-container {
+    overflow: visible;
+    border: 1px solid #cbd5e1;
+    background: #ffffff;
+  }
+
+  .footy-table {
+    min-width: 0;
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+    font-size: 8.2pt;
+  }
+
+  .head,
+  .cell {
+    position: static;
+    padding: 5px 4px;
+    border-bottom: 1px solid #d1d5db;
+    background: #ffffff !important;
+    color: #111827 !important;
+  }
+
+  .head {
+    border-bottom: 2px solid #94a3b8;
+    font-size: 7pt;
+  }
+
+  .position-col {
+    width: 28px;
+    min-width: 0;
+  }
+
+  .team-col {
+    width: auto;
+    min-width: 0;
+    max-width: none;
+  }
+
+  .team-link {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
+  .rank {
+    width: auto;
+    height: auto;
+    border: 0;
+    background: transparent;
+    color: #111827;
+    font-size: inherit;
+  }
+
+  .report {
+    display: none;
+  }
+}

--- a/src/app/components/league-table/league-table.scss
+++ b/src/app/components/league-table/league-table.scss
@@ -231,7 +231,7 @@
 @media print {
   .table-container {
     overflow: visible;
-    border: 1px solid #cbd5e1;
+    border: 0;
     background: #ffffff;
   }
 
@@ -240,21 +240,21 @@
     width: 100%;
     table-layout: fixed;
     border-collapse: collapse;
-    font-size: 8.2pt;
+    font-size: 7.2pt;
   }
 
   .head,
   .cell {
     position: static;
-    padding: 5px 4px;
-    border-bottom: 1px solid #d1d5db;
+    padding: 3px 3px;
+    border-bottom: 1px solid #d9d9d9;
     background: #ffffff !important;
-    color: #111827 !important;
+    color: #000000 !important;
   }
 
   .head {
-    border-bottom: 2px solid #94a3b8;
-    font-size: 7pt;
+    border-bottom: 1px solid #000000;
+    font-size: 6.4pt;
   }
 
   .position-col {
@@ -279,7 +279,7 @@
     height: auto;
     border: 0;
     background: transparent;
-    color: #111827;
+    color: #000000;
     font-size: inherit;
   }
 

--- a/src/app/components/league-tables-viewer/league-tables-viewer.html
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.html
@@ -1,52 +1,156 @@
 <div class="viewer">
   <section class="table-record">
     <header class="record-header app-page-header">
-      <p class="app-page-eyebrow">League Table Archive</p>
-      <h1 class="app-page-title">
-        @if (selectedYear() && currentLeagueLabel()) { {{ selectedYear() }} {{ currentLeagueLabel()
-        | leagueTierToStringy }} Table } @else { League Tables }
-      </h1>
-      <p class="app-page-lede">
-        Read preserved season standings with wins, draws, losses, scoring record, goal difference,
-        and points.
-      </p>
+      <div class="record-header-copy">
+        <p class="app-page-eyebrow">League Table Archive</p>
+        <h1 class="app-page-title">League Tables</h1>
+        <p class="record-selection">
+          @if (selectedYear() && currentLeagueLabel()) { {{ selectedYear() }} {{
+          currentLeagueLabel() | leagueTierToStringy }} } @else { &nbsp; }
+        </p>
+        <p class="app-page-lede">
+          Read preserved season standings with wins, draws, losses, scoring record, goal difference,
+          and points.
+        </p>
+      </div>
+      <div class="record-header-action">
+        @if (tableControlsReady()) {
+        <app-data-issue-report-dialog
+          triggerLabel="Report table issue"
+          [context]="dataIssueContext()"
+        />
+        } @else {
+        <span class="report-action-placeholder" aria-hidden="true"></span>
+        }
+      </div>
     </header>
 
-    <div class="record-tools" aria-label="Select season table">
-      <mat-form-field class="field" appearance="fill">
-        <mat-label>Season</mat-label>
-        <mat-icon matPrefix>calendar_today</mat-icon>
-        <mat-select [value]="selectedYear()" (selectionChange)="onYearChange($event.value)">
-          @for (year of years; track year) {
-          <mat-option [value]="year">{{ year }}</mat-option>
-          } @empty {
-          <mat-option disabled>No Seasons Available</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
+    <div class="record-control-row">
+      <div class="record-tools" aria-label="Select season table">
+        @if (tableControlsReady()) {
+        <mat-form-field class="field" appearance="fill">
+          <mat-label>Season</mat-label>
+          <mat-icon matPrefix>calendar_today</mat-icon>
+          <mat-select [value]="selectedYear()" (selectionChange)="onYearChange($event.value)">
+            @for (year of years; track year) {
+            <mat-option [value]="year">{{ year }}</mat-option>
+            } @empty {
+            <mat-option disabled>No Seasons Available</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
 
-      @if (leaguesForYear.length > 0) {
-      <mat-form-field class="field" appearance="fill">
-        <mat-label>Competition</mat-label>
-        <mat-icon matPrefix>sports_soccer</mat-icon>
-        <mat-select [value]="selectedLeague()" (selectionChange)="onLeagueChange($event.value)">
-          @for (league of leaguesForYear; track league) {
-          <mat-option [value]="league">{{ league | leagueTierToStringy }}</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
-      }
+        <mat-form-field class="field" appearance="fill">
+          <mat-label>Competition</mat-label>
+          <mat-icon matPrefix>sports_soccer</mat-icon>
+          <mat-select [value]="selectedLeague()" (selectionChange)="onLeagueChange($event.value)">
+            @for (league of leaguesForYear; track league) {
+            <mat-option [value]="league">{{ league | leagueTierToStringy }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+        } @else {
+        <div class="field-placeholder" aria-hidden="true">
+          <span></span>
+          <strong></strong>
+        </div>
+        <div class="field-placeholder" aria-hidden="true">
+          <span></span>
+          <strong></strong>
+        </div>
+        <p class="sr-only" role="status">Loading table filters.</p>
+        }
+      </div>
 
-      <app-data-issue-report-dialog
-        class="report-field"
-        triggerLabel="Report table issue"
-        [context]="dataIssueContext()"
-      />
+      <div class="record-control-actions">
+        <button
+          type="button"
+          class="control-action"
+          (click)="scrollToTableContent(tableResultShell)"
+        >
+          <mat-icon aria-hidden="true">south</mat-icon>
+          <span>Jump to table</span>
+        </button>
+        <button
+          type="button"
+          class="control-action"
+          aria-controls="table-presets"
+          [attr.aria-expanded]="!quickFiltersCollapsed()"
+          (click)="toggleQuickFilters()"
+        >
+          <mat-icon aria-hidden="true">
+            {{ quickFiltersCollapsed() ? 'unfold_more' : 'unfold_less' }}
+          </mat-icon>
+          <span>{{ quickFiltersCollapsed() ? 'Show presets' : 'Hide presets' }}</span>
+        </button>
+      </div>
     </div>
 
-    @if (currentTable(); as tableData) {
-    <app-season-summary-card [tableData]="tableData" />
-    <app-league-table [leagueTable]="tableData" />
-    }
+    <section
+      id="table-presets"
+      class="preset-panel"
+      aria-label="Notable table presets"
+      [hidden]="quickFiltersCollapsed()"
+    >
+      <div class="preset-panel-head">
+        <h2>Notable tables</h2>
+        <span>Fast jumps into useful archive views</span>
+      </div>
+      @if (tablePresets().length) {
+      <div class="preset-list">
+        @for (preset of tablePresets(); track preset.id) {
+        <button
+          type="button"
+          class="preset-chip"
+          [class.is-active]="activePresetId() === preset.id"
+          [attr.aria-pressed]="activePresetId() === preset.id"
+          (click)="applyPreset(preset)"
+        >
+          <span>{{ preset.label }}</span>
+          <small>{{ preset.season }} / {{ preset.detail }}</small>
+        </button>
+        }
+      </div>
+      } @else {
+      <div class="preset-placeholder-list" aria-hidden="true">
+        @for (preset of [1, 2, 3, 4]; track preset) {
+        <span></span>
+        }
+      </div>
+      }
+    </section>
+
+    <section
+      #tableResultShell
+      class="table-result-shell"
+      aria-label="Selected league table"
+      [attr.aria-busy]="currentTable() ? null : 'true'"
+      tabindex="-1"
+    >
+      @if (currentTable(); as tableData) {
+      <div
+        class="table-result"
+        [class.table-result--revealed]="tableRevealActive()"
+        [attr.data-table-key]="tableResultKey()"
+      >
+        <app-season-summary-card [tableData]="tableData" />
+        <app-league-table [leagueTable]="tableData" />
+      </div>
+      } @else {
+      <div class="table-result-placeholder" aria-hidden="true">
+        <div class="summary-placeholder app-panel">
+          <span></span>
+          <strong></strong>
+          <span></span>
+        </div>
+        <div class="table-placeholder app-data-shell">
+          @for (row of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]; track row) {
+          <span></span>
+          }
+        </div>
+      </div>
+      <p class="sr-only" role="status">Loading league table.</p>
+      }
+    </section>
   </section>
 </div>

--- a/src/app/components/league-tables-viewer/league-tables-viewer.html
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.html
@@ -120,6 +120,17 @@
       }
     </section>
 
+    @if (tableDataNotices().length) {
+    <section class="data-notice-stack" aria-label="Data classification notes">
+      @for (notice of tableDataNotices(); track notice.id) {
+      <aside class="data-notice" role="note">
+        <strong>{{ notice.title }}</strong>
+        <p>{{ notice.detail }}</p>
+      </aside>
+      }
+    </section>
+    }
+
     <section
       #tableResultShell
       class="table-result-shell"

--- a/src/app/components/league-tables-viewer/league-tables-viewer.scss
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.scss
@@ -227,6 +227,33 @@
   background: rgba(148, 163, 184, 0.12);
 }
 
+.data-notice-stack {
+  display: grid;
+  gap: 10px;
+}
+
+.data-notice {
+  border: 1px solid rgba(245, 158, 11, 0.34);
+  border-radius: 8px;
+  padding: 13px 14px;
+  display: grid;
+  gap: 5px;
+  background: rgba(245, 158, 11, 0.08);
+  color: var(--app-text-muted);
+}
+
+.data-notice strong {
+  color: var(--app-text-strong);
+  font-size: 0.96rem;
+}
+
+.data-notice p {
+  max-width: 82ch;
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
 :host ::ng-deep .field .mdc-text-field--filled {
   border: 1px solid var(--app-border);
   background: rgba(7, 10, 19, 0.28);

--- a/src/app/components/league-tables-viewer/league-tables-viewer.scss
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.scss
@@ -21,6 +21,37 @@
   margin-bottom: 0;
   padding-bottom: clamp(16px, 2.4vw, 26px);
   border-bottom: 1px solid var(--app-border);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: start;
+}
+
+.record-header-copy {
+  min-width: 0;
+}
+
+.record-header-action {
+  min-width: 150px;
+  min-height: 40px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.record-selection {
+  min-height: 1.15rem;
+  margin: 0 0 8px;
+  color: var(--app-text-muted);
+  font-size: 0.92rem;
+  font-weight: 750;
+}
+
+.record-control-row {
+  margin-top: -4px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px 18px;
+  align-items: start;
 }
 
 .record-tools {
@@ -29,7 +60,47 @@
   gap: 12px;
   align-items: flex-start;
   max-width: 760px;
-  margin-top: -4px;
+}
+
+.record-control-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.control-action {
+  min-height: 40px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 7px 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(7, 10, 19, 0.18);
+  color: var(--app-text-strong);
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.control-action:hover {
+  border-color: rgba(148, 163, 184, 0.44);
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.control-action:focus-visible,
+.preset-chip:focus-visible,
+.table-result-shell:focus-visible {
+  outline: 2px solid rgba(226, 232, 240, 0.76);
+  outline-offset: 3px;
+}
+
+.control-action mat-icon {
+  width: 18px;
+  height: 18px;
+  font-size: 18px;
+  line-height: 18px;
 }
 
 .field {
@@ -42,9 +113,118 @@
   --mat-select-panel-background-color: #111827;
 }
 
-.report-field {
+.field-placeholder {
+  width: min(100%, 280px);
+  min-height: 56px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 10px 13px;
+  display: grid;
+  align-content: center;
+  gap: 7px;
+  background: rgba(7, 10, 19, 0.28);
+}
+
+.field-placeholder span,
+.field-placeholder strong,
+.report-action-placeholder {
+  border-radius: 6px;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.field-placeholder span {
+  width: 76px;
+  height: 10px;
+}
+
+.field-placeholder strong {
+  width: 128px;
+  height: 16px;
+}
+
+.report-action-placeholder {
+  width: 150px;
+  height: 38px;
   display: block;
-  padding-top: 8px;
+}
+
+.preset-panel {
+  margin-top: -12px;
+  display: grid;
+  gap: 12px;
+}
+
+.preset-panel[hidden] {
+  display: none;
+}
+
+.preset-panel-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.preset-panel-head h2 {
+  margin: 0;
+  color: var(--app-text-strong);
+  font-size: 0.94rem;
+  font-weight: 800;
+}
+
+.preset-panel-head span {
+  color: var(--app-text-muted);
+  font-size: 0.82rem;
+}
+
+.preset-list,
+.preset-placeholder-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(178px, 1fr));
+  gap: 10px;
+}
+
+.preset-chip {
+  min-height: 66px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 10px 11px;
+  display: grid;
+  gap: 5px;
+  align-content: center;
+  text-align: left;
+  background: rgba(7, 10, 19, 0.18);
+  color: var(--app-text-strong);
+  font: inherit;
+  cursor: pointer;
+}
+
+.preset-chip:hover {
+  border-color: rgba(148, 163, 184, 0.44);
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.preset-chip.is-active {
+  border-color: rgba(217, 119, 6, 0.54);
+  background: rgba(217, 119, 6, 0.12);
+}
+
+.preset-chip span {
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.preset-chip small {
+  color: var(--app-text-muted);
+  font-size: 0.76rem;
+  line-height: 1.3;
+}
+
+.preset-placeholder-list span {
+  min-height: 66px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: rgba(148, 163, 184, 0.12);
 }
 
 :host ::ng-deep .field .mdc-text-field--filled {
@@ -72,18 +252,177 @@ app-season-summary-card {
   display: block;
 }
 
+.table-result-shell {
+  min-height: clamp(520px, 68vh, 820px);
+  scroll-margin-top: 96px;
+  display: block;
+}
+
+.table-result {
+  display: grid;
+  gap: clamp(18px, 3vw, 28px);
+  opacity: 0;
+  transform: translateY(6px);
+}
+
+.table-result--revealed {
+  animation: table-result-settle 360ms ease-out forwards;
+}
+
+.table-result-placeholder {
+  display: grid;
+  gap: clamp(18px, 3vw, 28px);
+}
+
+.summary-placeholder {
+  min-height: 118px;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.summary-placeholder span,
+.summary-placeholder strong,
+.table-placeholder span {
+  border-radius: 6px;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.summary-placeholder span:first-child {
+  width: min(180px, 58%);
+  height: 14px;
+}
+
+.summary-placeholder strong {
+  width: min(340px, 78%);
+  height: 32px;
+}
+
+.summary-placeholder span:last-child {
+  width: min(520px, 94%);
+  height: 14px;
+}
+
+.table-placeholder {
+  min-height: 390px;
+  padding: 12px;
+  display: grid;
+  gap: 8px;
+  overflow: hidden;
+}
+
+.table-placeholder span {
+  min-height: 24px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  clip-path: inset(50%);
+}
+
+@keyframes table-result-settle {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @media (max-width: 760px) {
+  .record-control-row {
+    grid-template-columns: 1fr;
+  }
+
   .record-tools {
     display: grid;
     gap: 10px;
     max-width: none;
   }
 
-  .field {
+  .record-control-actions {
+    justify-content: stretch;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .control-action {
+    justify-content: center;
+  }
+
+  .record-header {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .record-header-action {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .preset-panel {
+    margin-top: -6px;
+  }
+
+  .preset-panel-head {
+    display: grid;
+    gap: 3px;
+  }
+
+  .preset-list,
+  .preset-placeholder-list {
+    display: flex;
+    gap: 10px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+    scroll-snap-type: x proximity;
+  }
+
+  .preset-chip,
+  .preset-placeholder-list span {
+    flex: 0 0 min(78vw, 250px);
+    scroll-snap-align: start;
+  }
+
+  .field,
+  .field-placeholder {
     width: 100%;
   }
 
-  .report-field {
-    padding-top: 0;
+  .report-action-placeholder {
+    width: min(100%, 150px);
+  }
+
+  .table-result-shell {
+    min-height: 520px;
+  }
+
+  .summary-placeholder {
+    min-height: 108px;
+    padding: 14px;
+  }
+
+  .table-placeholder {
+    min-height: 340px;
+    padding: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .table-result {
+    opacity: 1;
+    transform: none;
+  }
+
+  .table-result--revealed {
+    animation: none;
   }
 }

--- a/src/app/components/league-tables-viewer/league-tables-viewer.scss
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.scss
@@ -456,22 +456,22 @@ app-season-summary-card {
 
 @media print {
   .table-record {
-    gap: 14px;
+    gap: 7pt;
   }
 
   .record-header {
-    padding-bottom: 10px;
+    padding-bottom: 5pt;
     display: block;
-    border-bottom: 2px solid #111827;
+    border-bottom: 1px solid #000000;
   }
 
   .record-selection {
-    color: #374151;
+    color: #222222;
     font-weight: 800;
   }
 
   .data-notice {
-    border-color: #cbd5e1;
+    border-color: #666666;
     background: #ffffff;
   }
 
@@ -481,7 +481,7 @@ app-season-summary-card {
   }
 
   .table-result {
-    gap: 12px;
+    gap: 6pt;
     opacity: 1;
     transform: none;
   }

--- a/src/app/components/league-tables-viewer/league-tables-viewer.scss
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.scss
@@ -453,3 +453,36 @@ app-season-summary-card {
     animation: none;
   }
 }
+
+@media print {
+  .table-record {
+    gap: 14px;
+  }
+
+  .record-header {
+    padding-bottom: 10px;
+    display: block;
+    border-bottom: 2px solid #111827;
+  }
+
+  .record-selection {
+    color: #374151;
+    font-weight: 800;
+  }
+
+  .data-notice {
+    border-color: #cbd5e1;
+    background: #ffffff;
+  }
+
+  .table-result-shell {
+    min-height: 0;
+    scroll-margin-top: 0;
+  }
+
+  .table-result {
+    gap: 12px;
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/src/app/components/league-tables-viewer/league-tables-viewer.spec.ts
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.spec.ts
@@ -1,17 +1,35 @@
 import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { convertToParamMap, ActivatedRoute, ParamMap, provideRouter } from '@angular/router';
 import { LeagueStore } from '@app/store/league.store';
+import { BehaviorSubject } from 'rxjs';
 import { LeagueTablesViewerComponent } from './league-tables-viewer';
 
 describe('LeagueTablesViewer', () => {
   let component: LeagueTablesViewerComponent;
   let fixture: ComponentFixture<LeagueTablesViewerComponent>;
   let store: InstanceType<typeof LeagueStore>;
+  let queryParamMap$: BehaviorSubject<ParamMap>;
 
   beforeEach(async () => {
+    queryParamMap$ = new BehaviorSubject(convertToParamMap({}));
+
     await TestBed.configureTestingModule({
       imports: [LeagueTablesViewerComponent],
-      providers: [LeagueStore, provideHttpClient()],
+      providers: [
+        LeagueStore,
+        provideHttpClient(),
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParamMap: queryParamMap$.asObservable(),
+            snapshot: {
+              queryParamMap: convertToParamMap({}),
+            },
+          },
+        },
+      ],
     }).compileComponents();
 
     store = TestBed.inject(LeagueStore);
@@ -92,6 +110,15 @@ describe('LeagueTablesViewer', () => {
     expect(component.selectedYear()).toBe(1992);
     expect(component.selectedLeague()).toBe('tier1');
     expect(component.activePresetId()).toBe('premier-league-launch');
+  });
+
+  it('selects a linked season table from route query params', () => {
+    queryParamMap$.next(convertToParamMap({ season: '1992', tier: 'tier2' }));
+    store.hydrate(tableArchiveFixture());
+    fixture.detectChanges();
+
+    expect(component.selectedYear()).toBe(1992);
+    expect(component.selectedLeague()).toBe('tier2');
   });
 
   it('collapses and expands the preset strip from the control row', () => {

--- a/src/app/components/league-tables-viewer/league-tables-viewer.spec.ts
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.spec.ts
@@ -6,6 +6,7 @@ import { LeagueTablesViewerComponent } from './league-tables-viewer';
 describe('LeagueTablesViewer', () => {
   let component: LeagueTablesViewerComponent;
   let fixture: ComponentFixture<LeagueTablesViewerComponent>;
+  let store: InstanceType<typeof LeagueStore>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -13,12 +14,156 @@ describe('LeagueTablesViewer', () => {
       providers: [LeagueStore, provideHttpClient()],
     }).compileComponents();
 
+    store = TestBed.inject(LeagueStore);
     fixture = TestBed.createComponent(LeagueTablesViewerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    fixture.destroy();
+    jest.useRealTimers();
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('renders a stable table result shell before archive data hydrates', () => {
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(element.querySelector('h1')?.textContent).toContain('League Tables');
+    expect(element.querySelectorAll('.field-placeholder')).toHaveLength(2);
+    expect(element.querySelector('.report-action-placeholder')).toBeTruthy();
+    expect(element.querySelector('.table-result-shell')).toBeTruthy();
+    expect(element.querySelector('.table-result-placeholder')).toBeTruthy();
+    expect(element.querySelector('.table-result')).toBeNull();
+  });
+
+  it('reveals the selected table in the reserved shell after data hydrates', () => {
+    jest.useFakeTimers();
+
+    store.hydrate(tableArchiveFixture());
+    fixture.detectChanges();
+
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(component.selectedYear()).toBe(2025);
+    expect(component.selectedLeague()).toBe('tier1');
+    expect(component.tableControlsReady()).toBe(true);
+    expect(component.tableResultKey()).toBe('2025:tier1');
+    expect(element.querySelectorAll('.field-placeholder')).toHaveLength(0);
+    expect(element.querySelector('.record-header-action .report-trigger')?.textContent).toContain(
+      'Report table issue'
+    );
+    expect(element.querySelector('.table-result-placeholder')).toBeNull();
+    expect(element.querySelector('.table-result')).toBeTruthy();
+    expect(component.tableRevealActive()).toBe(false);
+
+    jest.advanceTimersByTime(20);
+    fixture.detectChanges();
+
+    expect(component.tableRevealActive()).toBe(true);
+    expect(element.querySelector('.table-result--revealed')).toBeTruthy();
+  });
+
+  it('renders valid notable table presets and applies a selected preset', () => {
+    store.hydrate(tableArchiveFixture());
+    fixture.detectChanges();
+
+    const element: HTMLElement = fixture.nativeElement;
+    const presetLabels = Array.from(element.querySelectorAll('.preset-chip span')).map((item) =>
+      item.textContent?.trim()
+    );
+
+    expect(presetLabels).toContain('Latest top flight');
+    expect(presetLabels).toContain('Premier League launch');
+    expect(component.tablePresets().some((preset) => preset.tier === 'seasonInfo')).toBe(false);
+
+    const premierLeagueLaunch = component
+      .tablePresets()
+      .find((preset) => preset.id === 'premier-league-launch');
+
+    expect(premierLeagueLaunch).toBeTruthy();
+
+    component.applyPreset(premierLeagueLaunch!);
+    fixture.detectChanges();
+
+    expect(component.selectedYear()).toBe(1992);
+    expect(component.selectedLeague()).toBe('tier1');
+    expect(component.activePresetId()).toBe('premier-league-launch');
+  });
+
+  it('collapses and expands the preset strip from the control row', () => {
+    store.hydrate(tableArchiveFixture());
+    fixture.detectChanges();
+
+    const element: HTMLElement = fixture.nativeElement;
+    const toggle = Array.from(element.querySelectorAll<HTMLButtonElement>('.control-action')).find(
+      (button) => button.textContent?.includes('Hide presets')
+    );
+
+    expect(toggle).toBeTruthy();
+    expect(component.quickFiltersCollapsed()).toBe(false);
+    expect(element.querySelector('#table-presets')?.hasAttribute('hidden')).toBe(false);
+
+    toggle?.click();
+    fixture.detectChanges();
+
+    expect(component.quickFiltersCollapsed()).toBe(true);
+    expect(element.querySelector('#table-presets')?.hasAttribute('hidden')).toBe(true);
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('scrolls focus to the table result shell from the control row', () => {
+    const target = document.createElement('section');
+    const scrollIntoView = jest.fn();
+    const focus = jest.fn();
+    target.scrollIntoView = scrollIntoView;
+    target.focus = focus;
+
+    component.scrollToTableContent(target);
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
 });
+
+function tableArchiveFixture() {
+  return {
+    seasons: {
+      1992: {
+        seasonInfo: { table: [tableRow('Ignored Info Row')] },
+        tier1: [tableRow('Arsenal'), tableRow('Aston Villa', 2)],
+        tier2: [tableRow('Newcastle United')],
+      },
+      2025: {
+        seasonInfo: { table: [tableRow('Ignored Current Info Row')] },
+        tier1: [tableRow('Alpha FC'), tableRow('Bravo Town', 2)],
+        tier2: [tableRow('Charlie City')],
+      },
+    },
+  };
+}
+
+function tableRow(team: string, pos = 1) {
+  return {
+    team,
+    pos,
+    played: 38,
+    won: 24,
+    drawn: 8,
+    lost: 6,
+    goalsFor: 70 - pos,
+    goalsAgainst: 35,
+    goalDifference: 35 - pos,
+    goalAverage: null,
+    points: 80 - pos,
+    notes: null,
+    wasRelegated: false,
+    wasPromoted: false,
+    isExpansionTeam: false,
+    wasReElected: false,
+    wasReprieved: false,
+  };
+}

--- a/src/app/components/league-tables-viewer/league-tables-viewer.spec.ts
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.spec.ts
@@ -121,6 +121,32 @@ describe('LeagueTablesViewer', () => {
     expect(component.selectedLeague()).toBe('tier2');
   });
 
+  it('shows a targeted data note for selected regional Third Division tables', () => {
+    queryParamMap$.next(convertToParamMap({ season: '1921', tier: 'tier4' }));
+    store.hydrate(tableArchiveFixture());
+    fixture.detectChanges();
+
+    expect(component.tableDataNotices().map((notice) => notice.id)).toEqual([
+      'third-division-regional',
+    ]);
+    expect(fixture.nativeElement.textContent).toContain('Regional Third Division data');
+    expect(fixture.nativeElement.textContent).toContain('both represent pyramid level 3');
+  });
+
+  it('shows a targeted data note for selected parallel National League tables', () => {
+    queryParamMap$.next(convertToParamMap({ season: '2025', tier: 'tier7' }));
+    store.hydrate(tableArchiveFixture());
+    fixture.detectChanges();
+
+    expect(component.tableDataNotices().map((notice) => notice.id)).toEqual([
+      'national-league-regional',
+    ]);
+    expect(fixture.nativeElement.textContent).toContain('Parallel level 6 divisions');
+    expect(fixture.nativeElement.textContent).toContain(
+      'Tier7 should not be read as a true level 7'
+    );
+  });
+
   it('collapses and expands the preset strip from the control row', () => {
     store.hydrate(tableArchiveFixture());
     fixture.detectChanges();
@@ -159,6 +185,10 @@ describe('LeagueTablesViewer', () => {
 function tableArchiveFixture() {
   return {
     seasons: {
+      1921: {
+        tier3: [tableRow('Third Division North FC')],
+        tier4: [tableRow('Third Division South FC')],
+      },
       1992: {
         seasonInfo: { table: [tableRow('Ignored Info Row')] },
         tier1: [tableRow('Arsenal'), tableRow('Aston Villa', 2)],
@@ -168,6 +198,8 @@ function tableArchiveFixture() {
         seasonInfo: { table: [tableRow('Ignored Current Info Row')] },
         tier1: [tableRow('Alpha FC'), tableRow('Bravo Town', 2)],
         tier2: [tableRow('Charlie City')],
+        tier6: [tableRow('National North FC')],
+        tier7: [tableRow('National South FC')],
       },
     },
   };

--- a/src/app/components/league-tables-viewer/league-tables-viewer.ts
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.ts
@@ -1,8 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { Component, computed, effect, inject, OnDestroy, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
+import { ActivatedRoute } from '@angular/router';
 import { DataIssueReportDialog } from '@app/components/data-issue-report-dialog/data-issue-report-dialog';
 import { LeagueTierToStringyPipe } from '@app/pipes/league-tier-to-stringy-pipe';
 import { LeagueStore } from '@app/store/league.store';
@@ -38,6 +40,10 @@ interface TablePreset {
 export class LeagueTablesViewerComponent implements OnDestroy {
   store = inject(LeagueStore);
   private leagueLabelPipe = inject(LeagueTierToStringyPipe);
+  private route = inject(ActivatedRoute);
+  private queryParamMapSignal = toSignal(this.route.queryParamMap, {
+    initialValue: this.route.snapshot.queryParamMap,
+  });
   private tableRevealTimer: ReturnType<typeof setTimeout> | null = null;
 
   years: number[] = [];
@@ -51,10 +57,29 @@ export class LeagueTablesViewerComponent implements OnDestroy {
   constructor() {
     effect(() => {
       const seasonTiers = this.getCompetitionSeasonTiers();
+      const queryParams = this.queryParamMapSignal();
       this.years = seasonTiers.map((st) => st.season).sort((a, b) => b - a);
 
-      if (this.years.length > 0 && !this.selectedYear()) {
-        this.onYearChange(this.years[0]);
+      if (!this.years.length) {
+        return;
+      }
+
+      const requestedSeason = Number(queryParams.get('season'));
+      const requestedTier = queryParams.get('tier') ?? undefined;
+      const requestedSeasonTiers = Number.isInteger(requestedSeason)
+        ? seasonTiers.find((seasonTier) => seasonTier.season === requestedSeason)
+        : undefined;
+
+      if (
+        requestedSeasonTiers &&
+        (!requestedTier || requestedSeasonTiers.tiers.includes(requestedTier))
+      ) {
+        this.selectTable(requestedSeason, requestedTier ?? requestedSeasonTiers.tiers[0]);
+        return;
+      }
+
+      if (!this.selectedYear()) {
+        this.selectTable(this.years[0]);
       }
     });
 
@@ -196,13 +221,7 @@ export class LeagueTablesViewerComponent implements OnDestroy {
   });
 
   onYearChange(year: number) {
-    this.selectedYear.set(year);
-    this.selectedLeague.set(undefined);
-
-    const seasonTiers = this.getCompetitionSeasonTiers();
-    const currentSeasonsAvailableTiers = seasonTiers.find((st) => st.season === year);
-    this.leaguesForYear = currentSeasonsAvailableTiers?.tiers ?? [];
-    this.selectedLeague.set(this.leaguesForYear[0]);
+    this.selectTable(year);
   }
 
   onLeagueChange(league: string) {
@@ -229,6 +248,17 @@ export class LeagueTablesViewerComponent implements OnDestroy {
   private hasSeasonTier(season: number, tier: string): boolean {
     return this.getCompetitionSeasonTiers().some(
       (seasonTier) => seasonTier.season === season && seasonTier.tiers.includes(tier)
+    );
+  }
+
+  private selectTable(year: number, tier?: string) {
+    const seasonTiers = this.getCompetitionSeasonTiers();
+    const currentSeasonsAvailableTiers = seasonTiers.find((st) => st.season === year);
+    this.leaguesForYear = currentSeasonsAvailableTiers?.tiers ?? [];
+
+    this.selectedYear.set(year);
+    this.selectedLeague.set(
+      tier && this.leaguesForYear.includes(tier) ? tier : this.leaguesForYear[0]
     );
   }
 

--- a/src/app/components/league-tables-viewer/league-tables-viewer.ts
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, effect, inject, signal } from '@angular/core';
+import { Component, computed, effect, inject, OnDestroy, signal } from '@angular/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
@@ -10,6 +10,14 @@ import { LeagueTableView } from '@app/types';
 import type { DataIssueReportContext } from '@app/utils/data-issue-report';
 import { LeagueTableComponent } from '../league-table/league-table';
 import { SeasonSummaryCardComponent } from '../season-summary-card/season-summary-card';
+
+interface TablePreset {
+  id: string;
+  label: string;
+  detail: string;
+  season: number;
+  tier: string;
+}
 
 @Component({
   selector: 'app-league-tables-viewer',
@@ -27,25 +35,52 @@ import { SeasonSummaryCardComponent } from '../season-summary-card/season-summar
   ],
   providers: [LeagueTierToStringyPipe],
 })
-export class LeagueTablesViewerComponent {
+export class LeagueTablesViewerComponent implements OnDestroy {
   store = inject(LeagueStore);
   private leagueLabelPipe = inject(LeagueTierToStringyPipe);
+  private tableRevealTimer: ReturnType<typeof setTimeout> | null = null;
 
   years: number[] = [];
   leaguesForYear: string[] = [];
 
   selectedYear = signal<number | undefined>(undefined);
   selectedLeague = signal<string | undefined>(undefined);
+  tableRevealActive = signal(false);
+  quickFiltersCollapsed = signal(false);
 
   constructor() {
     effect(() => {
-      const seasonTiers = this.store.getSeasonTiers();
+      const seasonTiers = this.getCompetitionSeasonTiers();
       this.years = seasonTiers.map((st) => st.season).sort((a, b) => b - a);
 
       if (this.years.length > 0 && !this.selectedYear()) {
         this.onYearChange(this.years[0]);
       }
     });
+
+    effect(() => {
+      const tableKey = this.tableResultKey();
+      if (!tableKey) {
+        this.tableRevealActive.set(false);
+        return;
+      }
+
+      this.tableRevealActive.set(false);
+      if (this.tableRevealTimer) {
+        clearTimeout(this.tableRevealTimer);
+      }
+
+      this.tableRevealTimer = setTimeout(() => {
+        this.tableRevealActive.set(true);
+        this.tableRevealTimer = null;
+      }, 20);
+    });
+  }
+
+  ngOnDestroy() {
+    if (this.tableRevealTimer) {
+      clearTimeout(this.tableRevealTimer);
+    }
   }
 
   currentTable = computed<LeagueTableView[] | null>(() => {
@@ -67,6 +102,89 @@ export class LeagueTablesViewerComponent {
     return league ?? '';
   });
 
+  tableControlsReady = computed(() =>
+    Boolean(this.selectedYear() && this.selectedLeague() && this.years.length)
+  );
+
+  tablePresets = computed<TablePreset[]>(() => {
+    const seasonTiers = this.getCompetitionSeasonTiers();
+    const latestSeason = seasonTiers.at(-1)?.season;
+    const earliestTopFlight = seasonTiers.find((season) => season.tiers.includes('tier1'))?.season;
+    const firstSecondTier = seasonTiers.find((season) => season.tiers.includes('tier2'))?.season;
+    const candidates: TablePreset[] = [
+      {
+        id: 'latest-top-flight',
+        label: 'Latest top flight',
+        detail: 'Current Premier League table',
+        season: latestSeason ?? 0,
+        tier: 'tier1',
+      },
+      {
+        id: 'latest-championship',
+        label: 'Latest Championship',
+        detail: 'Promotion race context',
+        season: latestSeason ?? 0,
+        tier: 'tier2',
+      },
+      {
+        id: 'premier-league-launch',
+        label: 'Premier League launch',
+        detail: '1992 top-flight reset',
+        season: 1992,
+        tier: 'tier1',
+      },
+      {
+        id: 'post-war-restart',
+        label: 'Post-war restart',
+        detail: '1946 league return',
+        season: 1946,
+        tier: 'tier1',
+      },
+      {
+        id: 'first-football-league',
+        label: 'First league table',
+        detail: 'Earliest top-flight record',
+        season: earliestTopFlight ?? 0,
+        tier: 'tier1',
+      },
+      {
+        id: 'first-second-tier',
+        label: 'Second tier begins',
+        detail: 'First recorded tier two',
+        season: firstSecondTier ?? 0,
+        tier: 'tier2',
+      },
+    ];
+
+    return candidates.filter((preset, index, presets) => {
+      if (!this.hasSeasonTier(preset.season, preset.tier)) {
+        return false;
+      }
+
+      return (
+        presets.findIndex(
+          (candidate) => candidate.season === preset.season && candidate.tier === preset.tier
+        ) === index
+      );
+    });
+  });
+
+  activePresetId = computed(() => {
+    const selectedYear = this.selectedYear();
+    const selectedLeague = this.selectedLeague();
+    return (
+      this.tablePresets().find(
+        (preset) => preset.season === selectedYear && preset.tier === selectedLeague
+      )?.id ?? ''
+    );
+  });
+
+  tableResultKey = computed(() => {
+    const year = this.selectedYear();
+    const league = this.selectedLeague();
+    return year && league ? `${year}:${league}` : '';
+  });
+
   dataIssueContext = computed<DataIssueReportContext>(() => {
     const league = this.selectedLeague();
     return {
@@ -81,7 +199,7 @@ export class LeagueTablesViewerComponent {
     this.selectedYear.set(year);
     this.selectedLeague.set(undefined);
 
-    const seasonTiers = this.store.getSeasonTiers();
+    const seasonTiers = this.getCompetitionSeasonTiers();
     const currentSeasonsAvailableTiers = seasonTiers.find((st) => st.season === year);
     this.leaguesForYear = currentSeasonsAvailableTiers?.tiers ?? [];
     this.selectedLeague.set(this.leaguesForYear[0]);
@@ -89,5 +207,46 @@ export class LeagueTablesViewerComponent {
 
   onLeagueChange(league: string) {
     this.selectedLeague.set(league);
+  }
+
+  applyPreset(preset: TablePreset) {
+    this.onYearChange(preset.season);
+    this.selectedLeague.set(preset.tier);
+  }
+
+  toggleQuickFilters() {
+    this.quickFiltersCollapsed.update((isCollapsed) => !isCollapsed);
+  }
+
+  scrollToTableContent(target: HTMLElement) {
+    target.scrollIntoView({
+      behavior: this.prefersReducedMotion() ? 'auto' : 'smooth',
+      block: 'start',
+    });
+    target.focus({ preventScroll: true });
+  }
+
+  private hasSeasonTier(season: number, tier: string): boolean {
+    return this.getCompetitionSeasonTiers().some(
+      (seasonTier) => seasonTier.season === season && seasonTier.tiers.includes(tier)
+    );
+  }
+
+  private getCompetitionSeasonTiers(): { season: number; tiers: string[] }[] {
+    return this.store
+      .getSeasonTiers()
+      .map((seasonTier) => ({
+        season: seasonTier.season,
+        tiers: seasonTier.tiers.filter((tier) => /^tier\d+$/.test(tier)),
+      }))
+      .filter((seasonTier) => seasonTier.tiers.length);
+  }
+
+  private prefersReducedMotion(): boolean {
+    return (
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    );
   }
 }

--- a/src/app/components/league-tables-viewer/league-tables-viewer.ts
+++ b/src/app/components/league-tables-viewer/league-tables-viewer.ts
@@ -21,6 +21,42 @@ interface TablePreset {
   tier: string;
 }
 
+interface TableDataNoticeDefinition {
+  id: string;
+  tiers: readonly string[];
+  ranges: readonly { start: number; end: number }[];
+  title: string;
+  detail: string;
+}
+
+interface TableDataNotice {
+  id: string;
+  title: string;
+  detail: string;
+}
+
+const TABLE_DATA_NOTICES: TableDataNoticeDefinition[] = [
+  {
+    id: 'third-division-regional',
+    tiers: ['tier3', 'tier4'],
+    ranges: [
+      { start: 1921, end: 1938 },
+      { start: 1946, end: 1957 },
+    ],
+    title: 'Regional Third Division data',
+    detail:
+      'From 1921-22 through 1957-58, the Football League Third Division was split into North and South. These archive slots use tier3 for Third Division North and tier4 for Third Division South, but both represent pyramid level 3. True level 4 begins in 1958-59 with the Fourth Division.',
+  },
+  {
+    id: 'national-league-regional',
+    tiers: ['tier6', 'tier7'],
+    ranges: [{ start: 2021, end: 2025 }],
+    title: 'Parallel level 6 divisions',
+    detail:
+      'From 2021-2025 in the current archive, National League North and South are stored as tier6 and tier7 slots, but both represent parallel pyramid level 6 divisions. Tier7 should not be read as a true level 7 in this period.',
+  },
+];
+
 @Component({
   selector: 'app-league-tables-viewer',
   templateUrl: './league-tables-viewer.html',
@@ -208,6 +244,24 @@ export class LeagueTablesViewerComponent implements OnDestroy {
     const year = this.selectedYear();
     const league = this.selectedLeague();
     return year && league ? `${year}:${league}` : '';
+  });
+
+  tableDataNotices = computed<TableDataNotice[]>(() => {
+    const year = this.selectedYear();
+    const league = this.selectedLeague();
+    if (!year || !league) {
+      return [];
+    }
+
+    return TABLE_DATA_NOTICES.filter(
+      (notice) =>
+        notice.tiers.includes(league) &&
+        notice.ranges.some((range) => year >= range.start && year <= range.end)
+    ).map((notice) => ({
+      id: notice.id,
+      title: notice.title,
+      detail: notice.detail,
+    }));
   });
 
   dataIssueContext = computed<DataIssueReportContext>(() => {

--- a/src/app/components/season-summary-card/season-summary-card.html
+++ b/src/app/components/season-summary-card/season-summary-card.html
@@ -5,15 +5,33 @@
   <dl class="facts">
     <div class="fact">
       <dt>Champion</dt>
-      <dd>{{ champion }}</dd>
+      <dd>
+        @if (champion?.clubId) {
+        <a class="app-club-link" [routerLink]="['/teams', champion!.clubId]">
+          {{ champion!.name }}
+        </a>
+        } @else { {{ champion?.name }} }
+      </dd>
     </div>
     <div class="fact">
       <dt>Top Scoring Team</dt>
-      <dd>{{ topScoringTeam }}</dd>
+      <dd>
+        @if (topScoringTeam?.clubId) {
+        <a class="app-club-link" [routerLink]="['/teams', topScoringTeam!.clubId]">
+          {{ topScoringTeam!.name }}
+        </a>
+        } @else { {{ topScoringTeam?.name }} }
+      </dd>
     </div>
     <div class="fact">
       <dt>Best Defense</dt>
-      <dd>{{ bestDefense }}</dd>
+      <dd>
+        @if (bestDefense?.clubId) {
+        <a class="app-club-link" [routerLink]="['/teams', bestDefense!.clubId]">
+          {{ bestDefense!.name }}
+        </a>
+        } @else { {{ bestDefense?.name }} }
+      </dd>
     </div>
     <div class="fact">
       <dt>Avg Goals per Game</dt>
@@ -24,9 +42,13 @@
       <dt>Promoted</dt>
       <dd>
         <div class="chip-group">
-          @for (team of promotedTeams; track team) {
-          <span class="chip chip-up">{{ team }}</span>
-          }
+          @for (team of promotedTeams; track team) { @if (team.clubId) {
+          <a class="chip chip-up app-club-link" [routerLink]="['/teams', team.clubId]">
+            {{ team.name }}
+          </a>
+          } @else {
+          <span class="chip chip-up">{{ team.name }}</span>
+          } }
         </div>
       </dd>
     </div>
@@ -35,9 +57,13 @@
       <dt>Relegated</dt>
       <dd>
         <div class="chip-group">
-          @for (team of relegatedTeams; track team) {
-          <span class="chip chip-down">{{ team }}</span>
-          }
+          @for (team of relegatedTeams; track team) { @if (team.clubId) {
+          <a class="chip chip-down app-club-link" [routerLink]="['/teams', team.clubId]">
+            {{ team.name }}
+          </a>
+          } @else {
+          <span class="chip chip-down">{{ team.name }}</span>
+          } }
         </div>
       </dd>
     </div>

--- a/src/app/components/season-summary-card/season-summary-card.html
+++ b/src/app/components/season-summary-card/season-summary-card.html
@@ -61,6 +61,11 @@
           </button>
           }
         </div>
+        <div class="print-movement-list">
+          @for (team of promotedTeams; track team) {
+          <span>{{ team.name }}</span>
+          }
+        </div>
       </dd>
     </div>
     } @if (relegatedTeams.length) {
@@ -85,6 +90,11 @@
             {{ relegatedExpanded ? 'Show fewer' : '+' + movementOverflowTeams(relegatedTeams).length
             + ' more' }}
           </button>
+          }
+        </div>
+        <div class="print-movement-list">
+          @for (team of relegatedTeams; track team) {
+          <span>{{ team.name }}</span>
           }
         </div>
       </dd>

--- a/src/app/components/season-summary-card/season-summary-card.html
+++ b/src/app/components/season-summary-card/season-summary-card.html
@@ -38,32 +38,54 @@
       <dd>{{ avgGoalsPerGame }}</dd>
     </div>
     @if (promotedTeams.length) {
-    <div class="fact">
+    <div class="fact fact--movement">
       <dt>Promoted</dt>
       <dd>
         <div class="chip-group">
-          @for (team of promotedTeams; track team) { @if (team.clubId) {
+          @for (team of visibleMovementTeams(promotedTeams, promotedExpanded); track team) { @if
+          (team.clubId) {
           <a class="chip chip-up app-club-link" [routerLink]="['/teams', team.clubId]">
             {{ team.name }}
           </a>
           } @else {
           <span class="chip chip-up">{{ team.name }}</span>
-          } }
+          } } @if (movementOverflowTeams(promotedTeams).length) {
+          <button
+            type="button"
+            class="chip-toggle"
+            [attr.aria-expanded]="promotedExpanded"
+            (click)="togglePromotedExpanded()"
+          >
+            {{ promotedExpanded ? 'Show fewer' : '+' + movementOverflowTeams(promotedTeams).length +
+            ' more' }}
+          </button>
+          }
         </div>
       </dd>
     </div>
     } @if (relegatedTeams.length) {
-    <div class="fact">
+    <div class="fact fact--movement">
       <dt>Relegated</dt>
       <dd>
         <div class="chip-group">
-          @for (team of relegatedTeams; track team) { @if (team.clubId) {
+          @for (team of visibleMovementTeams(relegatedTeams, relegatedExpanded); track team) { @if
+          (team.clubId) {
           <a class="chip chip-down app-club-link" [routerLink]="['/teams', team.clubId]">
             {{ team.name }}
           </a>
           } @else {
           <span class="chip chip-down">{{ team.name }}</span>
-          } }
+          } } @if (movementOverflowTeams(relegatedTeams).length) {
+          <button
+            type="button"
+            class="chip-toggle"
+            [attr.aria-expanded]="relegatedExpanded"
+            (click)="toggleRelegatedExpanded()"
+          >
+            {{ relegatedExpanded ? 'Show fewer' : '+' + movementOverflowTeams(relegatedTeams).length
+            + ' more' }}
+          </button>
+          }
         </div>
       </dd>
     </div>

--- a/src/app/components/season-summary-card/season-summary-card.scss
+++ b/src/app/components/season-summary-card/season-summary-card.scss
@@ -26,10 +26,24 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px 22px;
+  min-width: 0;
 }
 
 .fact {
-  min-width: max-content;
+  min-width: 0;
+}
+
+.fact:not(.fact--movement) {
+  width: max-content;
+  max-width: 100%;
+}
+
+.fact--movement {
+  width: 100%;
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 8px;
+  align-items: start;
 }
 
 dt {
@@ -56,17 +70,64 @@ dd {
   display: inline-flex;
   flex-wrap: wrap;
   gap: 6px;
+  max-width: 100%;
   vertical-align: middle;
 }
 
 .chip {
   display: inline-block;
+  max-width: min(220px, 100%);
+  overflow: hidden;
   padding: 1px 6px;
   border-radius: 5px;
   border: 1px solid var(--app-border);
   color: var(--app-text-strong);
   font-size: 0.88rem;
   line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+a.chip {
+  cursor: pointer;
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+a.chip:hover {
+  filter: brightness(1.12);
+  text-decoration: underline;
+}
+
+a.chip:focus-visible,
+.chip-toggle:focus-visible {
+  outline: 2px solid rgba(226, 232, 240, 0.76);
+  outline-offset: 2px;
+}
+
+.chip-toggle {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 5px;
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--app-text-strong);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 750;
+  line-height: 1.35;
+}
+
+.chip-toggle:hover,
+.chip-toggle:focus-visible {
+  border-color: rgba(148, 163, 184, 0.46);
+  background: rgba(148, 163, 184, 0.14);
+}
+
+.chip-toggle:active {
+  transform: translateY(1px);
 }
 
 .chip-up {
@@ -94,6 +155,11 @@ dd {
   dt,
   dd {
     display: block;
+  }
+
+  .fact--movement {
+    grid-template-columns: 1fr;
+    gap: 3px;
   }
 
   dt {

--- a/src/app/components/season-summary-card/season-summary-card.scss
+++ b/src/app/components/season-summary-card/season-summary-card.scss
@@ -174,19 +174,18 @@ a.chip:focus-visible,
 @media print {
   .summary {
     display: block;
-    padding: 8px 0;
-    border-color: #cbd5e1;
-    break-inside: avoid;
+    padding: 4pt 0;
+    border: 0;
   }
 
   .summary-header {
-    margin-bottom: 8px;
+    margin-bottom: 4pt;
   }
 
   .facts {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 6px 14px;
+    gap: 2pt 10pt;
   }
 
   .fact,
@@ -206,12 +205,12 @@ a.chip:focus-visible,
   }
 
   .print-movement-list {
-    margin-top: 4px;
+    margin-top: 2pt;
     display: flex;
     flex-wrap: wrap;
-    gap: 4px 8px;
-    font-size: 0.82rem;
-    line-height: 1.35;
+    gap: 1pt 5pt;
+    font-size: 7.4pt;
+    line-height: 1.2;
   }
 
   .print-movement-list span:not(:last-child)::after {

--- a/src/app/components/season-summary-card/season-summary-card.scss
+++ b/src/app/components/season-summary-card/season-summary-card.scss
@@ -142,6 +142,10 @@ a.chip:focus-visible,
   background: rgba(220, 38, 38, 0.1);
 }
 
+.print-movement-list {
+  display: none;
+}
+
 @media (max-width: 760px) {
   .summary {
     grid-template-columns: 1fr;
@@ -164,5 +168,53 @@ a.chip:focus-visible,
 
   dt {
     margin: 0 0 3px;
+  }
+}
+
+@media print {
+  .summary {
+    display: block;
+    padding: 8px 0;
+    border-color: #cbd5e1;
+    break-inside: avoid;
+  }
+
+  .summary-header {
+    margin-bottom: 8px;
+  }
+
+  .facts {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px 14px;
+  }
+
+  .fact,
+  .fact:not(.fact--movement),
+  .fact--movement {
+    width: auto;
+    display: block;
+  }
+
+  dt,
+  dd {
+    display: inline;
+  }
+
+  .chip-group {
+    display: none;
+  }
+
+  .print-movement-list {
+    margin-top: 4px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 8px;
+    font-size: 0.82rem;
+    line-height: 1.35;
+  }
+
+  .print-movement-list span:not(:last-child)::after {
+    content: ',';
   }
 }

--- a/src/app/components/season-summary-card/season-summary-card.spec.ts
+++ b/src/app/components/season-summary-card/season-summary-card.spec.ts
@@ -45,6 +45,28 @@ describe('SeasonSummaryCard', () => {
       '/teams/alpha%20fc',
     ]);
   });
+
+  it('limits movement chip previews before showing overflow teams', () => {
+    const teams = [
+      { name: 'One', clubId: 'one' },
+      { name: 'Two', clubId: 'two' },
+      { name: 'Three', clubId: 'three' },
+      { name: 'Four', clubId: 'four' },
+      { name: 'Five', clubId: 'five' },
+      { name: 'Six', clubId: 'six' },
+    ];
+
+    expect(component.movementPreviewTeams(teams).map((team) => team.name)).toEqual([
+      'One',
+      'Two',
+      'Three',
+      'Four',
+    ]);
+    expect(component.movementOverflowTeams(teams).map((team) => team.name)).toEqual([
+      'Five',
+      'Six',
+    ]);
+  });
 });
 
 function tableRow(

--- a/src/app/components/season-summary-card/season-summary-card.spec.ts
+++ b/src/app/components/season-summary-card/season-summary-card.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { SeasonSummaryCardComponent } from './season-summary-card';
 
 describe('SeasonSummaryCard', () => {
@@ -8,6 +9,7 @@ describe('SeasonSummaryCard', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SeasonSummaryCardComponent],
+      providers: [provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SeasonSummaryCardComponent);
@@ -18,4 +20,61 @@ describe('SeasonSummaryCard', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('links summary club names when club metadata ids are available', () => {
+    component.tableData = [
+      tableRow('Alpha FC', 'alpha fc', 82, 74, 28),
+      tableRow('Bravo Town', 'bravo town', 76, 81, 34),
+    ];
+
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    const links = Array.from(
+      fixture.nativeElement.querySelectorAll<HTMLAnchorElement>('.app-club-link')
+    );
+
+    expect(links.map((link) => link.textContent?.trim())).toEqual([
+      'Alpha FC',
+      'Bravo Town',
+      'Alpha FC',
+    ]);
+    expect(links.map((link) => link.getAttribute('href'))).toEqual([
+      '/teams/alpha%20fc',
+      '/teams/bravo%20town',
+      '/teams/alpha%20fc',
+    ]);
+  });
 });
+
+function tableRow(
+  teamName: string,
+  clubId: string | null,
+  points: number,
+  goalsFor: number,
+  goalsAgainst: number
+) {
+  return {
+    season: 2025,
+    tier: 'tier1',
+    teamId: 1,
+    clubId,
+    teamName,
+    pos: 1,
+    played: 38,
+    won: 24,
+    drawn: 10,
+    lost: 4,
+    goalsFor,
+    goalsAgainst,
+    goalDifference: goalsFor - goalsAgainst,
+    goalAverage: null,
+    points,
+    notes: null,
+    wasRelegated: false,
+    wasPromoted: false,
+    isExpansionTeam: false,
+    wasReElected: false,
+    wasReprieved: false,
+  };
+}

--- a/src/app/components/season-summary-card/season-summary-card.ts
+++ b/src/app/components/season-summary-card/season-summary-card.ts
@@ -1,24 +1,30 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject, Input, OnChanges } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { LeagueStore } from '@app/store/league.store';
 import { LeagueTableView } from '@app/types';
+
+interface ClubNameReference {
+  name: string;
+  clubId: string | null;
+}
 
 @Component({
   selector: 'app-season-summary-card',
   templateUrl: './season-summary-card.html',
   styleUrl: './season-summary-card.scss',
-  imports: [CommonModule],
+  imports: [CommonModule, RouterLink],
 })
 export class SeasonSummaryCardComponent implements OnChanges {
   store = inject(LeagueStore);
   @Input() tableData: LeagueTableView[] = [];
 
-  champion?: string;
-  topScoringTeam?: string;
-  bestDefense?: string;
+  champion?: ClubNameReference;
+  topScoringTeam?: ClubNameReference;
+  bestDefense?: ClubNameReference;
   avgGoalsPerGame?: number;
-  promotedTeams: string[] = [];
-  relegatedTeams: string[] = [];
+  promotedTeams: ClubNameReference[] = [];
+  relegatedTeams: ClubNameReference[] = [];
 
   ngOnChanges(): void {
     if (!this.tableData?.length) return;
@@ -28,15 +34,15 @@ export class SeasonSummaryCardComponent implements OnChanges {
 
     // Champion = team with highest points
     const sortedByPoints = [...this.tableData].sort((a, b) => b.points - a.points);
-    this.champion = sortedByPoints[0].teamName;
+    this.champion = this.tableEntryReference(sortedByPoints[0]);
 
     // Top Scoring = most goalsFor
     const topScorer = [...this.tableData].sort((a, b) => b.goalsFor - a.goalsFor)[0];
-    this.topScoringTeam = topScorer.teamName;
+    this.topScoringTeam = this.tableEntryReference(topScorer);
 
     // Best Defense = fewest goalsAgainst
     const bestDef = [...this.tableData].sort((a, b) => a.goalsAgainst - b.goalsAgainst)[0];
-    this.bestDefense = bestDef.teamName;
+    this.bestDefense = this.tableEntryReference(bestDef);
 
     // Avg Goals per Game = total GF / total P
     const totalGF = this.tableData.reduce((sum, t) => sum + t.goalsFor, 0);
@@ -45,7 +51,20 @@ export class SeasonSummaryCardComponent implements OnChanges {
 
     // Promotion/Relegation)
     const { promoted, relegated } = this.store.getPromotionRelegationInfo(season, tier);
-    this.promotedTeams = promoted.map((t) => t.name);
-    this.relegatedTeams = relegated.map((t) => t.name);
+    this.promotedTeams = promoted.map((team) => ({
+      name: team.name,
+      clubId: team.clubIds[0] ?? null,
+    }));
+    this.relegatedTeams = relegated.map((team) => ({
+      name: team.name,
+      clubId: team.clubIds[0] ?? null,
+    }));
+  }
+
+  private tableEntryReference(entry: LeagueTableView): ClubNameReference {
+    return {
+      name: entry.teamName,
+      clubId: entry.clubId,
+    };
   }
 }

--- a/src/app/components/season-summary-card/season-summary-card.ts
+++ b/src/app/components/season-summary-card/season-summary-card.ts
@@ -4,10 +4,12 @@ import { RouterLink } from '@angular/router';
 import { LeagueStore } from '@app/store/league.store';
 import { LeagueTableView } from '@app/types';
 
-interface ClubNameReference {
+export interface ClubNameReference {
   name: string;
   clubId: string | null;
 }
+
+const MOVEMENT_TEAM_PREVIEW_LIMIT = 4;
 
 @Component({
   selector: 'app-season-summary-card',
@@ -25,9 +27,14 @@ export class SeasonSummaryCardComponent implements OnChanges {
   avgGoalsPerGame?: number;
   promotedTeams: ClubNameReference[] = [];
   relegatedTeams: ClubNameReference[] = [];
+  promotedExpanded = false;
+  relegatedExpanded = false;
 
   ngOnChanges(): void {
     if (!this.tableData?.length) return;
+
+    this.promotedExpanded = false;
+    this.relegatedExpanded = false;
 
     const tier = this.tableData[0].tier;
     const season = this.tableData[0].season;
@@ -59,6 +66,29 @@ export class SeasonSummaryCardComponent implements OnChanges {
       name: team.name,
       clubId: team.clubIds[0] ?? null,
     }));
+  }
+
+  movementPreviewTeams(teams: readonly ClubNameReference[]): readonly ClubNameReference[] {
+    return teams.slice(0, MOVEMENT_TEAM_PREVIEW_LIMIT);
+  }
+
+  movementOverflowTeams(teams: readonly ClubNameReference[]): readonly ClubNameReference[] {
+    return teams.slice(MOVEMENT_TEAM_PREVIEW_LIMIT);
+  }
+
+  visibleMovementTeams(
+    teams: readonly ClubNameReference[],
+    expanded: boolean
+  ): readonly ClubNameReference[] {
+    return expanded ? teams : this.movementPreviewTeams(teams);
+  }
+
+  togglePromotedExpanded() {
+    this.promotedExpanded = !this.promotedExpanded;
+  }
+
+  toggleRelegatedExpanded() {
+    this.relegatedExpanded = !this.relegatedExpanded;
   }
 
   private tableEntryReference(entry: LeagueTableView): ClubNameReference {

--- a/src/app/pages/home/home.html
+++ b/src/app/pages/home/home.html
@@ -2,28 +2,51 @@
   <section class="hero">
     <header class="app-page-header">
       <p class="app-page-eyebrow">English Football Archive</p>
-      <h1 class="app-page-title">
-        @if (archiveLoaded()) { Explore {{ seasonsCount() }} seasons of English football history. }
-        @else { Explore English football history. }
-      </h1>
+      <h1 class="app-page-title">Explore English football history.</h1>
       <p class="app-page-lede">
         FootyStats brings league tables, club histories, promotion paths, and long-run patterns into
         one searchable reference for the English game.
       </p>
     </header>
 
-    <div class="archive-meta" aria-label="Archive coverage" [attr.aria-busy]="!archiveLoaded()">
+    @if (archiveLoadFailed()) {
+    <div class="archive-status archive-status--error" role="alert">
+      <p>Archive coverage could not load.</p>
+      <button type="button" mat-button (click)="retryArchiveLoad()">Retry</button>
+    </div>
+    } @else {
+    <div
+      class="archive-meta"
+      aria-label="Archive coverage"
+      [attr.aria-busy]="archiveBusy() ? 'true' : null"
+    >
       @for (stat of archiveStats(); track stat.label) {
       <span>
         @if (archiveLoaded()) {
-        <strong>{{ stat.value }}</strong>
+        <strong
+          class="ticker-number"
+          [class.ticker-number--running]="archiveTickerRunning()"
+          [class.ticker-number--simple-reveal]="archiveSimpleRevealRunning()"
+          aria-hidden="true"
+        >
+          {{ archiveStatDisplayValue(stat) }}
+        </strong>
+        <span class="sr-only">{{ stat.value }}</span>
         } @else {
-        <strong class="metric-skeleton" aria-hidden="true"></strong>
+        <strong
+          class="metric-placeholder"
+          [class.metric-placeholder--visible]="showArchiveLoading()"
+          aria-hidden="true"
+        ></strong>
+        @if (showArchiveLoading()) {
         <span class="sr-only">Loading {{ stat.label }}</span>
-        } {{ stat.label }}
+        } } {{ stat.label }}
       </span>
+      } @if (showArchiveLoading()) {
+      <p class="sr-only" role="status">Loading archive coverage.</p>
       }
     </div>
+    }
 
     <div class="cta-row">
       <a mat-flat-button routerLink="/tables">Browse Tables</a>

--- a/src/app/pages/home/home.html
+++ b/src/app/pages/home/home.html
@@ -3,7 +3,8 @@
     <header class="app-page-header">
       <p class="app-page-eyebrow">English Football Archive</p>
       <h1 class="app-page-title">
-        Explore {{ seasonsCount() || '100+' }} seasons of English football history.
+        @if (archiveLoaded()) { Explore {{ seasonsCount() }} seasons of English football history. }
+        @else { Explore English football history. }
       </h1>
       <p class="app-page-lede">
         FootyStats brings league tables, club histories, promotion paths, and long-run patterns into
@@ -11,19 +12,17 @@
       </p>
     </header>
 
-    <div class="archive-meta" aria-label="Archive coverage">
+    <div class="archive-meta" aria-label="Archive coverage" [attr.aria-busy]="!archiveLoaded()">
+      @for (stat of archiveStats(); track stat.label) {
       <span>
-        <strong>{{ seasonsCount() || '100+' }}</strong>
-        seasons
+        @if (archiveLoaded()) {
+        <strong>{{ stat.value }}</strong>
+        } @else {
+        <strong class="metric-skeleton" aria-hidden="true"></strong>
+        <span class="sr-only">Loading {{ stat.label }}</span>
+        } {{ stat.label }}
       </span>
-      <span>
-        <strong>{{ teamsCount() || '50+' }}</strong>
-        clubs
-      </span>
-      <span>
-        <strong>{{ tiersCount() || '7' }}</strong>
-        tracked tiers
-      </span>
+      }
     </div>
 
     <div class="cta-row">

--- a/src/app/pages/home/home.html
+++ b/src/app/pages/home/home.html
@@ -34,10 +34,12 @@
         <span class="sr-only">{{ stat.value }}</span>
         } @else {
         <strong
-          class="metric-placeholder"
+          class="ticker-number metric-placeholder"
           [class.metric-placeholder--visible]="showArchiveLoading()"
           aria-hidden="true"
-        ></strong>
+        >
+          000
+        </strong>
         @if (showArchiveLoading()) {
         <span class="sr-only">Loading {{ stat.label }}</span>
         } } {{ stat.label }}

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -16,15 +16,15 @@
   margin-top: clamp(22px, 4vw, 36px);
   display: flex;
   flex-wrap: wrap;
-  gap: 10px 24px;
+  gap: 14px 32px;
   color: var(--app-text-muted);
   font-size: 0.98rem;
 }
 
 .archive-meta span {
   display: inline-flex;
-  align-items: baseline;
-  gap: 7px;
+  align-items: center;
+  gap: 12px;
 }
 
 .archive-meta strong {
@@ -33,19 +33,83 @@
   line-height: 1;
 }
 
-.metric-skeleton {
+.ticker-number {
+  position: relative;
+  min-width: 4.2ch;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 7px;
+  padding: 7px 12px 6px;
+  display: inline-grid;
+  place-items: center;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--app-text-strong);
+  font-family: 'Roboto Mono', 'SFMono-Regular', Consolas, monospace;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+}
+
+.ticker-number--running {
+  animation: ticker-board-rattle 760ms steps(8, end);
+  border-color: rgba(217, 119, 6, 0.42);
+  background: rgba(15, 23, 42, 0.86);
+  color: #fde68a;
+  text-shadow: 0 0 8px rgba(251, 191, 36, 0.32);
+}
+
+.ticker-number--running::after {
+  content: '';
+  position: absolute;
+  inset: 50% 0 auto;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.ticker-number--simple-reveal {
+  animation: archive-count-reveal 420ms ease-out;
+}
+
+@keyframes ticker-board-rattle {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  22% {
+    transform: translateY(-1px);
+  }
+
+  48% {
+    transform: translateY(1px);
+  }
+
+  74% {
+    transform: translateY(-1px);
+  }
+}
+
+@keyframes archive-count-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.metric-placeholder {
   display: inline-block;
   width: 3.2ch;
   height: clamp(1.25rem, 2vw, 1.65rem);
   border-radius: 6px;
-  background: linear-gradient(
-    90deg,
-    rgba(148, 163, 184, 0.14),
-    rgba(148, 163, 184, 0.28),
-    rgba(148, 163, 184, 0.14)
-  );
-  background-size: 200% 100%;
-  animation: metric-skeleton-pulse 1.35s ease-in-out infinite;
+  background: transparent;
+}
+
+.metric-placeholder--visible {
+  background: rgba(148, 163, 184, 0.22);
 }
 
 .sr-only {
@@ -58,14 +122,22 @@
   clip-path: inset(50%);
 }
 
-@keyframes metric-skeleton-pulse {
-  0% {
-    background-position: 100% 0;
-  }
+.archive-status {
+  margin-top: clamp(22px, 4vw, 36px);
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  color: var(--app-text-muted);
+}
 
-  100% {
-    background-position: -100% 0;
-  }
+.archive-status p {
+  margin: 0;
+}
+
+.archive-status button {
+  --mdc-text-button-label-text-color: var(--app-text-strong);
 }
 
 .cta-row {
@@ -147,14 +219,26 @@
   .archive-meta {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 8px;
+    gap: 10px;
   }
 
   .archive-meta span {
     border-top: 1px solid var(--app-border);
-    padding-top: 8px;
+    padding-top: 10px;
     display: grid;
-    gap: 3px;
+    gap: 5px;
+    align-items: start;
+  }
+
+  .ticker-number {
+    width: fit-content;
+    min-width: 0;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    background: transparent;
+    font-family: inherit;
+    letter-spacing: 0;
   }
 
   .cta-row {
@@ -167,7 +251,20 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .metric-skeleton {
+  .ticker-number--running {
     animation: none;
+  }
+
+  .ticker-number--running::after,
+  .ticker-number--simple-reveal {
+    animation: none;
+  }
+
+  .ticker-number--running::after {
+    display: none;
+  }
+
+  .metric-placeholder {
+    height: 1.25rem;
   }
 }

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -33,6 +33,41 @@
   line-height: 1;
 }
 
+.metric-skeleton {
+  display: inline-block;
+  width: 3.2ch;
+  height: clamp(1.25rem, 2vw, 1.65rem);
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    rgba(148, 163, 184, 0.14),
+    rgba(148, 163, 184, 0.28),
+    rgba(148, 163, 184, 0.14)
+  );
+  background-size: 200% 100%;
+  animation: metric-skeleton-pulse 1.35s ease-in-out infinite;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  clip-path: inset(50%);
+}
+
+@keyframes metric-skeleton-pulse {
+  0% {
+    background-position: 100% 0;
+  }
+
+  100% {
+    background-position: -100% 0;
+  }
+}
+
 .cta-row {
   margin-top: clamp(24px, 4vw, 40px);
   display: flex;
@@ -128,5 +163,11 @@
 
   .cta-row a {
     width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .metric-skeleton {
+    animation: none;
   }
 }

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -101,15 +101,14 @@
 }
 
 .metric-placeholder {
-  display: inline-block;
-  width: 3.2ch;
-  height: clamp(1.25rem, 2vw, 1.65rem);
-  border-radius: 6px;
   background: transparent;
+  color: transparent;
+  text-shadow: none;
 }
 
 .metric-placeholder--visible {
   background: rgba(148, 163, 184, 0.22);
+  border-color: rgba(148, 163, 184, 0.24);
 }
 
 .sr-only {
@@ -265,6 +264,6 @@
   }
 
   .metric-placeholder {
-    height: 1.25rem;
+    color: transparent;
   }
 }

--- a/src/app/pages/home/home.spec.ts
+++ b/src/app/pages/home/home.spec.ts
@@ -65,6 +65,7 @@ describe('Home', () => {
     expect(component.archiveLoaded()).toBe(false);
     expect(element.querySelector('h1')?.textContent).toContain('Explore English football history.');
     expect(element.querySelectorAll('.metric-placeholder')).toHaveLength(3);
+    expect(element.querySelectorAll('.metric-placeholder.ticker-number')).toHaveLength(3);
     expect(element.querySelectorAll('.metric-placeholder--visible')).toHaveLength(0);
     expect(element.querySelector('[role="status"]')).toBeNull();
   });

--- a/src/app/pages/home/home.spec.ts
+++ b/src/app/pages/home/home.spec.ts
@@ -1,19 +1,42 @@
+import { signal, type WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { provideRouter } from '@angular/router';
 import { LeagueStore } from '@app/store/league.store';
+import { DataLoaderService, type DataLoadStatus } from '@app/store/services/hydrate-store-json';
 import { Home } from './home';
 
 describe('Home', () => {
   let component: Home;
   let fixture: ComponentFixture<Home>;
   let store: InstanceType<typeof LeagueStore>;
+  let loadStatus: WritableSignal<DataLoadStatus>;
+  let showLoadingState: WritableSignal<boolean>;
+  let loadDataSpy: jest.Mock;
+  let originalMatchMedia: typeof window.matchMedia | undefined;
 
   beforeEach(async () => {
+    originalMatchMedia = window.matchMedia;
+    loadStatus = signal<DataLoadStatus>('idle');
+    showLoadingState = signal(false);
+    loadDataSpy = jest.fn().mockResolvedValue(undefined);
+
     await TestBed.configureTestingModule({
       imports: [Home],
 
-      providers: [provideRouter([]), LeagueStore],
+      providers: [
+        provideRouter([]),
+        LeagueStore,
+        {
+          provide: DataLoaderService,
+          useValue: {
+            loadStatus,
+            loadError: signal(null),
+            showLoadingState,
+            loadData: loadDataSpy,
+          },
+        },
+      ],
     }).compileComponents();
 
     store = TestBed.inject(LeagueStore);
@@ -22,16 +45,57 @@ describe('Home', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    fixture.destroy();
+    jest.useRealTimers();
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('shows stable loading placeholders before archive data hydrates', () => {
+  it('reserves archive metrics without flashing loading UI before delayed loading is visible', () => {
     const element: HTMLElement = fixture.nativeElement;
 
     expect(component.archiveLoaded()).toBe(false);
     expect(element.querySelector('h1')?.textContent).toContain('Explore English football history.');
-    expect(element.querySelectorAll('.metric-skeleton')).toHaveLength(3);
+    expect(element.querySelectorAll('.metric-placeholder')).toHaveLength(3);
+    expect(element.querySelectorAll('.metric-placeholder--visible')).toHaveLength(0);
+    expect(element.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('shows static archive loading state after the loader disclosure delay', () => {
+    loadStatus.set('loading');
+    showLoadingState.set(true);
+    fixture.detectChanges();
+
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(component.showArchiveLoading()).toBe(true);
+    expect(element.querySelectorAll('.metric-placeholder--visible')).toHaveLength(3);
+    expect(element.querySelector('[role="status"]')?.textContent).toContain(
+      'Loading archive coverage.'
+    );
+  });
+
+  it('shows archive load failure with a retry action', () => {
+    loadStatus.set('error');
+    fixture.detectChanges();
+
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(element.querySelector('[role="alert"]')?.textContent).toContain(
+      'Archive coverage could not load.'
+    );
+
+    element.querySelector<HTMLButtonElement>('button')?.click();
+
+    expect(loadDataSpy).toHaveBeenCalledTimes(1);
   });
 
   it('shows archive counts after data hydrates', () => {
@@ -55,13 +119,95 @@ describe('Home', () => {
     expect(component.seasonsCount()).toBe(2);
     expect(component.teamsCount()).toBe(3);
     expect(component.tiersCount()).toBe(3);
-    expect(element.querySelector('h1')?.textContent).toContain(
-      'Explore 2 seasons of English football history.'
-    );
-    expect(element.querySelectorAll('.metric-skeleton')).toHaveLength(0);
+    expect(element.querySelector('h1')?.textContent).toContain('Explore English football history.');
+    expect(element.querySelectorAll('.metric-placeholder')).toHaveLength(0);
     expect(element.querySelector('.archive-meta')?.textContent).toContain('3 clubs');
   });
+
+  it('reveals archive counts with a short ticker animation', () => {
+    jest.useFakeTimers();
+
+    store.hydrate(archiveFixture());
+    fixture.detectChanges();
+
+    expect(component.archiveTickerRunning()).toBe(true);
+    expect(component.archiveTickerValues()['clubs']).toBeDefined();
+    expect(fixture.nativeElement.querySelectorAll('.ticker-number--running')).toHaveLength(3);
+
+    jest.advanceTimersByTime(760);
+    fixture.detectChanges();
+
+    expect(component.archiveTickerRunning()).toBe(false);
+    expect(component.archiveTickerValues()).toMatchObject({
+      seasons: '2',
+      clubs: '3',
+      'tracked tiers': '3',
+    });
+  });
+
+  it('uses a simple final-value reveal on mobile instead of ticker cycling', () => {
+    jest.useFakeTimers();
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: query === '(max-width: 560px)',
+      })),
+    });
+
+    store.hydrate(archiveFixture());
+    fixture.detectChanges();
+
+    expect(component.archiveTickerRunning()).toBe(false);
+    expect(component.archiveSimpleRevealRunning()).toBe(true);
+    expect(component.archiveTickerValues()).toMatchObject({
+      seasons: '2',
+      clubs: '3',
+      'tracked tiers': '3',
+    });
+    expect(fixture.nativeElement.querySelectorAll('.ticker-number--running')).toHaveLength(0);
+    expect(fixture.nativeElement.querySelectorAll('.ticker-number--simple-reveal')).toHaveLength(3);
+
+    jest.advanceTimersByTime(420);
+    fixture.detectChanges();
+
+    expect(component.archiveSimpleRevealRunning()).toBe(false);
+  });
+
+  it('skips ticker motion when reduced motion is preferred', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: jest.fn().mockReturnValue({ matches: true }),
+    });
+
+    store.hydrate(archiveFixture());
+    fixture.detectChanges();
+
+    expect(component.archiveTickerRunning()).toBe(false);
+    expect(fixture.nativeElement.querySelectorAll('.ticker-number--running')).toHaveLength(0);
+    expect(component.archiveTickerValues()).toMatchObject({
+      seasons: '2',
+      clubs: '3',
+      'tracked tiers': '3',
+    });
+  });
 });
+
+function archiveFixture() {
+  return {
+    seasons: {
+      2024: {
+        tier1: [tableRow('Alpha FC')],
+        tier2: [tableRow('Bravo Town')],
+      },
+      2025: {
+        tier1: [tableRow('Alpha FC')],
+        tier3: [tableRow('Charlie City')],
+      },
+    },
+  };
+}
 
 function tableRow(team: string) {
   return {

--- a/src/app/pages/home/home.spec.ts
+++ b/src/app/pages/home/home.spec.ts
@@ -7,6 +7,7 @@ import { Home } from './home';
 describe('Home', () => {
   let component: Home;
   let fixture: ComponentFixture<Home>;
+  let store: InstanceType<typeof LeagueStore>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -15,6 +16,7 @@ describe('Home', () => {
       providers: [provideRouter([]), LeagueStore],
     }).compileComponents();
 
+    store = TestBed.inject(LeagueStore);
     fixture = TestBed.createComponent(Home);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -23,4 +25,62 @@ describe('Home', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('shows stable loading placeholders before archive data hydrates', () => {
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(component.archiveLoaded()).toBe(false);
+    expect(element.querySelector('h1')?.textContent).toContain('Explore English football history.');
+    expect(element.querySelectorAll('.metric-skeleton')).toHaveLength(3);
+  });
+
+  it('shows archive counts after data hydrates', () => {
+    store.hydrate({
+      seasons: {
+        2024: {
+          tier1: [tableRow('Alpha FC')],
+          tier2: [tableRow('Bravo Town')],
+        },
+        2025: {
+          tier1: [tableRow('Alpha FC')],
+          tier3: [tableRow('Charlie City')],
+        },
+      },
+    });
+    fixture.detectChanges();
+
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(component.archiveLoaded()).toBe(true);
+    expect(component.seasonsCount()).toBe(2);
+    expect(component.teamsCount()).toBe(3);
+    expect(component.tiersCount()).toBe(3);
+    expect(element.querySelector('h1')?.textContent).toContain(
+      'Explore 2 seasons of English football history.'
+    );
+    expect(element.querySelectorAll('.metric-skeleton')).toHaveLength(0);
+    expect(element.querySelector('.archive-meta')?.textContent).toContain('3 clubs');
+  });
 });
+
+function tableRow(team: string) {
+  return {
+    team,
+    pos: 1,
+    played: 38,
+    won: 24,
+    drawn: 8,
+    lost: 6,
+    goalsFor: 70,
+    goalsAgainst: 35,
+    goalDifference: 35,
+    goalAverage: null,
+    points: 80,
+    notes: null,
+    wasRelegated: false,
+    wasPromoted: false,
+    isExpansionTeam: false,
+    wasReElected: false,
+    wasReprieved: false,
+  };
+}

--- a/src/app/pages/home/home.ts
+++ b/src/app/pages/home/home.ts
@@ -1,8 +1,9 @@
 // home.component.ts
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, effect, inject, OnDestroy, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { RouterLink } from '@angular/router';
+import { DataLoaderService } from '@app/store/services/hydrate-store-json';
 import { LeagueStore } from '@app/store/league.store';
 
 interface ArchiveStat {
@@ -16,8 +17,12 @@ interface ArchiveStat {
   styleUrls: ['./home.scss'],
   imports: [CommonModule, MatButtonModule, RouterLink],
 })
-export class Home {
+export class Home implements OnDestroy {
   private store = inject(LeagueStore);
+  private dataLoader = inject(DataLoaderService);
+  private archiveTickerInterval: ReturnType<typeof setInterval> | null = null;
+  private archiveTickerTimeout: ReturnType<typeof setTimeout> | null = null;
+  private archiveTickerStarted = false;
 
   teamsCount = computed(() => {
     const teams = this.store.getTeams(); // <- reactive getter
@@ -32,9 +37,129 @@ export class Home {
     return tierNames.size;
   });
   archiveLoaded = computed(() => this.seasonsCount() > 0 && this.teamsCount() > 0);
+  showArchiveLoading = computed(() => !this.archiveLoaded() && this.dataLoader.showLoadingState());
+  archiveLoadFailed = computed(
+    () => !this.archiveLoaded() && this.dataLoader.loadStatus() === 'error'
+  );
+  archiveBusy = computed(() => !this.archiveLoaded() && this.dataLoader.loadStatus() === 'loading');
   archiveStats = computed<ArchiveStat[]>(() => [
     { label: 'seasons', value: this.seasonsCount() },
     { label: 'clubs', value: this.teamsCount() },
     { label: 'tracked tiers', value: this.tiersCount() },
   ]);
+  archiveTickerValues = signal<Record<string, string>>({});
+  archiveTickerRunning = signal(false);
+  archiveSimpleRevealRunning = signal(false);
+
+  constructor() {
+    effect(() => {
+      if (!this.archiveLoaded() || this.archiveTickerStarted) {
+        return;
+      }
+
+      this.archiveTickerStarted = true;
+      this.startArchiveTicker(this.archiveStats());
+    });
+  }
+
+  ngOnDestroy() {
+    this.clearArchiveTicker();
+  }
+
+  retryArchiveLoad() {
+    void this.dataLoader.loadData();
+  }
+
+  archiveStatDisplayValue(stat: ArchiveStat): string {
+    return this.archiveTickerValues()[stat.label] ?? this.formatArchiveValue(stat.value);
+  }
+
+  private startArchiveTicker(stats: ArchiveStat[]) {
+    this.clearArchiveTicker();
+
+    if (this.prefersReducedMotion()) {
+      this.archiveTickerValues.set(this.realArchiveValues(stats));
+      this.archiveTickerRunning.set(false);
+      this.archiveSimpleRevealRunning.set(false);
+      return;
+    }
+
+    if (this.prefersSimpleArchiveReveal()) {
+      this.archiveTickerValues.set(this.realArchiveValues(stats));
+      this.archiveTickerRunning.set(false);
+      this.archiveSimpleRevealRunning.set(true);
+      this.archiveTickerTimeout = setTimeout(() => {
+        this.archiveSimpleRevealRunning.set(false);
+        this.archiveTickerTimeout = null;
+      }, 420);
+      return;
+    }
+
+    this.archiveTickerRunning.set(true);
+    this.archiveSimpleRevealRunning.set(false);
+    this.archiveTickerValues.set(this.randomArchiveValues(stats));
+    this.archiveTickerInterval = setInterval(() => {
+      this.archiveTickerValues.set(this.randomArchiveValues(stats));
+    }, 70);
+    this.archiveTickerTimeout = setTimeout(() => {
+      this.clearArchiveTicker();
+      this.archiveTickerValues.set(this.realArchiveValues(stats));
+      this.archiveTickerRunning.set(false);
+    }, 760);
+  }
+
+  private clearArchiveTicker() {
+    if (this.archiveTickerInterval) {
+      clearInterval(this.archiveTickerInterval);
+      this.archiveTickerInterval = null;
+    }
+
+    if (this.archiveTickerTimeout) {
+      clearTimeout(this.archiveTickerTimeout);
+      this.archiveTickerTimeout = null;
+    }
+
+    this.archiveTickerRunning.set(false);
+    this.archiveSimpleRevealRunning.set(false);
+  }
+
+  private randomArchiveValues(stats: ArchiveStat[]): Record<string, string> {
+    return Object.fromEntries(
+      stats.map((stat) => {
+        const digits = Math.max(this.formatArchiveValue(stat.value).length, 2);
+        const ceiling = 10 ** digits;
+        const value = Math.floor(Math.random() * ceiling)
+          .toString()
+          .padStart(digits, '0');
+
+        return [stat.label, value];
+      })
+    );
+  }
+
+  private realArchiveValues(stats: ArchiveStat[]): Record<string, string> {
+    return Object.fromEntries(
+      stats.map((stat) => [stat.label, this.formatArchiveValue(stat.value)])
+    );
+  }
+
+  private formatArchiveValue(value: number): string {
+    return value.toLocaleString('en-US');
+  }
+
+  private prefersReducedMotion(): boolean {
+    return this.matchesMedia('(prefers-reduced-motion: reduce)');
+  }
+
+  private prefersSimpleArchiveReveal(): boolean {
+    return this.matchesMedia('(max-width: 560px)');
+  }
+
+  private matchesMedia(query: string): boolean {
+    return (
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia(query).matches
+    );
+  }
 }

--- a/src/app/pages/home/home.ts
+++ b/src/app/pages/home/home.ts
@@ -5,6 +5,11 @@ import { MatButtonModule } from '@angular/material/button';
 import { RouterLink } from '@angular/router';
 import { LeagueStore } from '@app/store/league.store';
 
+interface ArchiveStat {
+  label: string;
+  value: number;
+}
+
 @Component({
   selector: 'app-home',
   templateUrl: './home.html',
@@ -26,4 +31,10 @@ export class Home {
     const tierNames = new Set(this.store.getSeasonTiers().flatMap((season) => season.tiers));
     return tierNames.size;
   });
+  archiveLoaded = computed(() => this.seasonsCount() > 0 && this.teamsCount() > 0);
+  archiveStats = computed<ArchiveStat[]>(() => [
+    { label: 'seasons', value: this.seasonsCount() },
+    { label: 'clubs', value: this.teamsCount() },
+    { label: 'tracked tiers', value: this.tiersCount() },
+  ]);
 }

--- a/src/app/pages/league-deep-stats/league-deep-stats.html
+++ b/src/app/pages/league-deep-stats/league-deep-stats.html
@@ -177,11 +177,31 @@
         <h3>Title races</h3>
         <div class="deep-table">
           @for (row of raceRows(profile()!.closeTitleRaces); track row.season) {
-          <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
-            <strong>{{ row.season }}</strong>
-            <span>{{ row.primaryName }} over {{ row.secondaryName }}</span>
+          <div class="race-row">
+            <strong>
+              <a
+                class="table-row-link"
+                [routerLink]="['/tables']"
+                [queryParams]="tableQueryParams(row.season)"
+              >
+                {{ row.season }}
+              </a>
+            </strong>
+            <span>
+              @if (row.primaryClubId) {
+              <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
+                {{ row.primaryName }}
+              </a>
+              } @else { {{ row.primaryName }} }
+              <span>over</span>
+              @if (row.secondaryClubId) {
+              <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
+                {{ row.secondaryName }}
+              </a>
+              } @else { {{ row.secondaryName }} }
+            </span>
             <em>{{ row.detail }}</em>
-          </a>
+          </div>
           }
         </div>
       </section>
@@ -189,11 +209,31 @@
         <h3>Survival races</h3>
         <div class="deep-table">
           @for (row of raceRows(profile()!.closeSurvivalRaces); track row.season) {
-          <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
-            <strong>{{ row.season }}</strong>
-            <span>{{ row.primaryName }} above {{ row.secondaryName }}</span>
+          <div class="race-row">
+            <strong>
+              <a
+                class="table-row-link"
+                [routerLink]="['/tables']"
+                [queryParams]="tableQueryParams(row.season)"
+              >
+                {{ row.season }}
+              </a>
+            </strong>
+            <span>
+              @if (row.primaryClubId) {
+              <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
+                {{ row.primaryName }}
+              </a>
+              } @else { {{ row.primaryName }} }
+              <span>above</span>
+              @if (row.secondaryClubId) {
+              <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
+                {{ row.secondaryName }}
+              </a>
+              } @else { {{ row.secondaryName }} }
+            </span>
             <em>{{ row.detail }}</em>
-          </a>
+          </div>
           }
         </div>
       </section>
@@ -201,11 +241,31 @@
         <h3>Promotion races</h3>
         <div class="deep-table">
           @for (row of raceRows(profile()!.closePromotionRaces); track row.season) {
-          <a [routerLink]="['/tables']" [queryParams]="sourceTableQueryParams(row.season)">
-            <strong>{{ row.season }}</strong>
-            <span>{{ row.primaryName }} over {{ row.secondaryName }}</span>
+          <div class="race-row">
+            <strong>
+              <a
+                class="table-row-link"
+                [routerLink]="['/tables']"
+                [queryParams]="sourceTableQueryParams(row.season)"
+              >
+                {{ row.season }}
+              </a>
+            </strong>
+            <span>
+              @if (row.primaryClubId) {
+              <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
+                {{ row.primaryName }}
+              </a>
+              } @else { {{ row.primaryName }} }
+              <span>over</span>
+              @if (row.secondaryClubId) {
+              <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
+                {{ row.secondaryName }}
+              </a>
+              } @else { {{ row.secondaryName }} }
+            </span>
             <em>{{ row.detail }}</em>
-          </a>
+          </div>
           }
         </div>
       </section>

--- a/src/app/pages/league-deep-stats/league-deep-stats.html
+++ b/src/app/pages/league-deep-stats/league-deep-stats.html
@@ -1,0 +1,232 @@
+@if (!hasArchiveData()) { @if (loadFailed()) {
+<div class="loading loading--error app-page-shell" role="alert">
+  <p>League deep stats could not load.</p>
+  <button type="button" mat-button (click)="retryArchiveLoad()">Retry</button>
+</div>
+} @else if (showLoadingState()) {
+<div class="loading app-page-shell" role="status" aria-live="polite">Loading deep stats...</div>
+} } @else if (!profile()) {
+<section class="deep-stats app-surface app-page-shell">
+  <nav class="profile-top-actions" aria-label="League deep stats actions">
+    <a class="back-link" routerLink="/tables">Back to tables</a>
+  </nav>
+  <div class="empty-state app-panel">
+    <p class="app-page-eyebrow">Deep Stats</p>
+    <h1>League not found</h1>
+    <p>The requested league tier is not available in the current archive data.</p>
+  </div>
+</section>
+} @else {
+<section class="deep-stats app-surface app-page-shell">
+  <nav class="profile-top-actions" aria-label="League deep stats actions">
+    <a class="back-link" [routerLink]="['/leagues', tierId()]">Back to overview</a>
+    <div class="profile-action-links">
+      <button type="button" mat-button (click)="printPage()">Print</button>
+      <a mat-stroked-button routerLink="/tables">Open tables</a>
+    </div>
+  </nav>
+
+  <header class="profile-header">
+    <p class="app-page-eyebrow">Deep Stats</p>
+    <h1 class="app-page-title">{{ tierLabel() }}</h1>
+    <p class="app-page-lede">
+      Dense archive view across {{ profile()!.seasons.length }} tracked seasons from {{
+      seasonRangeLabel() }}.
+    </p>
+  </header>
+
+  <section class="stat-grid" aria-label="Deep league summary">
+    <div class="stat-cell">
+      <span>Rows</span>
+      <strong>{{ profile()!.totalRows }}</strong>
+    </div>
+    <div class="stat-cell">
+      <span>Clubs</span>
+      <strong>{{ profile()!.uniqueClubCount }}</strong>
+    </div>
+    <div class="stat-cell">
+      <span>Promoted In</span>
+      <strong>{{ profile()!.promotionInCount }}</strong>
+    </div>
+    <div class="stat-cell">
+      <span>Relegated Out</span>
+      <strong>{{ profile()!.relegationOutCount }}</strong>
+    </div>
+  </section>
+
+  <div class="deep-grid">
+    <section class="deep-panel app-panel">
+      <div class="panel-head">
+        <h2>Club Leaderboards</h2>
+        <span>top archive totals</span>
+      </div>
+      <div class="leaderboard-grid">
+        <section>
+          <h3>Most seasons</h3>
+          <div class="rank-list">
+            @for (row of leaderRows(profile()!.mostSeasons); track row.key) {
+            <div>
+              <span>
+                @if (row.clubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+                } @else { {{ row.name }} }
+              </span>
+              <strong>{{ row.detail }}</strong>
+            </div>
+            }
+          </div>
+        </section>
+
+        <section>
+          <h3>Most titles</h3>
+          <div class="rank-list">
+            @for (row of leaderRows(profile()!.mostTitles); track row.key) {
+            <div>
+              <span>
+                @if (row.clubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+                } @else { {{ row.name }} }
+              </span>
+              <strong>{{ row.detail }}</strong>
+            </div>
+            }
+          </div>
+        </section>
+
+        <section>
+          <h3>Top-three finishes</h3>
+          <div class="rank-list">
+            @for (row of leaderRows(profile()!.mostTopThreeFinishes); track row.key) {
+            <div>
+              <span>
+                @if (row.clubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+                } @else { {{ row.name }} }
+              </span>
+              <strong>{{ row.detail }}</strong>
+            </div>
+            }
+          </div>
+        </section>
+
+        <section>
+          <h3>Longest stays</h3>
+          <div class="rank-list">
+            @for (row of topRows(profile()!.longestStays); track row.key) {
+            <div>
+              <span>
+                @if (row.clubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+                } @else { {{ row.name }} }
+              </span>
+              <strong>{{ row.detail }}</strong>
+            </div>
+            }
+          </div>
+        </section>
+      </div>
+    </section>
+
+    <section class="deep-panel app-panel">
+      <div class="panel-head">
+        <h2>Movement</h2>
+        <span>{{ sourceTierLabel() }}</span>
+      </div>
+      <div class="leaderboard-grid">
+        <section>
+          <h3>Promoted into {{ tierLabel() }}</h3>
+          <div class="rank-list">
+            @for (row of leaderRows(profile()!.mostPromotionsIn); track row.key) {
+            <div>
+              <span>
+                @if (row.clubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+                } @else { {{ row.name }} }
+              </span>
+              <strong>{{ row.detail }}</strong>
+            </div>
+            }
+          </div>
+        </section>
+        <section>
+          <h3>Relegated from {{ tierLabel() }}</h3>
+          <div class="rank-list">
+            @for (row of leaderRows(profile()!.mostRelegationsOut); track row.key) {
+            <div>
+              <span>
+                @if (row.clubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+                } @else { {{ row.name }} }
+              </span>
+              <strong>{{ row.detail }}</strong>
+            </div>
+            }
+          </div>
+        </section>
+      </div>
+    </section>
+  </div>
+
+  <section class="deep-panel app-panel">
+    <div class="panel-head">
+      <h2>Close Seasons</h2>
+      <span>expanded race lists</span>
+    </div>
+    <div class="race-table-grid">
+      <section>
+        <h3>Title races</h3>
+        <div class="deep-table">
+          @for (row of raceRows(profile()!.closeTitleRaces); track row.season) {
+          <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
+            <strong>{{ row.season }}</strong>
+            <span>{{ row.primaryName }} over {{ row.secondaryName }}</span>
+            <em>{{ row.detail }}</em>
+          </a>
+          }
+        </div>
+      </section>
+      <section>
+        <h3>Survival races</h3>
+        <div class="deep-table">
+          @for (row of raceRows(profile()!.closeSurvivalRaces); track row.season) {
+          <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
+            <strong>{{ row.season }}</strong>
+            <span>{{ row.primaryName }} above {{ row.secondaryName }}</span>
+            <em>{{ row.detail }}</em>
+          </a>
+          }
+        </div>
+      </section>
+      <section>
+        <h3>Promotion races</h3>
+        <div class="deep-table">
+          @for (row of raceRows(profile()!.closePromotionRaces); track row.season) {
+          <a [routerLink]="['/tables']" [queryParams]="sourceTableQueryParams(row.season)">
+            <strong>{{ row.season }}</strong>
+            <span>{{ row.primaryName }} over {{ row.secondaryName }}</span>
+            <em>{{ row.detail }}</em>
+          </a>
+          }
+        </div>
+      </section>
+    </div>
+  </section>
+
+  <section class="deep-panel app-panel">
+    <div class="panel-head">
+      <h2>High-Churn Seasons</h2>
+      <span>top movement seasons</span>
+    </div>
+    <div class="churn-table">
+      @for (row of topRows(profile()!.churnSeasons, 16); track row.season) {
+      <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
+        <strong>{{ row.season }}</strong>
+        <span>{{ row.promotedIn }} promoted in</span>
+        <span>{{ row.relegatedOut }} relegated out</span>
+        <em>{{ row.totalMovement }} total</em>
+      </a>
+      }
+    </div>
+  </section>
+</section>
+}

--- a/src/app/pages/league-deep-stats/league-deep-stats.scss
+++ b/src/app/pages/league-deep-stats/league-deep-stats.scss
@@ -1,0 +1,309 @@
+:host {
+  display: block;
+}
+
+.loading,
+.empty-state {
+  color: var(--app-text-muted);
+}
+
+.deep-stats {
+  display: grid;
+  gap: 20px;
+}
+
+.profile-top-actions,
+.profile-action-links,
+.panel-head,
+.churn-table a {
+  display: flex;
+  align-items: center;
+}
+
+.profile-top-actions,
+.panel-head {
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.profile-action-links {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.back-link {
+  width: fit-content;
+  color: var(--app-text-muted);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  color: var(--app-text-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.profile-header {
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.profile-header .app-page-title {
+  margin: 8px 0;
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.05;
+}
+
+.stat-grid,
+.deep-grid,
+.leaderboard-grid,
+.race-table-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.stat-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.deep-grid,
+.race-table-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.race-table-grid section:first-child {
+  grid-column: 1 / -1;
+}
+
+.leaderboard-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.stat-cell,
+.deep-panel {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(148, 163, 184, 0.06), transparent 90px),
+    color-mix(in srgb, var(--app-surface-bg) 86%, transparent);
+}
+
+.stat-cell {
+  min-height: 72px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 11px 12px;
+  display: grid;
+  align-content: center;
+  gap: 4px;
+}
+
+.deep-panel {
+  padding: 16px;
+}
+
+.stat-cell::before,
+.deep-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: rgba(217, 119, 6, 0.74);
+}
+
+.stat-cell:nth-child(2)::before,
+.deep-panel:nth-of-type(2)::before {
+  background: rgba(96, 165, 250, 0.72);
+}
+
+.stat-cell:nth-child(3)::before {
+  background: rgba(34, 197, 94, 0.72);
+}
+
+.stat-cell:nth-child(4)::before {
+  background: rgba(20, 184, 166, 0.72);
+}
+
+.stat-cell span,
+.panel-head span {
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stat-cell strong {
+  color: var(--app-text-strong);
+  font-size: 1.05rem;
+}
+
+.panel-head {
+  margin-bottom: 14px;
+  padding: 0 0 11px 6px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.26);
+}
+
+.panel-head h2,
+.leaderboard-grid h3,
+.race-table-grid h3 {
+  margin: 0;
+  color: var(--app-text-strong);
+}
+
+.panel-head h2 {
+  font-size: 1.02rem;
+}
+
+.leaderboard-grid h3,
+.race-table-grid h3 {
+  margin-bottom: 9px;
+  font-size: 0.9rem;
+}
+
+.rank-list,
+.deep-table,
+.churn-table {
+  display: grid;
+  gap: 7px;
+}
+
+.rank-list div,
+.deep-table a,
+.churn-table a {
+  min-height: 42px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 7px;
+  background: rgba(7, 10, 19, 0.2);
+  color: var(--app-text-subtle);
+}
+
+.rank-list div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+}
+
+.rank-list strong,
+.deep-table em,
+.churn-table em {
+  color: var(--app-text-strong);
+  font-style: normal;
+  font-weight: 850;
+  text-align: right;
+}
+
+.deep-table a,
+.churn-table a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.deep-table a {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+}
+
+.deep-table a:hover,
+.deep-table a:focus-visible,
+.churn-table a:hover,
+.churn-table a:focus-visible {
+  border-color: rgba(245, 158, 11, 0.48);
+  background: rgba(245, 158, 11, 0.1);
+}
+
+.churn-table a {
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 10px;
+}
+
+@media (max-width: 880px) {
+  .profile-top-actions,
+  .panel-head,
+  .churn-table a {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .profile-action-links {
+    justify-content: flex-start;
+  }
+
+  .stat-grid,
+  .deep-grid,
+  .leaderboard-grid,
+  .race-table-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .deep-table a {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media print {
+  .deep-stats {
+    gap: 6pt;
+  }
+
+  .profile-top-actions {
+    display: none;
+  }
+
+  .deep-grid,
+  .leaderboard-grid,
+  .race-table-grid,
+  .stat-grid {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 7pt 10pt !important;
+  }
+
+  .stat-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+  }
+
+  .rank-list,
+  .deep-table,
+  .churn-table {
+    gap: 0;
+  }
+
+  .rank-list div,
+  .deep-table a,
+  .churn-table a {
+    min-height: 0;
+    padding: 2pt 0 !important;
+  }
+
+  .deep-table a {
+    grid-template-columns: 34pt minmax(0, 1fr) auto !important;
+  }
+
+  .deep-panel,
+  .stat-cell,
+  .rank-list div,
+  .deep-table a,
+  .churn-table a {
+    border-color: #dddddd;
+    background: #ffffff;
+  }
+
+  .deep-panel {
+    padding: 0;
+  }
+
+  .deep-panel::before,
+  .stat-cell::before {
+    display: none;
+  }
+}

--- a/src/app/pages/league-deep-stats/league-deep-stats.scss
+++ b/src/app/pages/league-deep-stats/league-deep-stats.scss
@@ -172,7 +172,7 @@
 }
 
 .rank-list div,
-.deep-table a,
+.deep-table .race-row,
 .churn-table a {
   min-height: 42px;
   border: 1px solid rgba(148, 163, 184, 0.2);
@@ -198,13 +198,13 @@
   text-align: right;
 }
 
-.deep-table a,
+.deep-table .table-row-link,
 .churn-table a {
   color: inherit;
   text-decoration: none;
 }
 
-.deep-table a {
+.deep-table .race-row {
   display: grid;
   grid-template-columns: 56px minmax(0, 1fr) auto;
   align-items: center;
@@ -212,8 +212,8 @@
   padding: 8px 10px;
 }
 
-.deep-table a:hover,
-.deep-table a:focus-visible,
+.deep-table .race-row:hover,
+.deep-table .race-row:focus-within,
 .churn-table a:hover,
 .churn-table a:focus-visible {
   border-color: rgba(245, 158, 11, 0.48);
@@ -245,7 +245,7 @@
     grid-template-columns: 1fr;
   }
 
-  .deep-table a {
+  .deep-table .race-row {
     grid-template-columns: 1fr;
   }
 }
@@ -279,20 +279,20 @@
   }
 
   .rank-list div,
-  .deep-table a,
+  .deep-table .race-row,
   .churn-table a {
     min-height: 0;
     padding: 2pt 0 !important;
   }
 
-  .deep-table a {
+  .deep-table .race-row {
     grid-template-columns: 34pt minmax(0, 1fr) auto !important;
   }
 
   .deep-panel,
   .stat-cell,
   .rank-list div,
-  .deep-table a,
+  .deep-table .race-row,
   .churn-table a {
     border-color: #dddddd;
     background: #ffffff;

--- a/src/app/pages/league-deep-stats/league-deep-stats.spec.ts
+++ b/src/app/pages/league-deep-stats/league-deep-stats.spec.ts
@@ -1,0 +1,115 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { LeagueStore } from '@app/store/league.store';
+import { DataLoaderService } from '@app/store/services/hydrate-store-json';
+import { of } from 'rxjs';
+import { LeagueDeepStats } from './league-deep-stats';
+
+describe('LeagueDeepStats', () => {
+  let fixture: ComponentFixture<LeagueDeepStats>;
+  let store: InstanceType<typeof LeagueStore>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LeagueDeepStats],
+      providers: [
+        LeagueStore,
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({ tier: 'tier1' })),
+            snapshot: {
+              paramMap: convertToParamMap({ tier: 'tier1' }),
+            },
+          },
+        },
+        {
+          provide: DataLoaderService,
+          useValue: {
+            loadStatus: signal('loaded'),
+            loadError: signal(null),
+            showLoadingState: signal(false),
+            loadData: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    store = TestBed.inject(LeagueStore);
+    store.hydrate(deepStatsFixture(), (teamName: string) => `${teamName.toLowerCase()} id`);
+    fixture = TestBed.createComponent(LeagueDeepStats);
+    fixture.detectChanges();
+  });
+
+  it('renders dense league sections with table links', () => {
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(element.textContent).toContain('Deep Stats');
+    expect(element.textContent).toContain('Club Leaderboards');
+    expect(element.textContent).toContain('Close Seasons');
+    expect(element.textContent).toContain('High-Churn Seasons');
+
+    const tableLink = Array.from(element.querySelectorAll<HTMLAnchorElement>('a')).find((link) =>
+      link.textContent?.includes('2021')
+    );
+    expect(tableLink?.getAttribute('href')).toContain('/tables?season=2021&tier=tier1');
+  });
+});
+
+function deepStatsFixture() {
+  return {
+    seasons: {
+      2020: {
+        tier1: [
+          row('Alpha FC', 1, 80, 70, 30, false, false),
+          row('Bravo Town', 2, 79, 68, 31, false, false),
+          row('Echo Rovers', 3, 35, 42, 60, true, false),
+        ],
+        tier2: [
+          row('Charlie City', 1, 84, 76, 35, false, true),
+          row('Delta United', 2, 83, 68, 38, false, false),
+        ],
+      },
+      2021: {
+        tier1: [
+          row('Alpha FC', 1, 85, 74, 28, false, false),
+          row('Charlie City', 2, 82, 70, 35, false, false),
+          row('Bravo Town', 3, 40, 46, 58, true, false),
+        ],
+        tier2: [row('Delta United', 1, 88, 78, 34, false, true)],
+      },
+    },
+  };
+}
+
+function row(
+  team: string,
+  pos: number,
+  points: number,
+  goalsFor: number,
+  goalsAgainst: number,
+  wasRelegated: boolean,
+  wasPromoted: boolean
+) {
+  return {
+    team,
+    pos,
+    played: 38,
+    won: 20,
+    drawn: 8,
+    lost: 10,
+    goalsFor,
+    goalsAgainst,
+    goalDifference: goalsFor - goalsAgainst,
+    goalAverage: null,
+    points,
+    notes: null,
+    wasRelegated,
+    wasPromoted,
+    isExpansionTeam: false,
+    wasReElected: false,
+    wasReprieved: false,
+  };
+}

--- a/src/app/pages/league-deep-stats/league-deep-stats.spec.ts
+++ b/src/app/pages/league-deep-stats/league-deep-stats.spec.ts
@@ -55,6 +55,12 @@ describe('LeagueDeepStats', () => {
       link.textContent?.includes('2021')
     );
     expect(tableLink?.getAttribute('href')).toContain('/tables?season=2021&tier=tier1');
+
+    const clubLink = Array.from(element.querySelectorAll<HTMLAnchorElement>('a')).find(
+      (link) =>
+        link.textContent?.trim() === 'Alpha FC' && link.getAttribute('href')?.includes('/teams/')
+    );
+    expect(clubLink?.getAttribute('href')).toBe('/teams/alpha%20fc%20id');
   });
 });
 

--- a/src/app/pages/league-deep-stats/league-deep-stats.ts
+++ b/src/app/pages/league-deep-stats/league-deep-stats.ts
@@ -1,0 +1,109 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { LeagueTierToStringyPipe } from '@app/pipes/league-tier-to-stringy-pipe';
+import { LeagueStore } from '@app/store/league.store';
+import { DataLoaderService } from '@app/store/services/hydrate-store-json';
+import {
+  buildTierProfileData,
+  type TierClubTotal,
+  type TierRaceRow,
+} from '@app/utils/tier-profile';
+
+@Component({
+  selector: 'app-league-deep-stats',
+  imports: [CommonModule, MatButtonModule, RouterLink],
+  providers: [LeagueTierToStringyPipe],
+  templateUrl: './league-deep-stats.html',
+  styleUrl: './league-deep-stats.scss',
+})
+export class LeagueDeepStats {
+  private route = inject(ActivatedRoute);
+  private store = inject(LeagueStore);
+  private dataLoader = inject(DataLoaderService);
+  private tierLabelPipe = inject(LeagueTierToStringyPipe);
+  private paramMap = toSignal(this.route.paramMap, {
+    initialValue: this.route.snapshot.paramMap,
+  });
+
+  tierId = computed(() => this.paramMap().get('tier') ?? '');
+  hasArchiveData = computed(() => this.store.getFullTable().length > 0);
+  showLoadingState = computed(() => !this.hasArchiveData() && this.dataLoader.showLoadingState());
+  loadFailed = computed(() => !this.hasArchiveData() && this.dataLoader.loadStatus() === 'error');
+  profile = computed(() => {
+    const tier = this.tierId();
+    if (!/^tier\d+$/.test(tier)) {
+      return null;
+    }
+
+    const profile = buildTierProfileData(
+      this.store.getFullTable(),
+      tier,
+      (teamId) => this.store.getTeamById(teamId),
+      {
+        leaderLimit: 24,
+        raceLimit: 24,
+        runLimit: 24,
+        churnLimit: 24,
+      }
+    );
+    return profile.totalRows ? profile : null;
+  });
+  tierLabel = computed(() => this.formatTierLabel(this.tierId()));
+  sourceTierLabel = computed(() => this.formatTierLabel(this.adjacentLowerTier(this.tierId())));
+
+  retryArchiveLoad() {
+    void this.dataLoader.loadData();
+  }
+
+  seasonRangeLabel(): string {
+    const seasons = this.profile()?.seasons ?? [];
+    if (!seasons.length) {
+      return 'No seasons';
+    }
+
+    const first = seasons[0];
+    const latest = seasons.at(-1);
+    return first === latest ? String(first) : `${first}-${latest}`;
+  }
+
+  tableQueryParams(season: number): { season: number; tier: string } {
+    return { season, tier: this.tierId() };
+  }
+
+  sourceTableQueryParams(season: number): { season: number; tier: string } {
+    return { season, tier: this.adjacentLowerTier(this.tierId()) };
+  }
+
+  topRows<T>(rows: readonly T[], limit = 12): T[] {
+    return rows.slice(0, limit);
+  }
+
+  raceRows(rows: readonly TierRaceRow[]): TierRaceRow[] {
+    return rows.slice(0, 12);
+  }
+
+  leaderRows(rows: readonly TierClubTotal[]): TierClubTotal[] {
+    return rows.slice(0, 12);
+  }
+
+  printPage() {
+    globalThis.print?.();
+  }
+
+  private formatTierLabel(tier: string): string {
+    return this.tierLabelPipe.transform(tier) || this.fallbackTierLabel(tier);
+  }
+
+  private fallbackTierLabel(tier: string): string {
+    const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+    return Number.isFinite(parsed) ? `Tier ${parsed}` : 'Unknown tier';
+  }
+
+  private adjacentLowerTier(tier: string): string {
+    const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+    return Number.isFinite(parsed) ? `tier${parsed + 1}` : tier;
+  }
+}

--- a/src/app/pages/league-table-historic/league-table-historic.spec.ts
+++ b/src/app/pages/league-table-historic/league-table-historic.spec.ts
@@ -1,17 +1,34 @@
 import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, ParamMap, provideRouter } from '@angular/router';
 
 import { LeagueTablesViewerComponent } from '@app/components/league-tables-viewer/league-tables-viewer';
+import { BehaviorSubject } from 'rxjs';
 import { LeagueTableHistoric } from './league-table-historic';
 
 describe('LeagueTableHistoric', () => {
   let component: LeagueTableHistoric;
   let fixture: ComponentFixture<LeagueTableHistoric>;
+  let queryParamMap$: BehaviorSubject<ParamMap>;
 
   beforeEach(async () => {
+    queryParamMap$ = new BehaviorSubject(convertToParamMap({}));
+
     await TestBed.configureTestingModule({
       imports: [LeagueTablesViewerComponent, LeagueTableHistoric],
-      providers: [provideHttpClient()],
+      providers: [
+        provideHttpClient(),
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParamMap: queryParamMap$.asObservable(),
+            snapshot: {
+              queryParamMap: convertToParamMap({}),
+            },
+          },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LeagueTableHistoric);

--- a/src/app/pages/movement-explorer/movement-explorer.html
+++ b/src/app/pages/movement-explorer/movement-explorer.html
@@ -145,15 +145,20 @@
         <div class="selected-label">Selected clubs</div>
         <div class="selected-chips">
           @for (team of selectedTeams(); track team.id) {
-          <button
-            class="chip"
-            type="button"
-            (click)="removeTeam(team.id)"
-            [attr.aria-label]="'Remove ' + team.name"
-          >
-            {{ team.name }}
-            <span aria-hidden="true">x</span>
-          </button>
+          <span class="selected-chip">
+            @if (primaryClubId(team); as clubId) {
+            <a class="app-club-link" [routerLink]="['/teams', clubId]">{{ team.name }}</a>
+            } @else {
+            <span class="selected-club-name">{{ team.name }}</span>
+            }
+            <button
+              type="button"
+              (click)="removeTeam(team.id)"
+              [attr.aria-label]="'Remove ' + team.name"
+            >
+              <span aria-hidden="true">x</span>
+            </button>
+          </span>
           }
         </div>
         <button class="clear-btn" type="button" (click)="clearSelectedTeams()">Clear clubs</button>
@@ -233,14 +238,23 @@
         </div>
         <div class="chart-context-clubs" aria-label="Selected clubs">
           @for (team of selectedTeams(); track team.id) {
-          <button
-            type="button"
-            [class.is-focused]="focusedTeamId() === team.id"
-            [attr.aria-pressed]="focusedTeamId() === team.id"
-            (click)="toggleFocusedTeam(team.id)"
-          >
-            {{ team.name }}
-          </button>
+          <span class="chart-context-club" [class.is-focused]="focusedTeamId() === team.id">
+            @if (primaryClubId(team); as clubId) {
+            <a class="app-club-link chart-club-link" [routerLink]="['/teams', clubId]">
+              {{ team.name }}
+            </a>
+            } @else {
+            <span class="chart-club-name">{{ team.name }}</span>
+            }
+            <button
+              type="button"
+              class="chart-focus-button"
+              [attr.aria-pressed]="focusedTeamId() === team.id"
+              (click)="toggleFocusedTeam(team.id)"
+            >
+              {{ focusedTeamId() === team.id ? 'Clear' : 'Focus' }}
+            </button>
+          </span>
           }
         </div>
       </section>

--- a/src/app/pages/movement-explorer/movement-explorer.scss
+++ b/src/app/pages/movement-explorer/movement-explorer.scss
@@ -245,7 +245,9 @@
 .quick-pick-tab,
 .team-option,
 .preset-btn,
-.chip,
+.selected-chip,
+.selected-chip button,
+.chart-focus-button,
 .clear-btn {
   border: 1px solid var(--app-border);
   border-radius: 6px;
@@ -266,7 +268,9 @@
 .team-option:hover:not(:disabled),
 .preset-btn:hover,
 .clear-btn:hover,
-.chip:hover {
+.selected-chip:hover,
+.selected-chip button:hover,
+.chart-focus-button:hover {
   border-color: rgba(148, 163, 184, 0.42);
   color: var(--app-text-strong);
 }
@@ -354,7 +358,7 @@
   text-transform: uppercase;
 }
 
-.chip {
+.selected-chip {
   padding: 7px 9px 7px 10px;
   display: inline-flex;
   align-items: center;
@@ -363,9 +367,18 @@
   color: var(--app-text-strong);
 }
 
-.chip span {
-  color: var(--app-text-muted);
-  font-weight: 800;
+.selected-chip button {
+  min-width: 22px;
+  min-height: 22px;
+  padding: 0 5px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 5px;
+}
+
+.selected-chip button:focus-visible {
+  outline: 2px solid var(--app-focus-ring);
+  outline-offset: 2px;
 }
 
 .clear-btn {
@@ -484,33 +497,41 @@
   gap: 8px;
 }
 
-.chart-context-clubs button {
+.chart-context-club {
   border: 1px solid var(--app-border);
   border-radius: 6px;
-  padding: 5px 8px;
+  padding: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   background: rgba(7, 10, 19, 0.18);
   color: var(--app-text-subtle);
   font-size: 0.84rem;
   font-weight: 650;
   line-height: 1.2;
-  cursor: pointer;
-  transition:
-    border-color 140ms ease,
-    background 140ms ease,
-    color 140ms ease;
 }
 
-.chart-context-clubs button:hover,
-.chart-context-clubs button:focus-visible {
+.chart-context-club:hover {
   border-color: rgba(245, 158, 11, 0.52);
   background: rgba(217, 119, 6, 0.12);
   color: var(--app-text-strong);
 }
 
-.chart-context-clubs button.is-focused {
+.chart-context-club.is-focused {
   border-color: rgba(245, 158, 11, 0.72);
   background: rgba(217, 119, 6, 0.22);
   color: #fde68a;
+}
+
+.chart-focus-button {
+  min-height: 24px;
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+
+.chart-focus-button:focus-visible {
+  outline: 2px solid var(--app-focus-ring);
+  outline-offset: 2px;
 }
 
 .empty {
@@ -681,7 +702,7 @@
 
   .team-option,
   .preset-btn,
-  .chip,
+  .selected-chip,
   .clear-btn {
     min-height: 38px;
     justify-content: center;

--- a/src/app/pages/movement-explorer/movement-explorer.ts
+++ b/src/app/pages/movement-explorer/movement-explorer.ts
@@ -14,7 +14,7 @@ import type { EChartsCoreOption } from 'echarts/core';
 import * as echarts from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { NgxEchartsDirective, provideEchartsCore } from 'ngx-echarts';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { LeagueStore } from '@app/store/league.store';
 import { buildClubIdentityTeamIndex } from '@app/utils/club-aliases';
 import { getWartimeSuspensionRanges } from '@app/utils/wartime-suspensions';
@@ -275,7 +275,7 @@ echarts.use([
 
 @Component({
   selector: 'app-movement-explorer',
-  imports: [CommonModule, NgxEchartsDirective],
+  imports: [CommonModule, RouterLink, NgxEchartsDirective],
   templateUrl: './movement-explorer.html',
   styleUrl: './movement-explorer.scss',
   providers: [provideEchartsCore({ echarts })],
@@ -836,6 +836,10 @@ export class MovementExplorer {
     this.selectedTeamIds.set([]);
     this.focusedTeamId.set(null);
     this.activeChartSetupId.set('');
+  }
+
+  primaryClubId(team: { clubIds?: string[] }): string | null {
+    return team.clubIds?.[0] ?? null;
   }
 
   onClubSearchInput(value: string) {

--- a/src/app/pages/team-deep-stats/team-deep-stats.html
+++ b/src/app/pages/team-deep-stats/team-deep-stats.html
@@ -1,0 +1,182 @@
+@if (!metadataLoaded()) { @if (loadFailed()) {
+<div class="loading loading--error app-page-shell" role="alert">
+  <p>Club deep stats could not load.</p>
+  <button type="button" mat-button (click)="retryArchiveLoad()">Retry</button>
+</div>
+} @else if (showLoadingState()) {
+<div class="loading app-page-shell" role="status" aria-live="polite">Loading deep stats...</div>
+} } @else if (!club()) {
+<section class="deep-stats app-surface app-page-shell">
+  <nav class="profile-top-actions" aria-label="Club deep stats actions">
+    <a class="back-link" routerLink="/teams">Back to clubs</a>
+  </nav>
+  <div class="empty-state app-panel">
+    <p class="app-page-eyebrow">Deep Stats</p>
+    <h1>Club not found</h1>
+    <p>The requested club identity is not available in the current metadata release.</p>
+  </div>
+</section>
+} @else {
+<section class="deep-stats app-surface app-page-shell">
+  <nav class="profile-top-actions" aria-label="Club deep stats actions">
+    <a class="back-link" [routerLink]="['/teams', clubId()]">Back to overview</a>
+    <div class="profile-action-links">
+      <button type="button" mat-button (click)="printPage()">Print</button>
+      <a mat-stroked-button routerLink="/teams">Club index</a>
+    </div>
+  </nav>
+
+  <header class="profile-header">
+    <p class="app-page-eyebrow">Deep Stats</p>
+    <h1 class="app-page-title">{{ club()!.canonicalName }}</h1>
+    <p class="app-page-lede">
+      Dense archive view for {{ deepStats().totals.seasons }} tracked table rows.
+    </p>
+  </header>
+
+  <section class="stat-grid" aria-label="Deep club summary">
+    <div class="stat-cell">
+      <span>Record</span>
+      <strong>
+        {{ deepStats().totals.won }}-{{ deepStats().totals.drawn }}-{{ deepStats().totals.lost }}
+      </strong>
+    </div>
+    <div class="stat-cell">
+      <span>Total Points</span>
+      <strong>{{ deepStats().totals.points }}</strong>
+    </div>
+    <div class="stat-cell">
+      <span>Goal Difference</span>
+      <strong>{{ signedNumber(deepStats().totals.goalDifference) }}</strong>
+    </div>
+    <div class="stat-cell">
+      <span>Points Per Game</span>
+      <strong>{{ formatDecimal(deepStats().totals.pointsPerGame) }}</strong>
+    </div>
+  </section>
+
+  <div class="deep-grid">
+    <section class="deep-panel app-panel">
+      <div class="panel-head">
+        <h2>Record Marks</h2>
+        <span>{{ deepStats().recordMarks.length }} marks</span>
+      </div>
+      <div class="mark-grid">
+        @for (mark of deepStats().recordMarks; track mark.label) {
+        <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(mark.season, mark.tier)">
+          <span>{{ mark.label }}</span>
+          <strong>{{ mark.value }}</strong>
+          <small>{{ mark.detail }}</small>
+        </a>
+        }
+      </div>
+    </section>
+
+    <section class="deep-panel app-panel">
+      <div class="panel-head">
+        <h2>Position Bands</h2>
+        <span>archive share</span>
+      </div>
+      <div class="band-grid">
+        @for (band of deepStats().positionBands; track band.label) {
+        <div>
+          <span>{{ band.label }}</span>
+          <strong>{{ band.count }}</strong>
+          <small>{{ band.detail }}</small>
+        </div>
+        }
+      </div>
+    </section>
+  </div>
+
+  <section class="deep-panel app-panel">
+    <div class="panel-head">
+      <h2>Tier Breakdown</h2>
+      <span>{{ deepStats().tierRows.length }} tiers</span>
+    </div>
+    <div class="data-table tier-table" role="table" aria-label="Club tier breakdown">
+      <div class="data-row data-head" role="row">
+        <span role="columnheader">Tier</span>
+        <span role="columnheader">Seasons</span>
+        <span role="columnheader">Range</span>
+        <span role="columnheader">Best</span>
+        <span role="columnheader">Avg Pos</span>
+        <span role="columnheader">Points</span>
+        <span role="columnheader">Moves</span>
+      </div>
+      @for (row of deepStats().tierRows; track row.tier) {
+      <div class="data-row" role="row">
+        <span role="cell">
+          <a class="app-club-link" [routerLink]="['/leagues', row.tier]">{{ row.tierLabel }}</a>
+        </span>
+        <span role="cell">{{ row.seasons }}</span>
+        <span role="cell">{{ row.firstSeason }}-{{ row.lastSeason }}</span>
+        <span role="cell">{{ ordinal(row.bestPosition) }} / {{ row.bestSeason }}</span>
+        <span role="cell">{{ formatDecimal(row.averagePosition) }}</span>
+        <span role="cell">{{ row.points }}</span>
+        <span role="cell">{{ row.movementEvents }}</span>
+      </div>
+      }
+    </div>
+  </section>
+
+  @if (deepStats().movementRows.length) {
+  <section class="deep-panel app-panel">
+    <div class="panel-head">
+      <h2>Movement Seasons</h2>
+      <span>{{ deepStats().movementRows.length }} markers</span>
+    </div>
+    <div class="movement-list">
+      @for (row of deepStats().movementRows; track row.season + row.tier) {
+      <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season, row.tier)">
+        <strong>{{ row.season }}</strong>
+        <span>{{ row.movementLabel }}</span>
+        <span>{{ row.tierLabel }} / {{ ordinal(row.position) }}</span>
+        <em>{{ row.points }} pts</em>
+      </a>
+      }
+    </div>
+  </section>
+  }
+
+  <section class="deep-panel app-panel">
+    <div class="panel-head">
+      <h2>Season Rows</h2>
+      <span>{{ deepStats().seasonRows.length }} rows</span>
+    </div>
+    <div class="data-table season-table" role="table" aria-label="Club season rows">
+      <div class="data-row data-head" role="row">
+        <span role="columnheader">Season</span>
+        <span role="columnheader">Name</span>
+        <span role="columnheader">Tier</span>
+        <span role="columnheader">Pos</span>
+        <span role="columnheader">P</span>
+        <span role="columnheader">W-D-L</span>
+        <span role="columnheader">GF-GA</span>
+        <span role="columnheader">GD</span>
+        <span role="columnheader">Pts</span>
+        <span role="columnheader">PPG</span>
+      </div>
+      @for (row of deepStats().seasonRows; track row.season + row.tier + row.teamName) {
+      <a
+        class="data-row"
+        role="row"
+        [routerLink]="['/tables']"
+        [queryParams]="tableQueryParams(row.season, row.tier)"
+      >
+        <span role="cell">{{ row.season }}</span>
+        <span role="cell">{{ row.teamName }}</span>
+        <span role="cell">{{ row.tierLabel }}</span>
+        <span role="cell">{{ ordinal(row.position) }}</span>
+        <span role="cell">{{ row.played }}</span>
+        <span role="cell">{{ row.won }}-{{ row.drawn }}-{{ row.lost }}</span>
+        <span role="cell">{{ row.goalsFor }}-{{ row.goalsAgainst }}</span>
+        <span role="cell">{{ signedNumber(row.goalDifference) }}</span>
+        <span role="cell">{{ row.points }}</span>
+        <span role="cell">{{ formatDecimal(row.pointsPerGame) }}</span>
+      </a>
+      }
+    </div>
+  </section>
+</section>
+}

--- a/src/app/pages/team-deep-stats/team-deep-stats.html
+++ b/src/app/pages/team-deep-stats/team-deep-stats.html
@@ -158,14 +158,21 @@
         <span role="columnheader">PPG</span>
       </div>
       @for (row of deepStats().seasonRows; track row.season + row.tier + row.teamName) {
-      <a
-        class="data-row"
-        role="row"
-        [routerLink]="['/tables']"
-        [queryParams]="tableQueryParams(row.season, row.tier)"
-      >
-        <span role="cell">{{ row.season }}</span>
-        <span role="cell">{{ row.teamName }}</span>
+      <div class="data-row" role="row">
+        <span role="cell">
+          <a
+            class="table-row-link"
+            [routerLink]="['/tables']"
+            [queryParams]="tableQueryParams(row.season, row.tier)"
+          >
+            {{ row.season }}
+          </a>
+        </span>
+        <span role="cell">
+          @if (row.clubId) {
+          <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.teamName }}</a>
+          } @else { {{ row.teamName }} }
+        </span>
         <span role="cell">{{ row.tierLabel }}</span>
         <span role="cell">{{ ordinal(row.position) }}</span>
         <span role="cell">{{ row.played }}</span>
@@ -174,7 +181,7 @@
         <span role="cell">{{ signedNumber(row.goalDifference) }}</span>
         <span role="cell">{{ row.points }}</span>
         <span role="cell">{{ formatDecimal(row.pointsPerGame) }}</span>
-      </a>
+      </div>
       }
     </div>
   </section>

--- a/src/app/pages/team-deep-stats/team-deep-stats.scss
+++ b/src/app/pages/team-deep-stats/team-deep-stats.scss
@@ -170,7 +170,7 @@
 
 .mark-grid a,
 .movement-list a,
-.season-table a {
+.table-row-link {
   color: inherit;
   text-decoration: none;
 }
@@ -179,8 +179,8 @@
 .mark-grid a:focus-visible,
 .movement-list a:hover,
 .movement-list a:focus-visible,
-.season-table a:hover,
-.season-table a:focus-visible {
+.season-table .data-row:hover,
+.season-table .data-row:focus-within {
   border-color: rgba(245, 158, 11, 0.48);
   background: rgba(245, 158, 11, 0.1);
 }
@@ -226,10 +226,9 @@
 }
 
 .season-table .data-row {
-  grid-template-columns: 74px minmax(150px, 1.1fr) minmax(
-      132px,
-      0.9fr
-    ) 64px 52px 86px 76px 58px 60px 60px;
+  grid-template-columns:
+    74px minmax(150px, 1.1fr) minmax(132px, 0.9fr)
+    64px 52px 86px 76px 58px 60px 60px;
 }
 
 .data-head {
@@ -324,10 +323,9 @@
   }
 
   .season-table .data-row {
-    grid-template-columns: 34pt minmax(72pt, 1.3fr) minmax(
-        58pt,
-        0.9fr
-      ) 28pt 24pt 40pt 38pt 28pt 30pt 30pt !important;
+    grid-template-columns:
+      34pt minmax(72pt, 1.3fr) minmax(58pt, 0.9fr)
+      28pt 24pt 40pt 38pt 28pt 30pt 30pt !important;
   }
 
   .mark-grid a,

--- a/src/app/pages/team-deep-stats/team-deep-stats.scss
+++ b/src/app/pages/team-deep-stats/team-deep-stats.scss
@@ -1,0 +1,366 @@
+:host {
+  display: block;
+}
+
+.loading,
+.empty-state {
+  color: var(--app-text-muted);
+}
+
+.deep-stats {
+  display: grid;
+  gap: 20px;
+}
+
+.profile-top-actions,
+.profile-action-links,
+.panel-head,
+.movement-list a {
+  display: flex;
+  align-items: center;
+}
+
+.profile-top-actions,
+.panel-head {
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.profile-action-links {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.back-link {
+  width: fit-content;
+  color: var(--app-text-muted);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  color: var(--app-text-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.profile-header {
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.profile-header .app-page-title {
+  margin: 8px 0;
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.05;
+}
+
+.stat-grid,
+.deep-grid,
+.mark-grid,
+.band-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.stat-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.deep-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.mark-grid,
+.band-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.stat-cell,
+.deep-panel {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(148, 163, 184, 0.06), transparent 90px),
+    color-mix(in srgb, var(--app-surface-bg) 86%, transparent);
+}
+
+.stat-cell {
+  min-height: 72px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 11px 12px;
+  display: grid;
+  align-content: center;
+  gap: 4px;
+}
+
+.deep-panel {
+  padding: 16px;
+}
+
+.stat-cell::before,
+.deep-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: rgba(217, 119, 6, 0.74);
+}
+
+.stat-cell:nth-child(2)::before,
+.deep-panel:nth-of-type(2)::before {
+  background: rgba(96, 165, 250, 0.72);
+}
+
+.stat-cell:nth-child(3)::before {
+  background: rgba(34, 197, 94, 0.72);
+}
+
+.stat-cell:nth-child(4)::before {
+  background: rgba(20, 184, 166, 0.72);
+}
+
+.stat-cell span,
+.panel-head span {
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stat-cell strong {
+  color: var(--app-text-strong);
+  font-size: 1.05rem;
+}
+
+.panel-head {
+  margin-bottom: 14px;
+  padding: 0 0 11px 6px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.26);
+}
+
+.panel-head h2 {
+  margin: 0;
+  color: var(--app-text-strong);
+  font-size: 1.02rem;
+}
+
+.mark-grid a,
+.band-grid div,
+.movement-list a,
+.data-row {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 7px;
+  background: rgba(7, 10, 19, 0.2);
+}
+
+.mark-grid a,
+.band-grid div {
+  min-height: 82px;
+  display: grid;
+  align-content: center;
+  gap: 4px;
+  padding: 10px 11px;
+}
+
+.mark-grid a,
+.movement-list a,
+.season-table a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.mark-grid a:hover,
+.mark-grid a:focus-visible,
+.movement-list a:hover,
+.movement-list a:focus-visible,
+.season-table a:hover,
+.season-table a:focus-visible {
+  border-color: rgba(245, 158, 11, 0.48);
+  background: rgba(245, 158, 11, 0.1);
+}
+
+.mark-grid span,
+.band-grid span {
+  color: var(--app-text-muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.mark-grid strong,
+.band-grid strong,
+.movement-list em {
+  color: var(--app-text-strong);
+  font-size: 1.05rem;
+  font-style: normal;
+  font-weight: 850;
+}
+
+.mark-grid small,
+.band-grid small {
+  color: var(--app-text-muted);
+}
+
+.data-table,
+.movement-list {
+  display: grid;
+  gap: 7px;
+}
+
+.data-row {
+  display: grid;
+  align-items: center;
+  gap: 10px;
+  min-height: 38px;
+  padding: 8px 10px;
+  color: var(--app-text-subtle);
+}
+
+.tier-table .data-row {
+  grid-template-columns: minmax(150px, 1fr) 78px 120px 112px 84px 82px 72px;
+}
+
+.season-table .data-row {
+  grid-template-columns: 74px minmax(150px, 1.1fr) minmax(
+      132px,
+      0.9fr
+    ) 64px 52px 86px 76px 58px 60px 60px;
+}
+
+.data-head {
+  min-height: 34px;
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(7, 10, 19, 0.38);
+}
+
+.movement-list a {
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 42px;
+  padding: 8px 10px;
+  color: var(--app-text-subtle);
+}
+
+@media (max-width: 980px) {
+  .profile-top-actions,
+  .panel-head,
+  .movement-list a {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .profile-action-links {
+    justify-content: flex-start;
+  }
+
+  .stat-grid,
+  .deep-grid,
+  .mark-grid,
+  .band-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .data-table {
+    gap: 10px;
+  }
+
+  .data-head {
+    display: none;
+  }
+
+  .tier-table .data-row,
+  .season-table .data-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+}
+
+@media print {
+  .deep-stats {
+    gap: 6pt;
+  }
+
+  .profile-top-actions {
+    display: none;
+  }
+
+  .deep-grid,
+  .mark-grid,
+  .band-grid,
+  .stat-grid {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 7pt 10pt !important;
+  }
+
+  .stat-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+  }
+
+  .data-table {
+    gap: 0;
+    font-size: 7.2pt;
+  }
+
+  .data-head {
+    display: grid !important;
+    border-bottom: 1px solid #000000 !important;
+    color: #000000;
+    font-size: 6.5pt;
+    letter-spacing: 0;
+  }
+
+  .tier-table .data-row {
+    grid-template-columns: minmax(84pt, 1.2fr) 34pt 58pt 58pt 42pt 42pt 34pt !important;
+  }
+
+  .season-table .data-row {
+    grid-template-columns: 34pt minmax(72pt, 1.3fr) minmax(
+        58pt,
+        0.9fr
+      ) 28pt 24pt 40pt 38pt 28pt 30pt 30pt !important;
+  }
+
+  .mark-grid a,
+  .band-grid div {
+    min-height: 0;
+    padding: 2pt 0 !important;
+  }
+
+  .movement-list a {
+    min-height: 0;
+    display: grid !important;
+    grid-template-columns: 34pt 52pt minmax(0, 1fr) 36pt !important;
+    align-items: center !important;
+    gap: 6pt !important;
+    padding: 2pt 0 !important;
+  }
+
+  .deep-panel,
+  .stat-cell,
+  .mark-grid a,
+  .band-grid div,
+  .movement-list a,
+  .data-row {
+    border-color: #dddddd;
+    background: #ffffff;
+  }
+
+  .deep-panel {
+    padding: 0;
+  }
+
+  .deep-panel::before,
+  .stat-cell::before {
+    display: none;
+  }
+}

--- a/src/app/pages/team-deep-stats/team-deep-stats.spec.ts
+++ b/src/app/pages/team-deep-stats/team-deep-stats.spec.ts
@@ -62,6 +62,12 @@ describe('TeamDeepStats', () => {
       link.textContent?.includes('2021')
     );
     expect(tableLink?.getAttribute('href')).toContain('/tables?season=2021&tier=tier1');
+
+    const clubLink = Array.from(element.querySelectorAll<HTMLAnchorElement>('a')).find(
+      (link) =>
+        link.textContent?.trim() === 'Alpha FC' && link.getAttribute('href')?.includes('/teams/')
+    );
+    expect(clubLink?.getAttribute('href')).toBe('/teams/alpha%20fc');
   });
 });
 

--- a/src/app/pages/team-deep-stats/team-deep-stats.spec.ts
+++ b/src/app/pages/team-deep-stats/team-deep-stats.spec.ts
@@ -1,0 +1,146 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { ClubMetadataStore } from '@app/store/club-metadata.store';
+import { LeagueStore } from '@app/store/league.store';
+import { DataLoaderService } from '@app/store/services/hydrate-store-json';
+import { of } from 'rxjs';
+import { TeamDeepStats } from './team-deep-stats';
+
+describe('TeamDeepStats', () => {
+  let fixture: ComponentFixture<TeamDeepStats>;
+  let leagueStore: InstanceType<typeof LeagueStore>;
+  let clubMetadataStore: InstanceType<typeof ClubMetadataStore>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TeamDeepStats],
+      providers: [
+        LeagueStore,
+        ClubMetadataStore,
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({ clubId: 'alpha fc' })),
+            snapshot: {
+              paramMap: convertToParamMap({ clubId: 'alpha fc' }),
+            },
+          },
+        },
+        {
+          provide: DataLoaderService,
+          useValue: {
+            loadStatus: signal('loaded'),
+            loadError: signal(null),
+            showLoadingState: signal(false),
+            loadData: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    leagueStore = TestBed.inject(LeagueStore);
+    clubMetadataStore = TestBed.inject(ClubMetadataStore);
+    clubMetadataStore.hydrate(clubMetadataFixture());
+    leagueStore.hydrate(teamStatsFixture(), (teamName: string) =>
+      teamName === 'Alpha FC' ? 'alpha fc' : null
+    );
+    fixture = TestBed.createComponent(TeamDeepStats);
+    fixture.detectChanges();
+  });
+
+  it('renders dense club sections with season table links', () => {
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(element.textContent).toContain('Alpha FC');
+    expect(element.textContent).toContain('Record Marks');
+    expect(element.textContent).toContain('Tier Breakdown');
+    expect(element.textContent).toContain('Season Rows');
+
+    const tableLink = Array.from(element.querySelectorAll<HTMLAnchorElement>('a')).find((link) =>
+      link.textContent?.includes('2021')
+    );
+    expect(tableLink?.getAttribute('href')).toContain('/tables?season=2021&tier=tier1');
+  });
+});
+
+function clubMetadataFixture() {
+  return {
+    metadata: {
+      schemaVersion: 1,
+      generator: 'test',
+      generatedAt: '2026-06-18T00:00:00.000Z',
+      gitSha: 'test',
+    },
+    clubs: {
+      'alpha fc': {
+        canonicalName: 'Alpha FC',
+        derived: {
+          source: 'test',
+          aliases: ['Alpha FC'],
+          observedNames: [
+            {
+              rawName: 'Alpha FC',
+              normalizedName: 'alpha fc',
+              firstSeenSeason: 2020,
+              lastSeenSeason: 2021,
+              seasonsSeen: [2020, 2021],
+              tiersSeen: ['tier1'],
+            },
+          ],
+          observedNamePeriods: [{ name: 'Alpha FC', startSeason: 2020, endSeason: 2021 }],
+          firstSeenSeason: 2020,
+          lastSeenSeason: 2021,
+          seasonsSeen: [2020, 2021],
+          totalSeasonsSeen: 2,
+          tiersSeen: ['tier1'],
+          tierSeasons: [{ tierKey: 'tier1', seasons: [2020, 2021] }],
+        },
+      },
+    },
+  };
+}
+
+function teamStatsFixture() {
+  return {
+    seasons: {
+      2020: {
+        tier1: [row('Alpha FC', 2, 80, 70, 30, false, false)],
+      },
+      2021: {
+        tier1: [row('Alpha FC', 1, 91, 86, 28, false, false)],
+      },
+    },
+  };
+}
+
+function row(
+  team: string,
+  pos: number,
+  points: number,
+  goalsFor: number,
+  goalsAgainst: number,
+  wasRelegated: boolean,
+  wasPromoted: boolean
+) {
+  return {
+    team,
+    pos,
+    played: 38,
+    won: 20,
+    drawn: 8,
+    lost: 10,
+    goalsFor,
+    goalsAgainst,
+    goalDifference: goalsFor - goalsAgainst,
+    goalAverage: null,
+    points,
+    notes: null,
+    wasRelegated,
+    wasPromoted,
+    isExpansionTeam: false,
+    wasReElected: false,
+    wasReprieved: false,
+  };
+}

--- a/src/app/pages/team-deep-stats/team-deep-stats.ts
+++ b/src/app/pages/team-deep-stats/team-deep-stats.ts
@@ -1,0 +1,100 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { LeagueTierToStringyPipe } from '@app/pipes/league-tier-to-stringy-pipe';
+import { ClubMetadataStore } from '@app/store/club-metadata.store';
+import { LeagueStore } from '@app/store/league.store';
+import { DataLoaderService } from '@app/store/services/hydrate-store-json';
+import { buildTeamDeepStatsData } from '@app/utils/team-deep-stats';
+
+@Component({
+  selector: 'app-team-deep-stats',
+  imports: [CommonModule, MatButtonModule, RouterLink],
+  providers: [LeagueTierToStringyPipe],
+  templateUrl: './team-deep-stats.html',
+  styleUrl: './team-deep-stats.scss',
+})
+export class TeamDeepStats {
+  private route = inject(ActivatedRoute);
+  private clubMetadataStore = inject(ClubMetadataStore);
+  private leagueStore = inject(LeagueStore);
+  private dataLoader = inject(DataLoaderService);
+  private tierLabelPipe = inject(LeagueTierToStringyPipe);
+  private paramMap = toSignal(this.route.paramMap, {
+    initialValue: this.route.snapshot.paramMap,
+  });
+
+  clubId = computed(() => this.paramMap().get('clubId') ?? '');
+  metadataLoaded = computed(() => Boolean(this.clubMetadataStore.getGeneratedAt()));
+  showLoadingState = computed(() => !this.metadataLoaded() && this.dataLoader.showLoadingState());
+  loadFailed = computed(() => !this.metadataLoaded() && this.dataLoader.loadStatus() === 'error');
+  club = computed(() => this.clubMetadataStore.getClubById(this.clubId()));
+  entries = computed(() =>
+    this.leagueStore
+      .getEntriesByClubId(this.clubId())
+      .slice()
+      .sort((a, b) => b.season - a.season || this.tierRank(a.tier) - this.tierRank(b.tier))
+  );
+  deepStats = computed(() =>
+    buildTeamDeepStatsData(
+      this.entries(),
+      (teamId) => this.leagueStore.getTeamNameById(teamId),
+      (tier) => this.tierLabel(tier)
+    )
+  );
+
+  retryArchiveLoad() {
+    void this.dataLoader.loadData();
+  }
+
+  tableQueryParams(season: number, tier: string): { season: number; tier: string } {
+    return { season, tier };
+  }
+
+  tierLabel(tier: string): string {
+    const label = this.tierLabelPipe.transform(tier);
+    if (label) {
+      return label;
+    }
+
+    const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+    return Number.isFinite(parsed) ? `Tier ${parsed}` : tier;
+  }
+
+  ordinal(value: number): string {
+    const mod100 = value % 100;
+    if (mod100 >= 11 && mod100 <= 13) {
+      return `${value}th`;
+    }
+
+    const suffixByMod10: Record<number, string> = {
+      1: 'st',
+      2: 'nd',
+      3: 'rd',
+    };
+    return `${value}${suffixByMod10[value % 10] ?? 'th'}`;
+  }
+
+  signedNumber(value: number | null): string {
+    if (value === null) {
+      return 'No data';
+    }
+
+    return value > 0 ? `+${value}` : String(value);
+  }
+
+  formatDecimal(value: number | null): string {
+    return value === null ? 'No data' : value.toFixed(2);
+  }
+
+  printPage() {
+    globalThis.print?.();
+  }
+
+  private tierRank(tier: string): number {
+    const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+    return Number.isFinite(parsed) ? parsed : 99;
+  }
+}

--- a/src/app/pages/team-overview/team-overview.html
+++ b/src/app/pages/team-overview/team-overview.html
@@ -227,7 +227,7 @@
           <span>{{ relationshipLabel(relationship.relationship, relationship.direction) }}</span>
           <strong>
             @if (relationship.relatedClubId) {
-            <a [routerLink]="['/teams', relationship.relatedClubId]">
+            <a class="app-club-link" [routerLink]="['/teams', relationship.relatedClubId]">
               {{ relationship.relatedName }}
             </a>
             } @else { {{ relationship.relatedName }} }
@@ -274,7 +274,13 @@
       @for (entry of recentSeasonRows(); track entry.season + entry.tier + entry.teamName) {
       <div class="recent-row">
         <span data-label="Season">{{ entry.season }}</span>
-        <span data-label="Name">{{ entry.teamName }}</span>
+        <span data-label="Name">
+          @if (entry.clubId) {
+          <a class="app-club-link recent-team-link" [routerLink]="['/teams', entry.clubId]">
+            {{ entry.teamName }}
+          </a>
+          } @else { {{ entry.teamName }} }
+        </span>
         <span data-label="Tier">{{ tierLabel(entry.tier) }}</span>
         <span data-label="Position">{{ ordinal(entry.pos) }}</span>
         <span data-label="Record">{{ entry.won }}-{{ entry.drawn }}-{{ entry.lost }}</span>
@@ -294,7 +300,13 @@
       <article class="mobile-recent-card">
         <div class="mobile-recent-main">
           <strong>{{ entry.season }}</strong>
+          @if (entry.clubId) {
+          <a class="app-club-link recent-team-link" [routerLink]="['/teams', entry.clubId]">
+            {{ entry.teamName }}
+          </a>
+          } @else {
           <span>{{ entry.teamName }}</span>
+          }
         </div>
         <div class="mobile-recent-facts">
           <span>{{ tierLabel(entry.tier) }} / {{ ordinal(entry.pos) }}</span>

--- a/src/app/pages/team-overview/team-overview.html
+++ b/src/app/pages/team-overview/team-overview.html
@@ -89,7 +89,9 @@
         @for (row of compactSeasonRows(); track row.season + row.tierLabel) {
         <div>
           <strong>{{ row.season }}</strong>
-          <span>{{ row.tierLabel }}</span>
+          <span>
+            <a class="app-club-link" [routerLink]="['/leagues', row.tier]">{{ row.tierLabel }}</a>
+          </span>
           <span>{{ row.positionLabel }}</span>
           <span>{{ row.recordLabel }}</span>
           @if (row.movementLabel) {
@@ -163,7 +165,9 @@
       <div class="tier-list">
         @for (tier of tierSummary(); track tier.tier) {
         <div class="tier-row">
-          <span>{{ tier.label }}</span>
+          <span>
+            <a class="app-club-link" [routerLink]="['/leagues', tier.tier]">{{ tier.label }}</a>
+          </span>
           <strong>{{ tier.count }}</strong>
         </div>
         }
@@ -281,7 +285,11 @@
           </a>
           } @else { {{ entry.teamName }} }
         </span>
-        <span data-label="Tier">{{ tierLabel(entry.tier) }}</span>
+        <span data-label="Tier">
+          <a class="app-club-link" [routerLink]="['/leagues', entry.tier]">
+            {{ tierLabel(entry.tier) }}
+          </a>
+        </span>
         <span data-label="Position">{{ ordinal(entry.pos) }}</span>
         <span data-label="Record">{{ entry.won }}-{{ entry.drawn }}-{{ entry.lost }}</span>
         <span data-label="Points">{{ entry.points }}</span>
@@ -309,7 +317,12 @@
           }
         </div>
         <div class="mobile-recent-facts">
-          <span>{{ tierLabel(entry.tier) }} / {{ ordinal(entry.pos) }}</span>
+          <span>
+            <a class="app-club-link" [routerLink]="['/leagues', entry.tier]">
+              {{ tierLabel(entry.tier) }}
+            </a>
+            / {{ ordinal(entry.pos) }}
+          </span>
           <span>{{ entry.won }}-{{ entry.drawn }}-{{ entry.lost }} / {{ entry.points }} pts</span>
         </div>
         <app-data-issue-report-dialog

--- a/src/app/pages/team-overview/team-overview.html
+++ b/src/app/pages/team-overview/team-overview.html
@@ -28,12 +28,15 @@
     <a class="back-link" routerLink="/teams" [queryParams]="backToTeamsQueryParams()">
       Back to clubs
     </a>
-    <app-data-issue-report-dialog
-      class="header-report"
-      triggerLabel="Flag club data"
-      triggerStyle="link"
-      [context]="dataIssueContext()"
-    />
+    <div class="profile-action-links">
+      <a mat-button [routerLink]="['/teams', clubId(), 'deep-stats']">Deep stats</a>
+      <app-data-issue-report-dialog
+        class="header-report"
+        triggerLabel="Flag club data"
+        triggerStyle="link"
+        [context]="dataIssueContext()"
+      />
+    </div>
   </div>
 
   <header class="profile-header">

--- a/src/app/pages/team-overview/team-overview.html
+++ b/src/app/pages/team-overview/team-overview.html
@@ -1,6 +1,11 @@
-@if (!metadataLoaded()) {
-<div class="loading app-page-shell">Loading club profile...</div>
-} @else if (!club()) {
+@if (!metadataLoaded()) { @if (loadFailed()) {
+<div class="loading loading--error app-page-shell" role="alert">
+  <p>Club profile data could not load.</p>
+  <button type="button" mat-button (click)="retryArchiveLoad()">Retry</button>
+</div>
+} @else if (showLoadingState()) {
+<div class="loading app-page-shell" role="status" aria-live="polite">Loading club profile...</div>
+} } @else if (!club()) {
 <section class="team-overview app-surface app-page-shell">
   <div class="profile-top-actions">
     <a class="back-link" routerLink="/teams" [queryParams]="backToTeamsQueryParams()">

--- a/src/app/pages/team-overview/team-overview.scss
+++ b/src/app/pages/team-overview/team-overview.scss
@@ -19,6 +19,14 @@
   gap: 16px;
 }
 
+.profile-action-links {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .back-link {
   width: fit-content;
   color: var(--app-text-muted);

--- a/src/app/pages/team-overview/team-overview.scss
+++ b/src/app/pages/team-overview/team-overview.scss
@@ -323,17 +323,6 @@
   font-size: 0.95rem;
 }
 
-.relationship-list a {
-  color: inherit;
-  text-decoration: none;
-  text-underline-offset: 3px;
-}
-
-.relationship-list a:hover {
-  color: #fde68a;
-  text-decoration: underline;
-}
-
 .historical-status {
   gap: 9px;
   border: 1px solid var(--app-border);

--- a/src/app/pages/team-overview/team-overview.spec.ts
+++ b/src/app/pages/team-overview/team-overview.spec.ts
@@ -1,4 +1,6 @@
 import { signal, type WritableSignal } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { convertToParamMap, ActivatedRoute } from '@angular/router';
 import { provideRouter } from '@angular/router';
@@ -60,6 +62,8 @@ describe('TeamOverview', () => {
             loadData: loadDataSpy,
           },
         },
+        provideHttpClient(),
+        provideHttpClientTesting(),
         provideRouter([]),
       ],
     }).compileComponents();
@@ -107,6 +111,33 @@ describe('TeamOverview', () => {
     component.teamsReturnFilter.set('top-flight');
 
     expect(component.backToTeamsQueryParams()).toEqual({ letter: 'A', filter: 'top-flight' });
+  });
+
+  it('links to the club deep stats route', () => {
+    component.club = (() => ({
+      clubId: 'alpha fc',
+      canonicalName: 'Alpha FC',
+      derived: {
+        source: 'football-data-output',
+        aliases: ['Alpha FC'],
+        observedNames: [],
+        observedNamePeriods: [],
+        firstSeenSeason: 2020,
+        lastSeenSeason: 2025,
+        seasonsSeen: [],
+        totalSeasonsSeen: 1,
+        tiersSeen: [],
+        tierSeasons: [],
+      },
+    })) as unknown as typeof component.club;
+    component.metadataLoaded = (() => true) as typeof component.metadataLoaded;
+    component.clubId = (() => 'alpha fc') as typeof component.clubId;
+    fixture.detectChanges();
+
+    const links = Array.from(fixture.nativeElement.querySelectorAll<HTMLAnchorElement>('a'));
+    const deepStatsLink = links.find((link) => link.textContent?.includes('Deep stats'));
+
+    expect(deepStatsLink?.getAttribute('href')).toBe('/teams/alpha%20fc/deep-stats');
   });
 
   it('labels identity periods ending in the latest tracked season as current', () => {

--- a/src/app/pages/team-overview/team-overview.spec.ts
+++ b/src/app/pages/team-overview/team-overview.spec.ts
@@ -1,6 +1,8 @@
+import { signal, type WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { convertToParamMap, ActivatedRoute } from '@angular/router';
 import { provideRouter } from '@angular/router';
+import { DataLoaderService, type DataLoadStatus } from '@app/store/services/hydrate-store-json';
 import { of } from 'rxjs';
 import { TeamOverview } from './team-overview';
 
@@ -28,8 +30,15 @@ jest.mock('ngx-echarts', () => {
 describe('TeamOverview', () => {
   let component: TeamOverview;
   let fixture: ComponentFixture<TeamOverview>;
+  let loadStatus: WritableSignal<DataLoadStatus>;
+  let showLoadingState: WritableSignal<boolean>;
+  let loadDataSpy: jest.Mock;
 
   beforeEach(async () => {
+    loadStatus = signal<DataLoadStatus>('idle');
+    showLoadingState = signal(false);
+    loadDataSpy = jest.fn().mockResolvedValue(undefined);
+
     await TestBed.configureTestingModule({
       imports: [TeamOverview],
       providers: [
@@ -40,6 +49,15 @@ describe('TeamOverview', () => {
             snapshot: {
               paramMap: convertToParamMap({ clubId: 'alpha fc' }),
             },
+          },
+        },
+        {
+          provide: DataLoaderService,
+          useValue: {
+            loadStatus,
+            loadError: signal(null),
+            showLoadingState,
+            loadData: loadDataSpy,
           },
         },
         provideRouter([]),
@@ -53,6 +71,35 @@ describe('TeamOverview', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('does not show a profile loading banner until the loader discloses slow loading', () => {
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(element.querySelector('.loading')).toBeNull();
+
+    loadStatus.set('loading');
+    showLoadingState.set(true);
+    fixture.detectChanges();
+
+    expect(element.querySelector('[role="status"]')?.textContent).toContain(
+      'Loading club profile...'
+    );
+  });
+
+  it('shows a retryable error state when profile data fails to load', () => {
+    loadStatus.set('error');
+    fixture.detectChanges();
+
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(element.querySelector('[role="alert"]')?.textContent).toContain(
+      'Club profile data could not load.'
+    );
+
+    element.querySelector<HTMLButtonElement>('button')?.click();
+
+    expect(loadDataSpy).toHaveBeenCalledTimes(1);
   });
 
   it('builds a teams back link query param from hidden navigation state', () => {

--- a/src/app/pages/team-overview/team-overview.ts
+++ b/src/app/pages/team-overview/team-overview.ts
@@ -76,6 +76,7 @@ interface SnapshotFact {
 
 interface CompactSeasonRow {
   season: number;
+  tier: string;
   tierLabel: string;
   positionLabel: string;
   recordLabel: string;
@@ -385,6 +386,7 @@ export class TeamOverview implements AfterViewInit, OnDestroy {
   compactSeasonRows = computed<CompactSeasonRow[]>(() =>
     this.entriesAscending().map((entry) => ({
       season: entry.season,
+      tier: entry.tier,
       tierLabel: this.tierLabel(entry.tier),
       positionLabel: this.ordinal(entry.pos),
       recordLabel: `${entry.won}-${entry.drawn}-${entry.lost}`,

--- a/src/app/pages/team-overview/team-overview.ts
+++ b/src/app/pages/team-overview/team-overview.ts
@@ -10,6 +10,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { LineChart } from 'echarts/charts';
 import { GridComponent, MarkAreaComponent, TooltipComponent } from 'echarts/components';
@@ -21,6 +22,7 @@ import { DataIssueReportDialog } from '@app/components/data-issue-report-dialog/
 import type { LeagueTableEntry } from '@app/store/league.models';
 import { ClubMetadataStore } from '@app/store/club-metadata.store';
 import { LeagueStore } from '@app/store/league.store';
+import { DataLoaderService } from '@app/store/services/hydrate-store-json';
 import { isTeamDirectoryFilter, type TeamDirectoryFilter } from '@app/types';
 import type { DataIssueReportContext } from '@app/utils/data-issue-report';
 import {
@@ -104,7 +106,7 @@ echarts.use([LineChart, GridComponent, TooltipComponent, MarkAreaComponent, Canv
 
 @Component({
   selector: 'app-team-overview',
-  imports: [CommonModule, RouterLink, NgxEchartsDirective, DataIssueReportDialog],
+  imports: [CommonModule, MatButtonModule, RouterLink, NgxEchartsDirective, DataIssueReportDialog],
   providers: [provideEchartsCore({ echarts })],
   templateUrl: './team-overview.html',
   styleUrl: './team-overview.scss',
@@ -114,6 +116,7 @@ export class TeamOverview implements AfterViewInit, OnDestroy {
   private router = inject(Router);
   private clubMetadataStore = inject(ClubMetadataStore);
   private leagueStore = inject(LeagueStore);
+  private dataLoader = inject(DataLoaderService);
   private historyPanelObserver?: ResizeObserver;
 
   @ViewChild('historyPanel') private historyPanel?: ElementRef<HTMLElement>;
@@ -124,6 +127,8 @@ export class TeamOverview implements AfterViewInit, OnDestroy {
 
   clubId = computed(() => this.paramMap().get('clubId') ?? '');
   metadataLoaded = computed(() => Boolean(this.clubMetadataStore.getGeneratedAt()));
+  showLoadingState = computed(() => !this.metadataLoaded() && this.dataLoader.showLoadingState());
+  loadFailed = computed(() => !this.metadataLoaded() && this.dataLoader.loadStatus() === 'error');
   milestonesExpanded = signal(false);
   milestoneCollapsedHeight = signal<number | null>(null);
   teamsReturnLetter = signal(this.readTeamsReturnLetter());
@@ -258,6 +263,10 @@ export class TeamOverview implements AfterViewInit, OnDestroy {
       season: entry.season,
       competition: this.tierLabel(entry.tier),
     };
+  }
+
+  retryArchiveLoad() {
+    void this.dataLoader.loadData();
   }
 
   identityPeriodRangeLabel(period: ClubDisplayNamePeriod): string {

--- a/src/app/pages/teams/teams.html
+++ b/src/app/pages/teams/teams.html
@@ -1,6 +1,11 @@
-@if (!teams().length) {
-<div class="loading">Loading teams...</div>
-} @else {
+@if (!teams().length) { @if (loadFailed()) {
+<div class="loading loading--error app-page-shell" role="alert">
+  <p>Club directory could not load.</p>
+  <button type="button" mat-button (click)="retryArchiveLoad()">Retry</button>
+</div>
+} @else if (showLoadingState()) {
+<div class="loading app-page-shell" role="status" aria-live="polite">Loading teams...</div>
+} } @else {
 <section class="teams-archive app-surface app-page-shell">
   <header class="app-page-header">
     <p class="app-page-eyebrow">Club Directory</p>

--- a/src/app/pages/teams/teams.scss
+++ b/src/app/pages/teams/teams.scss
@@ -10,6 +10,15 @@
   color: var(--app-text-muted);
 }
 
+.loading p {
+  margin: 0;
+}
+
+.loading button {
+  margin-top: 10px;
+  --mdc-text-button-label-text-color: var(--app-text-strong);
+}
+
 .teams-archive {
   margin-top: 6px;
 }

--- a/src/app/pages/teams/teams.spec.ts
+++ b/src/app/pages/teams/teams.spec.ts
@@ -1,5 +1,7 @@
+import { signal, type WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap, Router, provideRouter } from '@angular/router';
+import { DataLoaderService, type DataLoadStatus } from '@app/store/services/hydrate-store-json';
 import { of } from 'rxjs';
 
 import { Teams } from './teams';
@@ -8,8 +10,15 @@ describe('Teams', () => {
   let component: Teams;
   let fixture: ComponentFixture<Teams>;
   let router: Router;
+  let loadStatus: WritableSignal<DataLoadStatus>;
+  let showLoadingState: WritableSignal<boolean>;
+  let loadDataSpy: jest.Mock;
 
   beforeEach(async () => {
+    loadStatus = signal<DataLoadStatus>('idle');
+    showLoadingState = signal(false);
+    loadDataSpy = jest.fn().mockResolvedValue(undefined);
+
     await TestBed.configureTestingModule({
       imports: [Teams],
       providers: [
@@ -19,6 +28,15 @@ describe('Teams', () => {
           useValue: {
             queryParamMap: of(convertToParamMap({ letter: 'm', filter: 'historical' })),
             snapshot: { queryParamMap: convertToParamMap({ letter: 'm', filter: 'historical' }) },
+          },
+        },
+        {
+          provide: DataLoaderService,
+          useValue: {
+            loadStatus,
+            loadError: signal(null),
+            showLoadingState,
+            loadData: loadDataSpy,
           },
         },
       ],
@@ -92,5 +110,32 @@ describe('Teams', () => {
       queryParamsHandling: 'merge',
       replaceUrl: true,
     });
+  });
+
+  it('does not show a loading banner until the loader discloses slow loading', () => {
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(element.querySelector('.loading')).toBeNull();
+
+    loadStatus.set('loading');
+    showLoadingState.set(true);
+    fixture.detectChanges();
+
+    expect(element.querySelector('[role="status"]')?.textContent).toContain('Loading teams...');
+  });
+
+  it('shows a retryable error state when the club directory fails to load', () => {
+    loadStatus.set('error');
+    fixture.detectChanges();
+
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(element.querySelector('[role="alert"]')?.textContent).toContain(
+      'Club directory could not load.'
+    );
+
+    element.querySelector<HTMLButtonElement>('button')?.click();
+
+    expect(loadDataSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/pages/teams/teams.ts
+++ b/src/app/pages/teams/teams.ts
@@ -1,9 +1,11 @@
 import { Component, computed, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TeamList } from '@app/components/team-list/team-list';
 import { ClubMetadataStore } from '@app/store/club-metadata.store';
 import { LeagueStore } from '@app/store/league.store';
+import { DataLoaderService } from '@app/store/services/hydrate-store-json';
 import {
   isTeamDirectoryFilter,
   type TeamDirectoryCategory,
@@ -13,13 +15,14 @@ import {
 
 @Component({
   selector: 'app-teams',
-  imports: [TeamList],
+  imports: [MatButtonModule, TeamList],
   templateUrl: './teams.html',
   styleUrl: './teams.scss',
 })
 export class Teams {
   private store = inject(LeagueStore);
   private clubMetadataStore = inject(ClubMetadataStore);
+  private dataLoader = inject(DataLoaderService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
@@ -85,6 +88,8 @@ export class Teams {
     const filter = this.queryParamMap().get('filter') ?? 'all';
     return isTeamDirectoryFilter(filter) ? filter : 'all';
   });
+  showLoadingState = computed(() => !this.teams().length && this.dataLoader.showLoadingState());
+  loadFailed = computed(() => !this.teams().length && this.dataLoader.loadStatus() === 'error');
 
   onLetterSelected(letter: string) {
     void this.router.navigate([], {
@@ -111,5 +116,9 @@ export class Teams {
       queryParamsHandling: 'merge',
       replaceUrl: true,
     });
+  }
+
+  retryArchiveLoad() {
+    void this.dataLoader.loadData();
   }
 }

--- a/src/app/pages/tier-profile/tier-profile.html
+++ b/src/app/pages/tier-profile/tier-profile.html
@@ -7,9 +7,9 @@
 <div class="loading app-page-shell" role="status" aria-live="polite">Loading tier profile...</div>
 } } @else if (!profile()) {
 <section class="tier-profile app-surface app-page-shell">
-  <div class="profile-top-actions">
+  <nav class="profile-top-actions" aria-label="Tier profile actions">
     <a class="back-link" routerLink="/tables">Back to tables</a>
-  </div>
+  </nav>
   <div class="empty-state app-panel">
     <p class="app-page-eyebrow">Tier Profile</p>
     <h1>Tier not found</h1>
@@ -18,9 +18,20 @@
 </section>
 } @else {
 <section class="tier-profile app-surface app-page-shell">
-  <div class="profile-top-actions">
+  <nav class="profile-top-actions" aria-label="Tier profile actions">
     <a class="back-link" routerLink="/tables">Back to tables</a>
-  </div>
+    <div class="profile-action-links">
+      @if (latestTableQueryParams(); as latestTableParams) {
+      <a mat-stroked-button routerLink="/tables" [queryParams]="latestTableParams">
+        View latest table
+      </a>
+      } @if (upperTierId(); as upperTier) {
+      <a mat-button [routerLink]="['/leagues', upperTier]">Tier above</a>
+      } @if (lowerTierId(); as lowerTier) {
+      <a mat-button [routerLink]="['/leagues', lowerTier]">Tier below</a>
+      }
+    </div>
+  </nav>
 
   <header class="profile-header">
     <p class="app-page-eyebrow">Tier Profile</p>
@@ -30,6 +41,20 @@
       from {{ seasonRangeLabel() }}.
     </p>
   </header>
+
+  @if (dataNotices().length) {
+  <section class="data-notice-stack" aria-label="Data classification notes">
+    @for (notice of dataNotices(); track notice.id) {
+    <aside class="data-notice" role="note">
+      <div>
+        <strong>{{ notice.title }}</strong>
+        <p>{{ notice.detail }}</p>
+      </div>
+      <span>Affected seasons: {{ notice.seasonsLabel }}</span>
+    </aside>
+    }
+  </section>
+  }
 
   <section class="stat-grid" aria-label="Tier record summary">
     <div class="stat-cell">
@@ -50,6 +75,27 @@
         {{ profile()!.promotionInCount }} promotions / {{ profile()!.relegationOutCount }}
         relegations
       </strong>
+    </div>
+  </section>
+
+  <section class="era-filter-panel app-panel" aria-label="Season era filters">
+    <div class="era-filter-copy">
+      <h2>Era View</h2>
+      <p>{{ selectedEraSummary() }}</p>
+    </div>
+    <div class="era-filter-list">
+      @for (filter of availableEraFilters(); track filter.id) {
+      <a
+        [routerLink]="[]"
+        [queryParams]="eraQueryParams(filter.id)"
+        queryParamsHandling="merge"
+        [class.is-active]="selectedEraFilter().id === filter.id"
+        [attr.aria-current]="selectedEraFilter().id === filter.id ? 'page' : null"
+      >
+        <strong>{{ filter.label }}</strong>
+        <span>{{ filter.detail }}</span>
+      </a>
+      }
     </div>
   </section>
 
@@ -112,11 +158,29 @@
           <h3>Title races</h3>
           <div class="race-list">
             @for (row of raceRows(profile()!.closeTitleRaces); track row.season) {
-            <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
-              <strong>{{ row.season }}</strong>
-              <span>{{ row.primaryName }} over {{ row.secondaryName }}</span>
+            <div class="race-row">
+              <a
+                class="race-season-link"
+                [routerLink]="['/tables']"
+                [queryParams]="tableQueryParams(row.season)"
+              >
+                {{ row.season }}
+              </a>
+              <span class="race-matchup">
+                @if (row.primaryClubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
+                  {{ row.primaryName }}
+                </a>
+                } @else { {{ row.primaryName }} }
+                <span>over</span>
+                @if (row.secondaryClubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
+                  {{ row.secondaryName }}
+                </a>
+                } @else { {{ row.secondaryName }} }
+              </span>
               <em>{{ row.detail }}</em>
-            </a>
+            </div>
             }
           </div>
         </section>
@@ -126,11 +190,29 @@
           @if (raceRows(profile()!.closeSurvivalRaces).length) {
           <div class="race-list">
             @for (row of raceRows(profile()!.closeSurvivalRaces); track row.season) {
-            <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
-              <strong>{{ row.season }}</strong>
-              <span>{{ row.primaryName }} above {{ row.secondaryName }}</span>
+            <div class="race-row">
+              <a
+                class="race-season-link"
+                [routerLink]="['/tables']"
+                [queryParams]="tableQueryParams(row.season)"
+              >
+                {{ row.season }}
+              </a>
+              <span class="race-matchup">
+                @if (row.primaryClubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
+                  {{ row.primaryName }}
+                </a>
+                } @else { {{ row.primaryName }} }
+                <span>above</span>
+                @if (row.secondaryClubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
+                  {{ row.secondaryName }}
+                </a>
+                } @else { {{ row.secondaryName }} }
+              </span>
               <em>{{ row.detail }}</em>
-            </a>
+            </div>
             }
           </div>
           } @else {
@@ -143,11 +225,29 @@
           @if (raceRows(profile()!.closePromotionRaces).length) {
           <div class="race-list">
             @for (row of raceRows(profile()!.closePromotionRaces); track row.season) {
-            <a [routerLink]="['/tables']" [queryParams]="sourceTableQueryParams(row.season)">
-              <strong>{{ row.season }}</strong>
-              <span>{{ row.primaryName }} over {{ row.secondaryName }}</span>
+            <div class="race-row">
+              <a
+                class="race-season-link"
+                [routerLink]="['/tables']"
+                [queryParams]="sourceTableQueryParams(row.season)"
+              >
+                {{ row.season }}
+              </a>
+              <span class="race-matchup">
+                @if (row.primaryClubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
+                  {{ row.primaryName }}
+                </a>
+                } @else { {{ row.primaryName }} }
+                <span>over</span>
+                @if (row.secondaryClubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
+                  {{ row.secondaryName }}
+                </a>
+                } @else { {{ row.secondaryName }} }
+              </span>
               <em>{{ row.detail }}</em>
-            </a>
+            </div>
             }
           </div>
           } @else {
@@ -185,11 +285,24 @@
       </div>
       <div class="mark-list">
         @for (row of profile()!.notableSeasons; track row.label) {
-        <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
-          <span>{{ row.label }}</span>
-          <strong>{{ row.value }}</strong>
-          <small>{{ row.season }} / {{ row.teamName }}</small>
-        </a>
+        <div class="mark-row">
+          <a
+            class="mark-table-link"
+            [routerLink]="['/tables']"
+            [queryParams]="tableQueryParams(row.season)"
+          >
+            <span class="mark-label">{{ row.label }}</span>
+            <strong class="mark-value">{{ row.value }}</strong>
+            <small class="mark-season">{{ row.season }}</small>
+          </a>
+          @if (row.clubId) {
+          <a class="app-club-link mark-club-link" [routerLink]="['/teams', row.clubId]">
+            {{ row.teamName }}
+          </a>
+          } @else {
+          <small>{{ row.teamName }}</small>
+          }
+        </div>
         }
       </div>
     </section>

--- a/src/app/pages/tier-profile/tier-profile.html
+++ b/src/app/pages/tier-profile/tier-profile.html
@@ -21,6 +21,7 @@
   <nav class="profile-top-actions" aria-label="Tier profile actions">
     <a class="back-link" routerLink="/tables">Back to tables</a>
     <div class="profile-action-links">
+      <a mat-button [routerLink]="['/leagues', tierId(), 'deep-stats']">Deep stats</a>
       @if (latestTableQueryParams(); as latestTableParams) {
       <a mat-stroked-button routerLink="/tables" [queryParams]="latestTableParams">
         View latest table

--- a/src/app/pages/tier-profile/tier-profile.html
+++ b/src/app/pages/tier-profile/tier-profile.html
@@ -1,0 +1,215 @@
+@if (!hasArchiveData()) { @if (loadFailed()) {
+<div class="loading loading--error app-page-shell" role="alert">
+  <p>Tier profile data could not load.</p>
+  <button type="button" mat-button (click)="retryArchiveLoad()">Retry</button>
+</div>
+} @else if (showLoadingState()) {
+<div class="loading app-page-shell" role="status" aria-live="polite">Loading tier profile...</div>
+} } @else if (!profile()) {
+<section class="tier-profile app-surface app-page-shell">
+  <div class="profile-top-actions">
+    <a class="back-link" routerLink="/tables">Back to tables</a>
+  </div>
+  <div class="empty-state app-panel">
+    <p class="app-page-eyebrow">Tier Profile</p>
+    <h1>Tier not found</h1>
+    <p>The requested league tier is not available in the current archive data.</p>
+  </div>
+</section>
+} @else {
+<section class="tier-profile app-surface app-page-shell">
+  <div class="profile-top-actions">
+    <a class="back-link" routerLink="/tables">Back to tables</a>
+  </div>
+
+  <header class="profile-header">
+    <p class="app-page-eyebrow">Tier Profile</p>
+    <h1 class="app-page-title">{{ tierLabel() }}</h1>
+    <p class="app-page-lede">
+      {{ profile()!.totalRows }} table rows across {{ profile()!.seasons.length }} tracked seasons
+      from {{ seasonRangeLabel() }}.
+    </p>
+  </header>
+
+  <section class="stat-grid" aria-label="Tier record summary">
+    <div class="stat-cell">
+      <span>Tracked Seasons</span>
+      <strong>{{ profile()!.seasons.length }}</strong>
+    </div>
+    <div class="stat-cell">
+      <span>Clubs Seen</span>
+      <strong>{{ profile()!.uniqueClubCount }}</strong>
+    </div>
+    <div class="stat-cell">
+      <span>Latest Season</span>
+      <strong>{{ profile()!.latestSeason ?? 'No data' }}</strong>
+    </div>
+    <div class="stat-cell">
+      <span>Movement Events</span>
+      <strong>
+        {{ profile()!.promotionInCount }} promotions / {{ profile()!.relegationOutCount }}
+        relegations
+      </strong>
+    </div>
+  </section>
+
+  <div class="profile-feature-grid">
+    <section class="profile-panel app-panel movement-panel">
+      <div class="panel-head">
+        <h2>Movement Leaders</h2>
+        <span>{{ sourceTierLabel() || 'Source tier unavailable' }}</span>
+      </div>
+      <div class="leader-columns">
+        <section aria-label="Most promotions into this tier">
+          <h3>Most promoted into {{ tierLabel() }}</h3>
+          @if (movementRows(profile()!.mostPromotionsIn).length) {
+          <div class="leader-list">
+            @for (row of movementRows(profile()!.mostPromotionsIn); track row.key) {
+            <div>
+              <span>
+                @if (row.clubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+                } @else { {{ row.name }} }
+              </span>
+              <strong>{{ row.detail }}</strong>
+            </div>
+            }
+          </div>
+          } @else {
+          <p class="empty-copy">No promotion markers from the tier below are available.</p>
+          }
+        </section>
+
+        <section aria-label="Most relegations from this tier">
+          <h3>Most relegated from {{ tierLabel() }}</h3>
+          @if (movementRows(profile()!.mostRelegationsOut).length) {
+          <div class="leader-list">
+            @for (row of movementRows(profile()!.mostRelegationsOut); track row.key) {
+            <div>
+              <span>
+                @if (row.clubId) {
+                <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+                } @else { {{ row.name }} }
+              </span>
+              <strong>{{ row.detail }}</strong>
+            </div>
+            }
+          </div>
+          } @else {
+          <p class="empty-copy">No relegation markers are available for this tier.</p>
+          }
+        </section>
+      </div>
+    </section>
+
+    <section class="profile-panel app-panel close-panel">
+      <div class="panel-head">
+        <h2>Close Seasons</h2>
+        <span>Smallest points gaps</span>
+      </div>
+      <div class="race-groups">
+        <section>
+          <h3>Title races</h3>
+          <div class="race-list">
+            @for (row of raceRows(profile()!.closeTitleRaces); track row.season) {
+            <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
+              <strong>{{ row.season }}</strong>
+              <span>{{ row.primaryName }} over {{ row.secondaryName }}</span>
+              <em>{{ row.detail }}</em>
+            </a>
+            }
+          </div>
+        </section>
+
+        <section>
+          <h3>Survival races</h3>
+          @if (raceRows(profile()!.closeSurvivalRaces).length) {
+          <div class="race-list">
+            @for (row of raceRows(profile()!.closeSurvivalRaces); track row.season) {
+            <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
+              <strong>{{ row.season }}</strong>
+              <span>{{ row.primaryName }} above {{ row.secondaryName }}</span>
+              <em>{{ row.detail }}</em>
+            </a>
+            }
+          </div>
+          } @else {
+          <p class="empty-copy">No relegation line could be calculated.</p>
+          }
+        </section>
+
+        <section>
+          <h3>Promotion races into {{ tierLabel() }}</h3>
+          @if (raceRows(profile()!.closePromotionRaces).length) {
+          <div class="race-list">
+            @for (row of raceRows(profile()!.closePromotionRaces); track row.season) {
+            <a [routerLink]="['/tables']" [queryParams]="sourceTableQueryParams(row.season)">
+              <strong>{{ row.season }}</strong>
+              <span>{{ row.primaryName }} over {{ row.secondaryName }}</span>
+              <em>{{ row.detail }}</em>
+            </a>
+            }
+          </div>
+          } @else {
+          <p class="empty-copy">No promotion line could be calculated from the tier below.</p>
+          }
+        </section>
+      </div>
+    </section>
+  </div>
+
+  <div class="profile-grid">
+    <section class="profile-panel app-panel">
+      <div class="panel-head">
+        <h2>Most Seasons</h2>
+        <span>{{ profile()!.mostSeasons.length }} clubs</span>
+      </div>
+      <div class="leader-list">
+        @for (row of movementRows(profile()!.mostSeasons); track row.key) {
+        <div>
+          <span>
+            @if (row.clubId) {
+            <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+            } @else { {{ row.name }} }
+          </span>
+          <strong>{{ row.detail }}</strong>
+        </div>
+        }
+      </div>
+    </section>
+
+    <section class="profile-panel app-panel">
+      <div class="panel-head">
+        <h2>Notable Marks</h2>
+        <span>{{ profile()!.notableSeasons.length }} records</span>
+      </div>
+      <div class="mark-list">
+        @for (row of profile()!.notableSeasons; track row.label) {
+        <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
+          <span>{{ row.label }}</span>
+          <strong>{{ row.value }}</strong>
+          <small>{{ row.season }} / {{ row.teamName }}</small>
+        </a>
+        }
+      </div>
+    </section>
+  </div>
+
+  <section class="profile-panel app-panel churn-panel">
+    <div class="panel-head">
+      <h2>High-Churn Seasons</h2>
+      <span>Promotion and relegation movement</span>
+    </div>
+    <div class="churn-list">
+      @for (row of profile()!.churnSeasons; track row.season) {
+      <a [routerLink]="['/tables']" [queryParams]="tableQueryParams(row.season)">
+        <strong>{{ row.season }}</strong>
+        <span>{{ row.promotedIn }} promoted in</span>
+        <span>{{ row.relegatedOut }} relegated out</span>
+        <em>{{ row.totalMovement }} total</em>
+      </a>
+      }
+    </div>
+  </section>
+</section>
+}

--- a/src/app/pages/tier-profile/tier-profile.html
+++ b/src/app/pages/tier-profile/tier-profile.html
@@ -99,6 +99,90 @@
     </div>
   </section>
 
+  <section class="profile-panel app-panel dominance-panel">
+    <div class="panel-head">
+      <h2>Dominance</h2>
+      <span>Titles, podiums, and stays</span>
+    </div>
+    <div class="dominance-grid">
+      <section aria-label="Most titles in this tier">
+        <h3>Most titles</h3>
+        @if (topRow(profile()!.mostTitles); as row) {
+        <div class="dominance-card">
+          <span>
+            @if (row.clubId) {
+            <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+            } @else { {{ row.name }} }
+          </span>
+          <strong>{{ row.detail }}</strong>
+          @if (previewNames(profile()!.mostTitles); as nextNames) {
+          <small>Next: {{ nextNames }}</small>
+          }
+        </div>
+        } @else {
+        <p class="empty-copy">No title leaders are available for this view.</p>
+        }
+      </section>
+
+      <section aria-label="Most top-three finishes in this tier">
+        <h3>Top-three finishes</h3>
+        @if (topRow(profile()!.mostTopThreeFinishes); as row) {
+        <div class="dominance-card">
+          <span>
+            @if (row.clubId) {
+            <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+            } @else { {{ row.name }} }
+          </span>
+          <strong>{{ row.detail }}</strong>
+          @if (previewNames(profile()!.mostTopThreeFinishes); as nextNames) {
+          <small>Next: {{ nextNames }}</small>
+          }
+        </div>
+        } @else {
+        <p class="empty-copy">No top-three leaders are available for this view.</p>
+        }
+      </section>
+
+      <section aria-label="Longest continuous stay in this tier">
+        <h3>Longest stay</h3>
+        @if (topRow(profile()!.longestStays); as row) {
+        <div class="dominance-card">
+          <span>
+            @if (row.clubId) {
+            <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+            } @else { {{ row.name }} }
+          </span>
+          <strong>{{ row.detail }}</strong>
+          @if (previewNames(profile()!.longestStays); as nextNames) {
+          <small>Next: {{ nextNames }}</small>
+          }
+        </div>
+        } @else {
+        <p class="empty-copy">No continuous stay data is available for this view.</p>
+        }
+      </section>
+
+      <section aria-label="Longest active stay in this tier">
+        <h3>Active stay</h3>
+        @if (topRow(profile()!.longestActiveStays); as row) {
+        <div class="dominance-card">
+          <span>
+            @if (row.clubId) {
+            <a class="app-club-link" [routerLink]="['/teams', row.clubId]">{{ row.name }}</a>
+            } @else { {{ row.name }} }
+          </span>
+          <strong>{{ row.detail }}</strong>
+          @if (previewNames(profile()!.longestActiveStays); as nextNames) {
+          <small>Next: {{ nextNames }}</small>
+          }
+        </div>
+        } @else {
+        <p class="empty-copy">No active stay data is available for this view.</p>
+        }
+      </section>
+    </div>
+  </section>
+
   <div class="profile-feature-grid">
     <section class="profile-panel app-panel movement-panel">
       <div class="panel-head">
@@ -154,105 +238,150 @@
         <span>Smallest points gaps</span>
       </div>
       <div class="race-groups">
-        <section>
-          <h3>Title races</h3>
-          <div class="race-list">
-            @for (row of raceRows(profile()!.closeTitleRaces); track row.season) {
-            <div class="race-row">
-              <a
-                class="race-season-link"
-                [routerLink]="['/tables']"
-                [queryParams]="tableQueryParams(row.season)"
-              >
-                {{ row.season }}
-              </a>
-              <span class="race-matchup">
-                @if (row.primaryClubId) {
-                <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
-                  {{ row.primaryName }}
+        <section class="race-section">
+          <button
+            type="button"
+            class="race-section-toggle"
+            aria-controls="title-race-list"
+            [attr.aria-expanded]="isRaceSectionExpanded('title')"
+            (click)="toggleRaceSection('title')"
+          >
+            <span>Title races</span>
+            <em>{{ raceRows(profile()!.closeTitleRaces).length }} shown</em>
+          </button>
+          <div
+            id="title-race-list"
+            class="race-section-body"
+            [hidden]="!isRaceSectionExpanded('title')"
+          >
+            <div class="race-list">
+              @for (row of raceRows(profile()!.closeTitleRaces); track row.season) {
+              <div class="race-row">
+                <a
+                  class="race-season-link"
+                  [routerLink]="['/tables']"
+                  [queryParams]="tableQueryParams(row.season)"
+                >
+                  {{ row.season }}
                 </a>
-                } @else { {{ row.primaryName }} }
-                <span>over</span>
-                @if (row.secondaryClubId) {
-                <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
-                  {{ row.secondaryName }}
-                </a>
-                } @else { {{ row.secondaryName }} }
-              </span>
-              <em>{{ row.detail }}</em>
+                <span class="race-matchup">
+                  @if (row.primaryClubId) {
+                  <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
+                    {{ row.primaryName }}
+                  </a>
+                  } @else { {{ row.primaryName }} }
+                  <span>over</span>
+                  @if (row.secondaryClubId) {
+                  <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
+                    {{ row.secondaryName }}
+                  </a>
+                  } @else { {{ row.secondaryName }} }
+                </span>
+                <em>{{ row.detail }}</em>
+              </div>
+              }
             </div>
+          </div>
+        </section>
+
+        <section class="race-section">
+          <button
+            type="button"
+            class="race-section-toggle"
+            aria-controls="survival-race-list"
+            [attr.aria-expanded]="isRaceSectionExpanded('survival')"
+            (click)="toggleRaceSection('survival')"
+          >
+            <span>Survival races</span>
+            <em>{{ raceRows(profile()!.closeSurvivalRaces).length }} shown</em>
+          </button>
+          <div
+            id="survival-race-list"
+            class="race-section-body"
+            [hidden]="!isRaceSectionExpanded('survival')"
+          >
+            @if (raceRows(profile()!.closeSurvivalRaces).length) {
+            <div class="race-list">
+              @for (row of raceRows(profile()!.closeSurvivalRaces); track row.season) {
+              <div class="race-row">
+                <a
+                  class="race-season-link"
+                  [routerLink]="['/tables']"
+                  [queryParams]="tableQueryParams(row.season)"
+                >
+                  {{ row.season }}
+                </a>
+                <span class="race-matchup">
+                  @if (row.primaryClubId) {
+                  <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
+                    {{ row.primaryName }}
+                  </a>
+                  } @else { {{ row.primaryName }} }
+                  <span>above</span>
+                  @if (row.secondaryClubId) {
+                  <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
+                    {{ row.secondaryName }}
+                  </a>
+                  } @else { {{ row.secondaryName }} }
+                </span>
+                <em>{{ row.detail }}</em>
+              </div>
+              }
+            </div>
+            } @else {
+            <p class="empty-copy">No relegation line could be calculated.</p>
             }
           </div>
         </section>
 
-        <section>
-          <h3>Survival races</h3>
-          @if (raceRows(profile()!.closeSurvivalRaces).length) {
-          <div class="race-list">
-            @for (row of raceRows(profile()!.closeSurvivalRaces); track row.season) {
-            <div class="race-row">
-              <a
-                class="race-season-link"
-                [routerLink]="['/tables']"
-                [queryParams]="tableQueryParams(row.season)"
-              >
-                {{ row.season }}
-              </a>
-              <span class="race-matchup">
-                @if (row.primaryClubId) {
-                <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
-                  {{ row.primaryName }}
+        <section class="race-section">
+          <button
+            type="button"
+            class="race-section-toggle"
+            aria-controls="promotion-race-list"
+            [attr.aria-expanded]="isRaceSectionExpanded('promotion')"
+            (click)="toggleRaceSection('promotion')"
+          >
+            <span>Promotion races into {{ tierLabel() }}</span>
+            <em>{{ raceRows(profile()!.closePromotionRaces).length }} shown</em>
+          </button>
+          <div
+            id="promotion-race-list"
+            class="race-section-body"
+            [hidden]="!isRaceSectionExpanded('promotion')"
+          >
+            @if (raceRows(profile()!.closePromotionRaces).length) {
+            <div class="race-list">
+              @for (row of raceRows(profile()!.closePromotionRaces); track row.season) {
+              <div class="race-row">
+                <a
+                  class="race-season-link"
+                  [routerLink]="['/tables']"
+                  [queryParams]="sourceTableQueryParams(row.season)"
+                >
+                  {{ row.season }}
                 </a>
-                } @else { {{ row.primaryName }} }
-                <span>above</span>
-                @if (row.secondaryClubId) {
-                <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
-                  {{ row.secondaryName }}
-                </a>
-                } @else { {{ row.secondaryName }} }
-              </span>
-              <em>{{ row.detail }}</em>
+                <span class="race-matchup">
+                  @if (row.primaryClubId) {
+                  <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
+                    {{ row.primaryName }}
+                  </a>
+                  } @else { {{ row.primaryName }} }
+                  <span>over</span>
+                  @if (row.secondaryClubId) {
+                  <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
+                    {{ row.secondaryName }}
+                  </a>
+                  } @else { {{ row.secondaryName }} }
+                </span>
+                <em>{{ row.detail }}</em>
+              </div>
+              }
             </div>
+            } @else {
+            <p class="empty-copy">No promotion line could be calculated from the tier below.</p>
             }
           </div>
-          } @else {
-          <p class="empty-copy">No relegation line could be calculated.</p>
-          }
-        </section>
-
-        <section>
-          <h3>Promotion races into {{ tierLabel() }}</h3>
-          @if (raceRows(profile()!.closePromotionRaces).length) {
-          <div class="race-list">
-            @for (row of raceRows(profile()!.closePromotionRaces); track row.season) {
-            <div class="race-row">
-              <a
-                class="race-season-link"
-                [routerLink]="['/tables']"
-                [queryParams]="sourceTableQueryParams(row.season)"
-              >
-                {{ row.season }}
-              </a>
-              <span class="race-matchup">
-                @if (row.primaryClubId) {
-                <a class="app-club-link" [routerLink]="['/teams', row.primaryClubId]">
-                  {{ row.primaryName }}
-                </a>
-                } @else { {{ row.primaryName }} }
-                <span>over</span>
-                @if (row.secondaryClubId) {
-                <a class="app-club-link" [routerLink]="['/teams', row.secondaryClubId]">
-                  {{ row.secondaryName }}
-                </a>
-                } @else { {{ row.secondaryName }} }
-              </span>
-              <em>{{ row.detail }}</em>
-            </div>
-            }
-          </div>
-          } @else {
-          <p class="empty-copy">No promotion line could be calculated from the tier below.</p>
-          }
         </section>
       </div>
     </section>

--- a/src/app/pages/tier-profile/tier-profile.scss
+++ b/src/app/pages/tier-profile/tier-profile.scss
@@ -1,0 +1,294 @@
+:host {
+  display: block;
+}
+
+.loading,
+.empty-state {
+  color: var(--app-text-muted);
+}
+
+.tier-profile {
+  display: grid;
+  gap: 20px;
+}
+
+.profile-top-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.back-link {
+  width: fit-content;
+  color: var(--app-text-muted);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  color: var(--app-text-strong);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.profile-header {
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.profile-header .app-page-title {
+  margin: 8px 0;
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.05;
+}
+
+.stat-grid,
+.profile-grid,
+.profile-feature-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.stat-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.profile-grid,
+.profile-feature-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.stat-cell,
+.profile-panel {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(148, 163, 184, 0.06), transparent 90px),
+    color-mix(in srgb, var(--app-surface-bg) 86%, transparent);
+}
+
+.stat-cell {
+  min-height: 72px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 11px 12px;
+  display: grid;
+  align-content: center;
+  gap: 4px;
+}
+
+.profile-panel {
+  padding: 16px;
+}
+
+.stat-cell::before,
+.profile-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: rgba(217, 119, 6, 0.74);
+}
+
+.stat-cell:nth-child(2)::before,
+.close-panel::before {
+  background: rgba(96, 165, 250, 0.72);
+}
+
+.stat-cell:nth-child(3)::before,
+.churn-panel::before {
+  background: rgba(34, 197, 94, 0.72);
+}
+
+.stat-cell:nth-child(4)::before {
+  background: rgba(20, 184, 166, 0.72);
+}
+
+.stat-cell span,
+.panel-head span {
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stat-cell strong {
+  color: var(--app-text-strong);
+  font-size: 0.95rem;
+  line-height: 1.3;
+}
+
+.panel-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+  padding: 0 0 11px 6px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.26);
+}
+
+.panel-head h2,
+.leader-columns h3,
+.race-groups h3 {
+  margin: 0;
+  color: var(--app-text-strong);
+}
+
+.panel-head h2 {
+  font-size: 1.05rem;
+}
+
+.leader-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.leader-columns section,
+.race-groups section {
+  display: grid;
+  align-content: start;
+  gap: 9px;
+}
+
+.leader-columns h3,
+.race-groups h3 {
+  font-size: 0.88rem;
+}
+
+.leader-list,
+.race-groups,
+.race-list,
+.mark-list,
+.churn-list {
+  display: grid;
+  gap: 8px;
+}
+
+.leader-list > div,
+.race-list a,
+.mark-list a,
+.churn-list a {
+  min-height: 42px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 9px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: rgba(7, 10, 19, 0.2);
+}
+
+.race-list a,
+.mark-list a,
+.churn-list a {
+  color: inherit;
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+.leader-list > div:hover,
+.race-list a:hover,
+.mark-list a:hover,
+.churn-list a:hover {
+  border-color: rgba(148, 163, 184, 0.34);
+  background: rgba(15, 23, 42, 0.42);
+}
+
+.leader-list span,
+.race-list span,
+.mark-list span,
+.churn-list span,
+.empty-copy {
+  color: var(--app-text-muted);
+  font-size: 0.9rem;
+}
+
+.leader-list strong,
+.race-list strong,
+.mark-list strong,
+.churn-list strong {
+  color: var(--app-text-strong);
+  font-size: 0.95rem;
+}
+
+.race-list em,
+.churn-list em {
+  width: fit-content;
+  border: 1px solid rgba(245, 158, 11, 0.34);
+  border-radius: 999px;
+  padding: 3px 7px;
+  background: rgba(245, 158, 11, 0.1);
+  color: #fde68a;
+  font-size: 0.74rem;
+  font-style: normal;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.mark-list a {
+  min-height: 74px;
+  align-items: flex-start;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.mark-list small {
+  color: var(--app-text-muted);
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.empty-copy {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.churn-list a {
+  display: grid;
+  grid-template-columns: 0.8fr 1fr 1fr auto;
+}
+
+@media (max-width: 900px) {
+  .profile-grid,
+  .profile-feature-grid,
+  .leader-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .stat-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .tier-profile {
+    gap: 16px;
+  }
+
+  .stat-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-panel {
+    padding: 14px;
+  }
+
+  .panel-head {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .leader-list > div,
+  .race-list a,
+  .churn-list a {
+    display: grid;
+    grid-template-columns: 1fr;
+    justify-items: start;
+  }
+}

--- a/src/app/pages/tier-profile/tier-profile.scss
+++ b/src/app/pages/tier-profile/tier-profile.scss
@@ -625,20 +625,21 @@
 
 @media print {
   .tier-profile {
-    gap: 12px;
+    gap: 6pt;
   }
 
   .profile-header {
-    padding-bottom: 10px;
-    border-bottom: 2px solid #111827;
+    padding-bottom: 5pt;
+    border-bottom: 1px solid #000000;
   }
 
   .stat-grid,
   .profile-grid,
   .profile-feature-grid,
   .dominance-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px;
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 7pt 10pt !important;
   }
 
   .profile-panel,
@@ -649,12 +650,19 @@
   .race-row,
   .mark-row,
   .churn-list a {
-    border-color: #cbd5e1;
+    border-color: #dddddd;
     background: #ffffff;
   }
 
+  .leader-list,
+  .race-list,
+  .mark-list,
+  .churn-list {
+    gap: 0;
+  }
+
   .profile-panel {
-    padding: 10px;
+    padding: 0;
   }
 
   .profile-panel::before,
@@ -664,12 +672,12 @@
   }
 
   .panel-head {
-    margin-bottom: 8px;
-    padding-bottom: 6px;
+    margin-bottom: 4pt;
+    padding-bottom: 2pt;
   }
 
   .race-section {
-    border-color: #cbd5e1;
+    border: 0;
     background: #ffffff;
   }
 
@@ -688,8 +696,8 @@
 
   .race-list em,
   .churn-list em {
-    border-color: #cbd5e1;
+    border-color: transparent;
     background: #ffffff;
-    color: #111827;
+    color: #333333;
   }
 }

--- a/src/app/pages/tier-profile/tier-profile.scss
+++ b/src/app/pages/tier-profile/tier-profile.scss
@@ -151,7 +151,8 @@
 }
 
 .stat-cell:nth-child(3)::before,
-.churn-panel::before {
+.churn-panel::before,
+.dominance-panel::before {
   background: rgba(34, 197, 94, 0.72);
 }
 
@@ -254,7 +255,8 @@
 
 .panel-head h2,
 .leader-columns h3,
-.race-groups h3 {
+.race-groups h3,
+.dominance-grid h3 {
   margin: 0;
   color: var(--app-text-strong);
 }
@@ -277,7 +279,8 @@
 }
 
 .leader-columns h3,
-.race-groups h3 {
+.race-groups h3,
+.dominance-grid h3 {
   font-size: 0.88rem;
 }
 
@@ -288,6 +291,125 @@
 .churn-list {
   display: grid;
   gap: 8px;
+}
+
+.race-section {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 8px;
+  padding: 8px;
+  background: rgba(7, 10, 19, 0.12);
+}
+
+.race-section-toggle {
+  width: 100%;
+  border: 0;
+  border-radius: 6px;
+  padding: 4px 2px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  background: transparent;
+  color: var(--app-text-strong);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.race-section-toggle:hover,
+.race-section-toggle:focus-visible {
+  background: rgba(148, 163, 184, 0.08);
+  outline: 2px solid transparent;
+}
+
+.race-section-toggle:focus-visible {
+  outline-color: rgba(226, 232, 240, 0.76);
+  outline-offset: 2px;
+}
+
+.race-section-toggle span {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+
+.race-section-toggle span::before {
+  content: '+';
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
+  display: inline-grid;
+  place-items: center;
+  color: var(--app-text-muted);
+  font-size: 0.76rem;
+  line-height: 1;
+}
+
+.race-section-toggle[aria-expanded='true'] span::before {
+  content: '-';
+}
+
+.race-section-toggle em {
+  flex: 0 0 auto;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 999px;
+  padding: 2px 7px;
+  color: var(--app-text-muted);
+  font-size: 0.7rem;
+  font-style: normal;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.race-section-body {
+  padding-top: 8px;
+}
+
+.dominance-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.dominance-grid section {
+  display: grid;
+  align-content: start;
+  gap: 9px;
+  min-width: 0;
+}
+
+.dominance-card {
+  min-height: 92px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 10px 11px;
+  display: grid;
+  align-content: start;
+  gap: 5px;
+  background: rgba(7, 10, 19, 0.2);
+}
+
+.dominance-card span {
+  color: var(--app-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.dominance-card strong {
+  color: var(--app-text-strong);
+  font-size: 0.96rem;
+  line-height: 1.3;
+}
+
+.dominance-card small {
+  color: var(--app-text-muted);
+  font-size: 0.76rem;
+  line-height: 1.35;
 }
 
 .leader-list > div,
@@ -429,7 +551,8 @@
   .profile-grid,
   .profile-feature-grid,
   .leader-columns,
-  .era-filter-panel {
+  .era-filter-panel,
+  .dominance-grid {
     grid-template-columns: 1fr;
   }
 
@@ -497,5 +620,76 @@
   .mark-club-link {
     justify-self: start;
     text-align: left;
+  }
+}
+
+@media print {
+  .tier-profile {
+    gap: 12px;
+  }
+
+  .profile-header {
+    padding-bottom: 10px;
+    border-bottom: 2px solid #111827;
+  }
+
+  .stat-grid,
+  .profile-grid,
+  .profile-feature-grid,
+  .dominance-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .profile-panel,
+  .stat-cell,
+  .data-notice,
+  .dominance-card,
+  .leader-list > div,
+  .race-row,
+  .mark-row,
+  .churn-list a {
+    border-color: #cbd5e1;
+    background: #ffffff;
+  }
+
+  .profile-panel {
+    padding: 10px;
+  }
+
+  .profile-panel::before,
+  .stat-cell::before,
+  .data-notice::before {
+    display: none;
+  }
+
+  .panel-head {
+    margin-bottom: 8px;
+    padding-bottom: 6px;
+  }
+
+  .race-section {
+    border-color: #cbd5e1;
+    background: #ffffff;
+  }
+
+  .race-section-toggle {
+    pointer-events: none;
+  }
+
+  .race-section-toggle span::before,
+  .race-section-toggle em {
+    display: none;
+  }
+
+  .race-section-body[hidden] {
+    display: block !important;
+  }
+
+  .race-list em,
+  .churn-list em {
+    border-color: #cbd5e1;
+    background: #ffffff;
+    color: #111827;
   }
 }

--- a/src/app/pages/tier-profile/tier-profile.scss
+++ b/src/app/pages/tier-profile/tier-profile.scss
@@ -16,6 +16,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
+}
+
+.profile-action-links {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 .back-link {
@@ -42,9 +51,52 @@
   line-height: 1.05;
 }
 
+.data-notice-stack {
+  display: grid;
+  gap: 10px;
+}
+
+.data-notice {
+  border: 1px solid rgba(245, 158, 11, 0.34);
+  border-radius: 8px;
+  padding: 13px 14px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  background: rgba(245, 158, 11, 0.08);
+  color: var(--app-text-muted);
+}
+
+.data-notice strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--app-text-strong);
+  font-size: 0.96rem;
+}
+
+.data-notice p {
+  max-width: 74ch;
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.data-notice span {
+  flex: 0 0 auto;
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 999px;
+  padding: 4px 8px;
+  color: #fde68a;
+  font-size: 0.74rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
 .stat-grid,
 .profile-grid,
-.profile-feature-grid {
+.profile-feature-grid,
+.era-filter-list {
   display: grid;
   gap: 14px;
 }
@@ -60,6 +112,7 @@
 }
 
 .stat-cell,
+.era-filter-panel,
 .profile-panel {
   position: relative;
   overflow: hidden;
@@ -83,6 +136,7 @@
 }
 
 .stat-cell::before,
+.era-filter-panel::before,
 .profile-panel::before {
   content: '';
   position: absolute;
@@ -103,6 +157,74 @@
 
 .stat-cell:nth-child(4)::before {
   background: rgba(20, 184, 166, 0.72);
+}
+
+.era-filter-panel {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.34fr) minmax(0, 1fr);
+  gap: 14px;
+  padding: 14px 16px 16px;
+}
+
+.era-filter-copy {
+  display: grid;
+  align-content: center;
+  gap: 4px;
+  padding-left: 6px;
+}
+
+.era-filter-copy h2,
+.era-filter-copy p {
+  margin: 0;
+}
+
+.era-filter-copy h2 {
+  color: var(--app-text-strong);
+  font-size: 1.02rem;
+}
+
+.era-filter-copy p {
+  color: var(--app-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.era-filter-list {
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 8px;
+}
+
+.era-filter-list a {
+  min-height: 54px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 9px 10px;
+  display: grid;
+  align-content: center;
+  gap: 2px;
+  color: inherit;
+  text-decoration: none;
+  background: rgba(7, 10, 19, 0.2);
+}
+
+.era-filter-list a:hover,
+.era-filter-list a:focus-visible,
+.era-filter-list a.is-active {
+  border-color: rgba(245, 158, 11, 0.48);
+  background: rgba(245, 158, 11, 0.1);
+}
+
+.era-filter-list strong {
+  color: var(--app-text-strong);
+  font-size: 0.88rem;
+}
+
+.era-filter-list span {
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .stat-cell span,
@@ -169,8 +291,8 @@
 }
 
 .leader-list > div,
-.race-list a,
-.mark-list a,
+.race-row,
+.mark-row,
 .churn-list a {
   min-height: 42px;
   border: 1px solid var(--app-border);
@@ -183,7 +305,7 @@
   background: rgba(7, 10, 19, 0.2);
 }
 
-.race-list a,
+.race-season-link,
 .mark-list a,
 .churn-list a {
   color: inherit;
@@ -192,8 +314,8 @@
 }
 
 .leader-list > div:hover,
-.race-list a:hover,
-.mark-list a:hover,
+.race-row:hover,
+.mark-row:hover,
 .churn-list a:hover {
   border-color: rgba(148, 163, 184, 0.34);
   background: rgba(15, 23, 42, 0.42);
@@ -209,11 +331,12 @@
 }
 
 .leader-list strong,
-.race-list strong,
+.race-season-link,
 .mark-list strong,
 .churn-list strong {
   color: var(--app-text-strong);
   font-size: 0.95rem;
+  font-weight: 800;
 }
 
 .race-list em,
@@ -230,14 +353,63 @@
   white-space: nowrap;
 }
 
-.mark-list a {
-  min-height: 74px;
-  align-items: flex-start;
-  flex-direction: column;
-  justify-content: center;
+.race-matchup {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
-.mark-list small {
+.race-matchup > span {
+  font-size: inherit;
+}
+
+.mark-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(130px, auto);
+  align-items: center;
+}
+
+.mark-table-link {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, auto) auto;
+  grid-template-areas:
+    'label label'
+    'value season';
+  justify-content: start;
+  gap: 5px 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.mark-table-link:hover {
+  background: transparent;
+}
+
+.mark-label {
+  grid-area: label;
+}
+
+.mark-value {
+  grid-area: value;
+}
+
+.mark-season {
+  grid-area: season;
+  align-self: end;
+}
+
+.mark-club-link {
+  min-width: 0;
+  justify-self: end;
+  text-align: right;
+}
+
+.mark-list small,
+.mark-season {
   color: var(--app-text-muted);
   font-size: 0.78rem;
   line-height: 1.35;
@@ -256,7 +428,8 @@
 @media (max-width: 900px) {
   .profile-grid,
   .profile-feature-grid,
-  .leader-columns {
+  .leader-columns,
+  .era-filter-panel {
     grid-template-columns: 1fr;
   }
 
@@ -268,6 +441,20 @@
 @media (max-width: 620px) {
   .tier-profile {
     gap: 16px;
+  }
+
+  .profile-top-actions,
+  .profile-action-links {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .profile-action-links {
+    width: 100%;
+  }
+
+  .profile-action-links a {
+    justify-content: center;
   }
 
   .stat-grid {
@@ -284,11 +471,31 @@
     gap: 5px;
   }
 
+  .data-notice {
+    display: grid;
+    gap: 10px;
+  }
+
+  .data-notice span {
+    justify-self: start;
+    white-space: normal;
+  }
+
   .leader-list > div,
-  .race-list a,
+  .race-row,
+  .mark-row,
   .churn-list a {
     display: grid;
     grid-template-columns: 1fr;
     justify-items: start;
+  }
+
+  .mark-table-link {
+    grid-template-columns: minmax(0, auto) auto;
+  }
+
+  .mark-club-link {
+    justify-self: start;
+    text-align: left;
   }
 }

--- a/src/app/pages/tier-profile/tier-profile.spec.ts
+++ b/src/app/pages/tier-profile/tier-profile.spec.ts
@@ -61,6 +61,11 @@ describe('TierProfile', () => {
     expect(element.textContent).toContain('Most relegated from Premier League');
     expect(element.textContent).toContain('Close Seasons');
     expect(element.textContent).toContain('Era View');
+    expect(element.textContent).toContain('Dominance');
+    expect(element.textContent).toContain('Most titles');
+    expect(element.textContent).toContain('Top-three finishes');
+    expect(element.textContent).toContain('2 titles');
+    expect(element.textContent).toContain('2 seasons (2020-2021)');
     expect(element.textContent).not.toContain('Regional Third Division data');
   });
 
@@ -76,6 +81,26 @@ describe('TierProfile', () => {
     const latestTableLink = links.find((link) => link.textContent?.includes('View latest table'));
 
     expect(latestTableLink?.getAttribute('href')).toContain('/tables?season=2021&tier=tier1');
+  });
+
+  it('collapses secondary close season sections by default', () => {
+    const element: HTMLElement = fixture.nativeElement;
+    const survivalToggle = Array.from(element.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes('Survival races')
+    );
+    const survivalList = element.querySelector<HTMLElement>('#survival-race-list');
+
+    expect(component.isRaceSectionExpanded('title')).toBe(true);
+    expect(component.isRaceSectionExpanded('survival')).toBe(false);
+    expect(survivalToggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(survivalList?.hidden).toBe(true);
+
+    survivalToggle?.click();
+    fixture.detectChanges();
+
+    expect(component.isRaceSectionExpanded('survival')).toBe(true);
+    expect(survivalToggle?.getAttribute('aria-expanded')).toBe('true');
+    expect(survivalList?.hidden).toBe(false);
   });
 
   it('filters profile data by the selected era query param', () => {

--- a/src/app/pages/tier-profile/tier-profile.spec.ts
+++ b/src/app/pages/tier-profile/tier-profile.spec.ts
@@ -1,0 +1,122 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { convertToParamMap, ActivatedRoute, provideRouter } from '@angular/router';
+import { LeagueStore } from '@app/store/league.store';
+import { DataLoaderService } from '@app/store/services/hydrate-store-json';
+import { of } from 'rxjs';
+import { TierProfile } from './tier-profile';
+
+describe('TierProfile', () => {
+  let fixture: ComponentFixture<TierProfile>;
+  let component: TierProfile;
+  let store: InstanceType<typeof LeagueStore>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TierProfile],
+      providers: [
+        LeagueStore,
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({ tier: 'tier1' })),
+            snapshot: {
+              paramMap: convertToParamMap({ tier: 'tier1' }),
+            },
+          },
+        },
+        {
+          provide: DataLoaderService,
+          useValue: {
+            loadStatus: signal('loaded'),
+            loadError: signal(null),
+            showLoadingState: signal(false),
+            loadData: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    store = TestBed.inject(LeagueStore);
+    store.hydrate(tierProfileFixture(), (teamName: string) => `${teamName.toLowerCase()} id`);
+    fixture = TestBed.createComponent(TierProfile);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('renders tier movement and close season context', () => {
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(component.tierLabel()).toBe('Premier League');
+    expect(element.querySelector('h1')?.textContent).toContain('Premier League');
+    expect(element.textContent).toContain('Most promoted into Premier League');
+    expect(element.textContent).toContain('Most relegated from Premier League');
+    expect(element.textContent).toContain('Close Seasons');
+  });
+
+  it('links close races to the selected table archive season', () => {
+    const links = Array.from(fixture.nativeElement.querySelectorAll<HTMLAnchorElement>('a'));
+    const tableLink = links.find((link) => link.textContent?.includes('2020'));
+
+    expect(tableLink?.getAttribute('href')).toContain('/tables?season=2020&tier=tier1');
+  });
+});
+
+function tierProfileFixture() {
+  return {
+    seasons: {
+      2020: {
+        tier1: [
+          row('Alpha FC', 1, 82, 80, 30, false, false),
+          row('Bravo Town', 2, 81, 76, 35, false, false),
+          row('Delta United', 3, 39, 42, 55, false, false),
+          row('Echo Rovers', 4, 38, 36, 60, true, false),
+        ],
+        tier2: [
+          row('Charlie City', 1, 84, 74, 35, false, true),
+          row('Delta United', 2, 83, 68, 40, false, true),
+          row('Echo Rovers', 3, 82, 64, 42, false, false),
+        ],
+      },
+      2021: {
+        tier1: [
+          row('Bravo Town', 1, 90, 88, 25, false, false),
+          row('Alpha FC', 2, 83, 70, 30, false, false),
+          row('Charlie City', 3, 44, 52, 49, false, false),
+        ],
+        tier2: [row('Charlie City', 1, 86, 79, 30, false, true)],
+      },
+    },
+  };
+}
+
+function row(
+  team: string,
+  pos: number,
+  points: number,
+  goalsFor: number,
+  goalsAgainst: number,
+  wasRelegated: boolean,
+  wasPromoted: boolean
+) {
+  return {
+    team,
+    pos,
+    played: 38,
+    won: 20,
+    drawn: 8,
+    lost: 10,
+    goalsFor,
+    goalsAgainst,
+    goalDifference: goalsFor - goalsAgainst,
+    goalAverage: null,
+    points,
+    notes: null,
+    wasRelegated,
+    wasPromoted,
+    isExpansionTeam: false,
+    wasReElected: false,
+    wasReprieved: false,
+  };
+}

--- a/src/app/pages/tier-profile/tier-profile.spec.ts
+++ b/src/app/pages/tier-profile/tier-profile.spec.ts
@@ -1,17 +1,22 @@
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { convertToParamMap, ActivatedRoute, provideRouter } from '@angular/router';
+import { convertToParamMap, ActivatedRoute, ParamMap, provideRouter } from '@angular/router';
 import { LeagueStore } from '@app/store/league.store';
 import { DataLoaderService } from '@app/store/services/hydrate-store-json';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { TierProfile } from './tier-profile';
 
 describe('TierProfile', () => {
   let fixture: ComponentFixture<TierProfile>;
   let component: TierProfile;
   let store: InstanceType<typeof LeagueStore>;
+  let paramMap$: BehaviorSubject<ParamMap>;
+  let queryParamMap$: BehaviorSubject<ParamMap>;
 
   beforeEach(async () => {
+    paramMap$ = new BehaviorSubject(convertToParamMap({ tier: 'tier1' }));
+    queryParamMap$ = new BehaviorSubject(convertToParamMap({}));
+
     await TestBed.configureTestingModule({
       imports: [TierProfile],
       providers: [
@@ -20,9 +25,11 @@ describe('TierProfile', () => {
         {
           provide: ActivatedRoute,
           useValue: {
-            paramMap: of(convertToParamMap({ tier: 'tier1' })),
+            paramMap: paramMap$.asObservable(),
+            queryParamMap: queryParamMap$.asObservable(),
             snapshot: {
               paramMap: convertToParamMap({ tier: 'tier1' }),
+              queryParamMap: convertToParamMap({}),
             },
           },
         },
@@ -53,6 +60,8 @@ describe('TierProfile', () => {
     expect(element.textContent).toContain('Most promoted into Premier League');
     expect(element.textContent).toContain('Most relegated from Premier League');
     expect(element.textContent).toContain('Close Seasons');
+    expect(element.textContent).toContain('Era View');
+    expect(element.textContent).not.toContain('Regional Third Division data');
   });
 
   it('links close races to the selected table archive season', () => {
@@ -61,11 +70,48 @@ describe('TierProfile', () => {
 
     expect(tableLink?.getAttribute('href')).toContain('/tables?season=2020&tier=tier1');
   });
+
+  it('links the action row to the latest table in the selected view', () => {
+    const links = Array.from(fixture.nativeElement.querySelectorAll<HTMLAnchorElement>('a'));
+    const latestTableLink = links.find((link) => link.textContent?.includes('View latest table'));
+
+    expect(latestTableLink?.getAttribute('href')).toContain('/tables?season=2021&tier=tier1');
+  });
+
+  it('filters profile data by the selected era query param', () => {
+    queryParamMap$.next(convertToParamMap({ era: 'goal-average' }));
+    fixture.detectChanges();
+
+    expect(component.profile()?.seasons).toEqual([1975]);
+    expect(fixture.nativeElement.textContent).toContain('Showing 1975');
+  });
+
+  it('shows a targeted data note for regional Third Division seasons', () => {
+    paramMap$.next(convertToParamMap({ tier: 'tier4' }));
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Regional Third Division data');
+    expect(text).toContain('both represent pyramid level 3');
+    expect(text).toContain('Affected seasons: 1921');
+  });
 });
 
 function tierProfileFixture() {
   return {
     seasons: {
+      1975: {
+        tier1: [
+          row('Alpha FC', 1, 50, 60, 30, false, false),
+          row('Bravo Town', 2, 49, 70, 40, false, false),
+        ],
+      },
+      1921: {
+        tier4: [
+          row('Charlie City', 1, 40, 60, 30, false, false),
+          row('Delta United', 2, 39, 58, 31, false, false),
+        ],
+      },
       2020: {
         tier1: [
           row('Alpha FC', 1, 82, 80, 30, false, false),

--- a/src/app/pages/tier-profile/tier-profile.spec.ts
+++ b/src/app/pages/tier-profile/tier-profile.spec.ts
@@ -83,6 +83,13 @@ describe('TierProfile', () => {
     expect(latestTableLink?.getAttribute('href')).toContain('/tables?season=2021&tier=tier1');
   });
 
+  it('links to the deep stats route for the selected tier', () => {
+    const links = Array.from(fixture.nativeElement.querySelectorAll<HTMLAnchorElement>('a'));
+    const deepStatsLink = links.find((link) => link.textContent?.includes('Deep stats'));
+
+    expect(deepStatsLink?.getAttribute('href')).toBe('/leagues/tier1/deep-stats');
+  });
+
   it('collapses secondary close season sections by default', () => {
     const element: HTMLElement = fixture.nativeElement;
     const survivalToggle = Array.from(element.querySelectorAll<HTMLButtonElement>('button')).find(

--- a/src/app/pages/tier-profile/tier-profile.ts
+++ b/src/app/pages/tier-profile/tier-profile.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
@@ -9,6 +9,7 @@ import { DataLoaderService } from '@app/store/services/hydrate-store-json';
 import {
   buildTierProfileData,
   type TierClubTotal,
+  type TierDominanceRun,
   type TierRaceRow,
 } from '@app/utils/tier-profile';
 
@@ -40,6 +41,8 @@ interface TierDataNotice {
   detail: string;
   seasonsLabel: string;
 }
+
+type RaceSectionId = 'title' | 'survival' | 'promotion';
 
 const ERA_FILTERS: EraFilter[] = [
   {
@@ -122,6 +125,11 @@ export class TierProfile {
   });
 
   tierId = computed(() => this.paramMap().get('tier') ?? '');
+  expandedRaceSections = signal<Record<RaceSectionId, boolean>>({
+    title: true,
+    survival: false,
+    promotion: false,
+  });
   hasArchiveData = computed(() => this.store.getFullTable().length > 0);
   showLoadingState = computed(() => !this.hasArchiveData() && this.dataLoader.showLoadingState());
   loadFailed = computed(() => !this.hasArchiveData() && this.dataLoader.loadStatus() === 'error');
@@ -261,6 +269,32 @@ export class TierProfile {
 
   raceRows(rows: TierRaceRow[]): TierRaceRow[] {
     return rows.slice(0, 5);
+  }
+
+  isRaceSectionExpanded(sectionId: RaceSectionId): boolean {
+    return this.expandedRaceSections()[sectionId];
+  }
+
+  toggleRaceSection(sectionId: RaceSectionId) {
+    this.expandedRaceSections.update((sections) => ({
+      ...sections,
+      [sectionId]: !sections[sectionId],
+    }));
+  }
+
+  runRows(rows: TierDominanceRun[]): TierDominanceRun[] {
+    return rows.slice(0, 5);
+  }
+
+  topRow<T>(rows: readonly T[]): T | null {
+    return rows[0] ?? null;
+  }
+
+  previewNames(rows: readonly { name: string }[]): string {
+    return rows
+      .slice(1, 3)
+      .map((row) => row.name)
+      .join(' / ');
   }
 
   eraQueryParams(filterId: string): { era: string | null } {

--- a/src/app/pages/tier-profile/tier-profile.ts
+++ b/src/app/pages/tier-profile/tier-profile.ts
@@ -1,0 +1,103 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { LeagueTierToStringyPipe } from '@app/pipes/league-tier-to-stringy-pipe';
+import { LeagueStore } from '@app/store/league.store';
+import { DataLoaderService } from '@app/store/services/hydrate-store-json';
+import {
+  buildTierProfileData,
+  type TierClubTotal,
+  type TierRaceRow,
+} from '@app/utils/tier-profile';
+
+@Component({
+  selector: 'app-tier-profile',
+  imports: [CommonModule, MatButtonModule, RouterLink],
+  providers: [LeagueTierToStringyPipe],
+  templateUrl: './tier-profile.html',
+  styleUrl: './tier-profile.scss',
+})
+export class TierProfile {
+  private route = inject(ActivatedRoute);
+  private store = inject(LeagueStore);
+  private dataLoader = inject(DataLoaderService);
+  private tierLabelPipe = inject(LeagueTierToStringyPipe);
+  private paramMap = toSignal(this.route.paramMap, {
+    initialValue: this.route.snapshot.paramMap,
+  });
+
+  tierId = computed(() => this.paramMap().get('tier') ?? '');
+  hasArchiveData = computed(() => this.store.getFullTable().length > 0);
+  showLoadingState = computed(() => !this.hasArchiveData() && this.dataLoader.showLoadingState());
+  loadFailed = computed(() => !this.hasArchiveData() && this.dataLoader.loadStatus() === 'error');
+  profile = computed(() => {
+    const tier = this.tierId();
+    if (!/^tier\d+$/.test(tier)) {
+      return null;
+    }
+
+    const profile = buildTierProfileData(this.store.getFullTable(), tier, (teamId) =>
+      this.store.getTeamById(teamId)
+    );
+    return profile.totalRows ? profile : null;
+  });
+
+  tierLabel = computed(() => this.formatTierLabel(this.tierId()));
+  sourceTierLabel = computed(() => {
+    const sourceTier = this.adjacentLowerTier(this.tierId());
+    return sourceTier ? this.formatTierLabel(sourceTier) : '';
+  });
+
+  retryArchiveLoad() {
+    void this.dataLoader.loadData();
+  }
+
+  seasonRangeLabel(): string {
+    const seasons = this.profile()?.seasons ?? [];
+    if (!seasons.length) {
+      return 'No seasons';
+    }
+
+    const first = seasons[0];
+    const latest = seasons.at(-1);
+    return first === latest ? String(first) : `${first}-${latest}`;
+  }
+
+  tableQueryParams(season: number): { season: number; tier: string } {
+    return {
+      season,
+      tier: this.tierId(),
+    };
+  }
+
+  sourceTableQueryParams(season: number): { season: number; tier: string } {
+    return {
+      season,
+      tier: this.adjacentLowerTier(this.tierId()) ?? this.tierId(),
+    };
+  }
+
+  movementRows(rows: TierClubTotal[]): TierClubTotal[] {
+    return rows.slice(0, 6);
+  }
+
+  raceRows(rows: TierRaceRow[]): TierRaceRow[] {
+    return rows.slice(0, 5);
+  }
+
+  private formatTierLabel(tier: string): string {
+    return this.tierLabelPipe.transform(tier) || this.fallbackTierLabel(tier);
+  }
+
+  private fallbackTierLabel(tier: string): string {
+    const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+    return Number.isFinite(parsed) ? `Tier ${parsed}` : 'Unknown tier';
+  }
+
+  private adjacentLowerTier(tier: string): string | null {
+    const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+    return Number.isFinite(parsed) ? `tier${parsed + 1}` : null;
+  }
+}

--- a/src/app/pages/tier-profile/tier-profile.ts
+++ b/src/app/pages/tier-profile/tier-profile.ts
@@ -12,6 +12,96 @@ import {
   type TierRaceRow,
 } from '@app/utils/tier-profile';
 
+interface EraFilter {
+  id: string;
+  label: string;
+  detail: string;
+  start: number | null;
+  end: number | null;
+  tier1Only?: boolean;
+}
+
+interface TierDataNoticeDefinition {
+  id: string;
+  tiers: readonly string[];
+  ranges: readonly SeasonRange[];
+  title: string;
+  detail: string;
+}
+
+interface SeasonRange {
+  start: number;
+  end: number;
+}
+
+interface TierDataNotice {
+  id: string;
+  title: string;
+  detail: string;
+  seasonsLabel: string;
+}
+
+const ERA_FILTERS: EraFilter[] = [
+  {
+    id: 'all',
+    label: 'All eras',
+    detail: 'Full archive',
+    start: null,
+    end: null,
+  },
+  {
+    id: 'goal-average',
+    label: 'Goal average',
+    detail: 'Up to 1975',
+    start: null,
+    end: 1975,
+  },
+  {
+    id: 'gd-goals',
+    label: 'GD and goals',
+    detail: '1976-2018',
+    start: 1976,
+    end: 2018,
+  },
+  {
+    id: 'premier-league',
+    label: 'Premier League',
+    detail: '1992 onward',
+    start: 1992,
+    end: null,
+    tier1Only: true,
+  },
+  {
+    id: 'modern',
+    label: 'Modern rules',
+    detail: '2019 onward',
+    start: 2019,
+    end: null,
+  },
+];
+
+const TIER_DATA_NOTICES: TierDataNoticeDefinition[] = [
+  {
+    id: 'third-division-regional',
+    tiers: ['tier3', 'tier4'],
+    ranges: [
+      { start: 1921, end: 1938 },
+      { start: 1946, end: 1957 },
+    ],
+    title: 'Regional Third Division data',
+    detail:
+      'From 1921-22 through 1957-58, the Football League Third Division was split into North and South. These archive slots use tier3 for Third Division North and tier4 for Third Division South, but both represent pyramid level 3. True level 4 begins in 1958-59 with the Fourth Division.',
+  },
+  {
+    id: 'national-league-regional',
+    tiers: ['tier6', 'tier7'],
+    ranges: [{ start: 2021, end: 2025 }],
+    title: 'Parallel level 6 divisions',
+    detail:
+      'From 2021-2025 in the current archive, National League North and South are stored as tier6 and tier7 slots, but both represent parallel pyramid level 6 divisions. Tier7 should not be read as a true level 7 in this period.',
+  },
+];
+
 @Component({
   selector: 'app-tier-profile',
   imports: [CommonModule, MatButtonModule, RouterLink],
@@ -27,12 +117,15 @@ export class TierProfile {
   private paramMap = toSignal(this.route.paramMap, {
     initialValue: this.route.snapshot.paramMap,
   });
+  private queryParamMap = toSignal(this.route.queryParamMap, {
+    initialValue: this.route.snapshot.queryParamMap,
+  });
 
   tierId = computed(() => this.paramMap().get('tier') ?? '');
   hasArchiveData = computed(() => this.store.getFullTable().length > 0);
   showLoadingState = computed(() => !this.hasArchiveData() && this.dataLoader.showLoadingState());
   loadFailed = computed(() => !this.hasArchiveData() && this.dataLoader.loadStatus() === 'error');
-  profile = computed(() => {
+  fullProfile = computed(() => {
     const tier = this.tierId();
     if (!/^tier\d+$/.test(tier)) {
       return null;
@@ -43,11 +136,84 @@ export class TierProfile {
     );
     return profile.totalRows ? profile : null;
   });
+  availableEraFilters = computed(() => {
+    const profile = this.fullProfile();
+    if (!profile) {
+      return [];
+    }
+
+    const seasons = profile.seasons;
+    const filters = ERA_FILTERS.filter(
+      (filter) =>
+        (!filter.tier1Only || this.tierId() === 'tier1') &&
+        seasons.some((season) => this.seasonMatchesEra(season, filter))
+    );
+    const latestSeason = profile.latestSeason;
+    if (latestSeason) {
+      const recentFilter: EraFilter = {
+        id: 'recent',
+        label: 'Last 10 seasons',
+        detail: `${Math.max(seasons[0], latestSeason - 9)}-${latestSeason}`,
+        start: latestSeason - 9,
+        end: latestSeason,
+      };
+      filters.push(recentFilter);
+    }
+
+    return filters;
+  });
+  selectedEraFilter = computed(() => {
+    const requestedEra = this.queryParamMap().get('era') ?? 'all';
+    return (
+      this.availableEraFilters().find((filter) => filter.id === requestedEra) ??
+      this.availableEraFilters()[0] ??
+      ERA_FILTERS[0]
+    );
+  });
+  profile = computed(() => {
+    const fullProfile = this.fullProfile();
+    const tier = this.tierId();
+    const selectedEra = this.selectedEraFilter();
+    if (!fullProfile || selectedEra.id === 'all') {
+      return fullProfile;
+    }
+
+    const filteredEntries = this.store
+      .getFullTable()
+      .filter((entry) => this.seasonMatchesEra(entry.season, selectedEra));
+    const profile = buildTierProfileData(filteredEntries, tier, (teamId) =>
+      this.store.getTeamById(teamId)
+    );
+    return profile.totalRows ? profile : fullProfile;
+  });
 
   tierLabel = computed(() => this.formatTierLabel(this.tierId()));
   sourceTierLabel = computed(() => {
     const sourceTier = this.adjacentLowerTier(this.tierId());
     return sourceTier ? this.formatTierLabel(sourceTier) : '';
+  });
+  upperTierId = computed(() => {
+    const tier = this.adjacentUpperTier(this.tierId());
+    return tier && this.hasTier(tier) ? tier : null;
+  });
+  lowerTierId = computed(() => {
+    const tier = this.adjacentLowerTier(this.tierId());
+    return tier && this.hasTier(tier) ? tier : null;
+  });
+  dataNotices = computed<TierDataNotice[]>(() => {
+    const profile = this.profile();
+    if (!profile) {
+      return [];
+    }
+
+    return TIER_DATA_NOTICES.filter((notice) => notice.tiers.includes(this.tierId()))
+      .map((notice) => ({
+        id: notice.id,
+        title: notice.title,
+        detail: notice.detail,
+        seasonsLabel: this.affectedSeasonsLabel(profile.seasons, notice.ranges),
+      }))
+      .filter((notice) => notice.seasonsLabel.length > 0);
   });
 
   retryArchiveLoad() {
@@ -72,6 +238,16 @@ export class TierProfile {
     };
   }
 
+  latestTableQueryParams(): { season: number; tier: string } | null {
+    const latestSeason = this.profile()?.latestSeason;
+    return latestSeason
+      ? {
+          season: latestSeason,
+          tier: this.tierId(),
+        }
+      : null;
+  }
+
   sourceTableQueryParams(season: number): { season: number; tier: string } {
     return {
       season,
@@ -87,6 +263,25 @@ export class TierProfile {
     return rows.slice(0, 5);
   }
 
+  eraQueryParams(filterId: string): { era: string | null } {
+    return {
+      era: filterId === 'all' ? null : filterId,
+    };
+  }
+
+  selectedEraSummary(): string {
+    const profile = this.profile();
+    if (!profile?.seasons.length) {
+      return 'No seasons in this view';
+    }
+
+    const first = profile.seasons[0];
+    const latest = profile.seasons.at(-1);
+    return first === latest
+      ? `Showing ${first}`
+      : `Showing ${profile.seasons.length} seasons from ${first}-${latest}`;
+  }
+
   private formatTierLabel(tier: string): string {
     return this.tierLabelPipe.transform(tier) || this.fallbackTierLabel(tier);
   }
@@ -99,5 +294,52 @@ export class TierProfile {
   private adjacentLowerTier(tier: string): string | null {
     const parsed = Number.parseInt(tier.replace('tier', ''), 10);
     return Number.isFinite(parsed) ? `tier${parsed + 1}` : null;
+  }
+
+  private adjacentUpperTier(tier: string): string | null {
+    const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+    return Number.isFinite(parsed) && parsed > 1 ? `tier${parsed - 1}` : null;
+  }
+
+  private hasTier(tier: string): boolean {
+    return this.store.getFullTable().some((entry) => entry.tier === tier);
+  }
+
+  private seasonMatchesEra(season: number, filter: EraFilter): boolean {
+    return (
+      (filter.start === null || season >= filter.start) &&
+      (filter.end === null || season <= filter.end)
+    );
+  }
+
+  private affectedSeasonsLabel(seasons: readonly number[], ranges: readonly SeasonRange[]): string {
+    const affectedSeasons = seasons.filter((season) =>
+      ranges.some((range) => season >= range.start && season <= range.end)
+    );
+    if (!affectedSeasons.length) {
+      return '';
+    }
+
+    const segments: string[] = [];
+    let segmentStart = affectedSeasons[0];
+    let previousSeason = affectedSeasons[0];
+
+    affectedSeasons.slice(1).forEach((season) => {
+      if (season === previousSeason + 1) {
+        previousSeason = season;
+        return;
+      }
+
+      segments.push(this.formatSeasonSegment(segmentStart, previousSeason));
+      segmentStart = season;
+      previousSeason = season;
+    });
+
+    segments.push(this.formatSeasonSegment(segmentStart, previousSeason));
+    return segments.join(', ');
+  }
+
+  private formatSeasonSegment(start: number, end: number): string {
+    return start === end ? String(start) : `${start}-${end}`;
   }
 }

--- a/src/app/pipes/league-tier-to-stringy-pipe.spec.ts
+++ b/src/app/pipes/league-tier-to-stringy-pipe.spec.ts
@@ -13,6 +13,8 @@ describe('LeagueTierToStringyPipe', () => {
     ['tier3', 'League One'],
     ['tier4', 'League Two'],
     ['tier5', 'National League'],
+    ['tier6', 'National League North'],
+    ['tier7', 'National League South'],
   ])('maps %s to %s', (input, expected) => {
     expect(pipe.transform(input)).toBe(expected);
   });

--- a/src/app/pipes/league-tier-to-stringy-pipe.ts
+++ b/src/app/pipes/league-tier-to-stringy-pipe.ts
@@ -6,6 +6,8 @@ const tierToStringy: Record<string, string> = {
   tier3: 'League One',
   tier4: 'League Two',
   tier5: 'National League',
+  tier6: 'National League North',
+  tier7: 'National League South',
 };
 
 @Pipe({

--- a/src/app/store/services/data-bundle.models.ts
+++ b/src/app/store/services/data-bundle.models.ts
@@ -7,7 +7,8 @@ export interface SeasonsDocument {
 
 export interface DataBundleAssetManifest {
   url: string;
-  sha256: string;
+  sha256?: string;
+  gitBlobSha?: string;
   size?: number;
 }
 
@@ -37,8 +38,10 @@ export interface ActiveDataInfo {
 }
 
 export interface GitHubReleaseAsset {
+  url?: string;
   name: string;
   browser_download_url: string;
+  digest?: string;
   size?: number;
 }
 
@@ -47,4 +50,16 @@ export interface GitHubRelease {
   published_at: string;
   target_commitish?: string;
   assets: GitHubReleaseAsset[];
+}
+
+export interface GitHubTreeItem {
+  path: string;
+  type: 'blob' | 'tree' | string;
+  sha: string;
+  size?: number;
+}
+
+export interface GitHubTree {
+  tree: GitHubTreeItem[];
+  truncated?: boolean;
 }

--- a/src/app/store/services/data-bundle.models.ts
+++ b/src/app/store/services/data-bundle.models.ts
@@ -1,0 +1,50 @@
+import type { DataAssetMetadata, ClubMetadataDocument } from '../club-metadata.models';
+
+export interface SeasonsDocument {
+  seasons: Record<string, unknown>;
+  metadata?: DataAssetMetadata;
+}
+
+export interface DataBundleAssetManifest {
+  url: string;
+  sha256: string;
+  size?: number;
+}
+
+export interface DataBundleManifest {
+  version: string;
+  generatedAt: string;
+  gitSha: string;
+  assets: {
+    seasons: DataBundleAssetManifest;
+    clubMetadata: DataBundleAssetManifest;
+  };
+}
+
+export interface InstalledDataBundle {
+  manifest: DataBundleManifest;
+  seasonsDocument: SeasonsDocument;
+  clubMetadataDocument: ClubMetadataDocument;
+  installedAt: string;
+}
+
+export interface ActiveDataInfo {
+  source: 'shipped' | 'local-override';
+  version: string;
+  generatedAt: string;
+  gitSha: string;
+  installedAt?: string;
+}
+
+export interface GitHubReleaseAsset {
+  name: string;
+  browser_download_url: string;
+  size?: number;
+}
+
+export interface GitHubRelease {
+  tag_name: string;
+  published_at: string;
+  target_commitish?: string;
+  assets: GitHubReleaseAsset[];
+}

--- a/src/app/store/services/data-override-storage.ts
+++ b/src/app/store/services/data-override-storage.ts
@@ -1,0 +1,146 @@
+import { Injectable } from '@angular/core';
+import type { DataBundleManifest, InstalledDataBundle } from './data-bundle.models';
+
+const DB_NAME = 'footy-stats-data';
+const DB_VERSION = 1;
+const STORE_NAME = 'bundles';
+const ACTIVE_BUNDLE_KEY = 'active';
+const LOCAL_STORAGE_META_KEY = 'footy-stats:dataOverrideMeta:v1';
+const LOCAL_STORAGE_BUNDLE_KEY = 'footy-stats:dataOverrideBundle:v1';
+
+@Injectable({ providedIn: 'root' })
+export class DataOverrideStorage {
+  async read(): Promise<InstalledDataBundle | null> {
+    const indexedDbBundle = await this.readFromIndexedDb();
+    if (indexedDbBundle) {
+      return indexedDbBundle;
+    }
+
+    return this.readFromLocalStorage();
+  }
+
+  async write(bundle: InstalledDataBundle): Promise<void> {
+    try {
+      await this.writeToIndexedDb(bundle);
+      this.writeMetadataToLocalStorage(bundle.manifest, bundle.installedAt);
+      globalThis.localStorage?.removeItem(LOCAL_STORAGE_BUNDLE_KEY);
+      return;
+    } catch {
+      this.writeToLocalStorage(bundle);
+    }
+  }
+
+  async clear(): Promise<void> {
+    await this.deleteFromIndexedDb();
+    globalThis.localStorage?.removeItem(LOCAL_STORAGE_META_KEY);
+    globalThis.localStorage?.removeItem(LOCAL_STORAGE_BUNDLE_KEY);
+  }
+
+  readMetadata(): { manifest: DataBundleManifest; installedAt: string } | null {
+    const raw = globalThis.localStorage?.getItem(LOCAL_STORAGE_META_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(raw) as { manifest: DataBundleManifest; installedAt: string };
+    } catch {
+      globalThis.localStorage?.removeItem(LOCAL_STORAGE_META_KEY);
+      return null;
+    }
+  }
+
+  private async readFromIndexedDb(): Promise<InstalledDataBundle | null> {
+    const db = await this.openDatabase();
+    if (!db) {
+      return null;
+    }
+
+    return new Promise<InstalledDataBundle | null>((resolve) => {
+      const transaction = db.transaction(STORE_NAME, 'readonly');
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.get(ACTIVE_BUNDLE_KEY);
+      request.onsuccess = () =>
+        resolve((request.result as InstalledDataBundle | undefined) ?? null);
+      request.onerror = () => resolve(null);
+    }).finally(() => db.close());
+  }
+
+  private async writeToIndexedDb(bundle: InstalledDataBundle): Promise<void> {
+    const db = await this.openDatabase();
+    if (!db) {
+      throw new Error('IndexedDB is unavailable.');
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, 'readwrite');
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.put(bundle, ACTIVE_BUNDLE_KEY);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+      transaction.onerror = () => reject(transaction.error);
+    }).finally(() => db.close());
+  }
+
+  private async deleteFromIndexedDb(): Promise<void> {
+    const db = await this.openDatabase();
+    if (!db) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      const transaction = db.transaction(STORE_NAME, 'readwrite');
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.delete(ACTIVE_BUNDLE_KEY);
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+    }).finally(() => db.close());
+  }
+
+  private openDatabase(): Promise<IDBDatabase | null> {
+    if (!globalThis.indexedDB) {
+      return Promise.resolve(null);
+    }
+
+    return new Promise((resolve) => {
+      const request = globalThis.indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => resolve(null);
+    });
+  }
+
+  private readFromLocalStorage(): InstalledDataBundle | null {
+    const raw = globalThis.localStorage?.getItem(LOCAL_STORAGE_BUNDLE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(raw) as InstalledDataBundle;
+    } catch {
+      globalThis.localStorage?.removeItem(LOCAL_STORAGE_BUNDLE_KEY);
+      return null;
+    }
+  }
+
+  private writeToLocalStorage(bundle: InstalledDataBundle) {
+    globalThis.localStorage?.setItem(LOCAL_STORAGE_BUNDLE_KEY, JSON.stringify(bundle));
+    this.writeMetadataToLocalStorage(bundle.manifest, bundle.installedAt);
+  }
+
+  private writeMetadataToLocalStorage(manifest: DataBundleManifest, installedAt: string) {
+    globalThis.localStorage?.setItem(
+      LOCAL_STORAGE_META_KEY,
+      JSON.stringify({
+        manifest,
+        installedAt,
+      })
+    );
+  }
+}

--- a/src/app/store/services/data-update.service.spec.ts
+++ b/src/app/store/services/data-update.service.spec.ts
@@ -1,0 +1,236 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '@env/environment';
+import type { ClubMetadataDocument } from '../club-metadata.models';
+import type { ActiveDataInfo, DataBundleManifest, SeasonsDocument } from './data-bundle.models';
+import { DataUpdateService } from './data-update.service';
+import { DataLoaderService } from './hydrate-store-json';
+
+describe('DataUpdateService', () => {
+  let service: DataUpdateService;
+  let http: HttpTestingController;
+  let originalCrypto: Crypto;
+  let activeDataInfo: ReturnType<typeof signal<ActiveDataInfo | null>>;
+  let dataLoader: {
+    activeDataInfo: ReturnType<typeof signal<ActiveDataInfo | null>>;
+    installOverride: jest.Mock<Promise<void>>;
+    clearOverrideAndReload: jest.Mock<Promise<void>>;
+  };
+
+  beforeEach(() => {
+    originalCrypto = globalThis.crypto;
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: {
+        ...originalCrypto,
+        subtle: {
+          digest: jest.fn((_algorithm: AlgorithmIdentifier, data: BufferSource) =>
+            Promise.resolve(fakeDigest(data))
+          ),
+        },
+      },
+    });
+
+    activeDataInfo = signal<ActiveDataInfo | null>({
+      source: 'shipped',
+      version: 'shipped-sha',
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      gitSha: 'shipped-sha',
+    });
+    dataLoader = {
+      activeDataInfo,
+      installOverride: jest.fn(() => Promise.resolve()),
+      clearOverrideAndReload: jest.fn(() => Promise.resolve()),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: DataLoaderService,
+          useValue: dataLoader,
+        },
+      ],
+    });
+
+    service = TestBed.inject(DataUpdateService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: originalCrypto,
+    });
+  });
+
+  it('finds a newer release manifest and exposes an available update', async () => {
+    const checkPromise = service.checkForUpdates();
+
+    http.expectOne(environment.dataUpdates.githubLatestReleaseApiUrl).flush({
+      tag_name: 'data-2026-06-18',
+      published_at: '2026-06-18T12:00:00.000Z',
+      assets: [
+        {
+          name: 'footy-stats-data-manifest.json',
+          browser_download_url: 'https://example.com/manifest.json',
+        },
+      ],
+    });
+    await Promise.resolve();
+    http.expectOne('https://example.com/manifest.json').flush(manifest());
+
+    await checkPromise;
+
+    expect(service.checkStatus()).toBe('available');
+    expect(service.updateAvailable()).toBe(true);
+    expect(service.latestManifest()?.version).toBe('data-2026-06-18');
+  });
+
+  it('downloads, verifies, and installs the latest data bundle', async () => {
+    const seasonsText = JSON.stringify(seasonsDocument());
+    const clubMetadataText = JSON.stringify(clubMetadataDocument());
+    const updateManifest = manifest({
+      seasonsSha256: await sha256Hex(seasonsText),
+      clubMetadataSha256: await sha256Hex(clubMetadataText),
+    });
+
+    const checkPromise = service.checkForUpdates();
+    http.expectOne(environment.dataUpdates.githubLatestReleaseApiUrl).flush({
+      tag_name: 'data-2026-06-18',
+      published_at: '2026-06-18T12:00:00.000Z',
+      assets: [
+        {
+          name: 'footy-stats-data-manifest.json',
+          browser_download_url: 'https://example.com/manifest.json',
+        },
+      ],
+    });
+    await Promise.resolve();
+    http.expectOne('https://example.com/manifest.json').flush(updateManifest);
+    await checkPromise;
+
+    const installPromise = service.installLatestUpdate();
+
+    http.expectOne('https://example.com/seasons.json').flush(seasonsText);
+    http.expectOne('https://example.com/club-metadata.json').flush(clubMetadataText);
+
+    await installPromise;
+
+    expect(dataLoader.installOverride).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manifest: updateManifest,
+        seasonsDocument: seasonsDocument(),
+        clubMetadataDocument: clubMetadataDocument(),
+      })
+    );
+    expect(service.installStatus()).toBe('installed');
+    expect(service.checkStatus()).toBe('up-to-date');
+  });
+
+  it('reports checksum failures without installing the bundle', async () => {
+    const clubMetadataText = JSON.stringify(clubMetadataDocument());
+    const updateManifest = manifest({
+      seasonsSha256: '0'.repeat(64),
+      clubMetadataSha256: await sha256Hex(clubMetadataText),
+    });
+    const checkPromise = service.checkForUpdates();
+    http.expectOne(environment.dataUpdates.githubLatestReleaseApiUrl).flush({
+      tag_name: 'data-2026-06-18',
+      published_at: '2026-06-18T12:00:00.000Z',
+      assets: [
+        {
+          name: 'footy-stats-data-manifest.json',
+          browser_download_url: 'https://example.com/manifest.json',
+        },
+      ],
+    });
+    await Promise.resolve();
+    http.expectOne('https://example.com/manifest.json').flush(updateManifest);
+    await checkPromise;
+
+    const installPromise = service.installLatestUpdate();
+
+    http.expectOne('https://example.com/seasons.json').flush(JSON.stringify(seasonsDocument()));
+    http.expectOne('https://example.com/club-metadata.json').flush(clubMetadataText);
+
+    await installPromise;
+
+    expect(dataLoader.installOverride).not.toHaveBeenCalled();
+    expect(service.installStatus()).toBe('error');
+    expect(service.statusMessage()).toBe('seasons.json checksum mismatch.');
+  });
+});
+
+function manifest({
+  seasonsSha256 = '0'.repeat(64),
+  clubMetadataSha256 = '1'.repeat(64),
+}: {
+  seasonsSha256?: string;
+  clubMetadataSha256?: string;
+} = {}): DataBundleManifest {
+  return {
+    version: 'data-2026-06-18',
+    generatedAt: '2026-06-18T12:00:00.000Z',
+    gitSha: 'remote-sha',
+    assets: {
+      seasons: {
+        url: 'https://example.com/seasons.json',
+        sha256: seasonsSha256,
+      },
+      clubMetadata: {
+        url: 'https://example.com/club-metadata.json',
+        sha256: clubMetadataSha256,
+      },
+    },
+  };
+}
+
+function seasonsDocument(): SeasonsDocument {
+  return {
+    metadata: {
+      generatedAt: '2026-06-18T12:00:00.000Z',
+      gitSha: 'remote-sha',
+    },
+    seasons: {
+      2024: {
+        tier1: [],
+      },
+    },
+  };
+}
+
+function clubMetadataDocument(): ClubMetadataDocument {
+  return {
+    metadata: {
+      schemaVersion: 1,
+      generator: 'test',
+      generatedAt: '2026-06-18T12:00:00.000Z',
+      gitSha: 'remote-sha',
+    },
+    clubs: {},
+  };
+}
+
+async function sha256Hex(text: string): Promise<string> {
+  const bytes = new TextEncoder().encode(text);
+  const hash = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(hash))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function fakeDigest(data: BufferSource): ArrayBuffer {
+  const view =
+    data instanceof ArrayBuffer
+      ? new Uint8Array(data)
+      : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  const text = new TextDecoder().decode(view);
+  const hex = text.includes('"clubs"') ? 'b'.repeat(64) : 'a'.repeat(64);
+
+  return Uint8Array.from(hex.match(/../g) ?? [], (byte) => Number.parseInt(byte, 16)).buffer;
+}

--- a/src/app/store/services/data-update.service.spec.ts
+++ b/src/app/store/services/data-update.service.spec.ts
@@ -91,6 +91,82 @@ describe('DataUpdateService', () => {
     expect(service.latestManifest()?.version).toBe('data-2026-06-18');
   });
 
+  it('builds a verified manifest from footy-data-kit release assets', async () => {
+    const checkPromise = service.checkForUpdates();
+
+    http.expectOne(environment.dataUpdates.githubLatestReleaseApiUrl).flush({
+      tag_name: 'v0.8.2',
+      published_at: '2026-06-18T01:33:25.000Z',
+      target_commitish: 'main',
+      assets: [
+        {
+          url: 'https://api.github.com/repos/dills122/footy-data-kit/releases/assets/1',
+          name: 'all-seasons.min.json',
+          browser_download_url: 'https://example.com/all-seasons.min.json',
+          digest: `sha256:${'c'.repeat(64)}`,
+          size: 3300786,
+        },
+        {
+          url: 'https://api.github.com/repos/dills122/footy-data-kit/releases/assets/2',
+          name: 'all-seasons.json',
+          browser_download_url: 'https://example.com/all-seasons.json',
+          digest: `sha256:${'a'.repeat(64)}`,
+          size: 6187960,
+        },
+        {
+          url: 'https://api.github.com/repos/dills122/footy-data-kit/releases/assets/3',
+          name: 'club-metadata.json',
+          browser_download_url: 'https://example.com/club-metadata.json',
+          digest: `sha256:${'b'.repeat(64)}`,
+          size: 1267095,
+        },
+      ],
+    });
+    await Promise.resolve();
+    http
+      .expectOne(
+        'https://api.github.com/repos/dills122/footy-data-kit/git/trees/v0.8.2?recursive=1'
+      )
+      .flush({
+        truncated: false,
+        tree: [
+          {
+            path: 'data-output/all-seasons.min.json',
+            type: 'blob',
+            sha: 'season-git-sha',
+            size: 3300774,
+          },
+          {
+            path: 'data/club-metadata.json',
+            type: 'blob',
+            sha: 'club-git-sha',
+            size: 1267071,
+          },
+        ],
+      });
+
+    await checkPromise;
+
+    expect(service.checkStatus()).toBe('available');
+    expect(service.latestManifest()).toEqual({
+      version: 'v0.8.2',
+      generatedAt: '2026-06-18T01:33:25.000Z',
+      gitSha: 'v0.8.2',
+      assets: {
+        seasons: {
+          url: 'https://raw.githubusercontent.com/dills122/footy-data-kit/v0.8.2/data-output/all-seasons.min.json',
+          gitBlobSha: 'season-git-sha',
+          size: 3300774,
+        },
+        clubMetadata: {
+          url: 'https://raw.githubusercontent.com/dills122/footy-data-kit/v0.8.2/data/club-metadata.json',
+          gitBlobSha: 'club-git-sha',
+          size: 1267071,
+        },
+      },
+    });
+  });
+
   it('downloads, verifies, and installs the latest data bundle', async () => {
     const seasonsText = JSON.stringify(seasonsDocument());
     const clubMetadataText = JSON.stringify(clubMetadataDocument());
@@ -116,7 +192,9 @@ describe('DataUpdateService', () => {
 
     const installPromise = service.installLatestUpdate();
 
-    http.expectOne('https://example.com/seasons.json').flush(seasonsText);
+    const seasonsRequest = http.expectOne('https://example.com/seasons.json');
+    expect(seasonsRequest.request.headers.has('Accept')).toBe(false);
+    seasonsRequest.flush(seasonsText);
     http.expectOne('https://example.com/club-metadata.json').flush(clubMetadataText);
 
     await installPromise;
@@ -130,6 +208,59 @@ describe('DataUpdateService', () => {
     );
     expect(service.installStatus()).toBe('installed');
     expect(service.checkStatus()).toBe('up-to-date');
+  });
+
+  it('downloads and verifies raw GitHub URLs for release fallback manifests', async () => {
+    const seasonsText = JSON.stringify(seasonsDocument());
+    const clubMetadataText = JSON.stringify(clubMetadataDocument());
+    const updateManifest = manifest({
+      seasonsUrl:
+        'https://raw.githubusercontent.com/dills122/footy-data-kit/v0.8.2/data-output/all-seasons.min.json',
+      clubMetadataUrl:
+        'https://raw.githubusercontent.com/dills122/footy-data-kit/v0.8.2/data/club-metadata.json',
+      seasonsSha256: null,
+      clubMetadataSha256: null,
+      seasonsGitBlobSha: await gitBlobSha(seasonsText),
+      clubMetadataGitBlobSha: await gitBlobSha(clubMetadataText),
+    });
+
+    const checkPromise = service.checkForUpdates();
+    http.expectOne(environment.dataUpdates.githubLatestReleaseApiUrl).flush({
+      tag_name: 'data-2026-06-18',
+      published_at: '2026-06-18T12:00:00.000Z',
+      assets: [
+        {
+          name: 'footy-stats-data-manifest.json',
+          browser_download_url: 'https://example.com/manifest.json',
+        },
+      ],
+    });
+    await Promise.resolve();
+    http.expectOne('https://example.com/manifest.json').flush(updateManifest);
+    await checkPromise;
+
+    const installPromise = service.installLatestUpdate();
+
+    const seasonsRequest = http.expectOne(
+      'https://raw.githubusercontent.com/dills122/footy-data-kit/v0.8.2/data-output/all-seasons.min.json'
+    );
+    expect(seasonsRequest.request.headers.has('Accept')).toBe(false);
+    seasonsRequest.flush(seasonsText);
+
+    const clubMetadataRequest = http.expectOne(
+      'https://raw.githubusercontent.com/dills122/footy-data-kit/v0.8.2/data/club-metadata.json'
+    );
+    expect(clubMetadataRequest.request.headers.has('Accept')).toBe(false);
+    clubMetadataRequest.flush(clubMetadataText);
+
+    await installPromise;
+
+    expect(dataLoader.installOverride).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manifest: updateManifest,
+      })
+    );
+    expect(service.installStatus()).toBe('installed');
   });
 
   it('reports checksum failures without installing the bundle', async () => {
@@ -167,11 +298,19 @@ describe('DataUpdateService', () => {
 });
 
 function manifest({
+  seasonsUrl = 'https://example.com/seasons.json',
+  clubMetadataUrl = 'https://example.com/club-metadata.json',
   seasonsSha256 = '0'.repeat(64),
   clubMetadataSha256 = '1'.repeat(64),
+  seasonsGitBlobSha,
+  clubMetadataGitBlobSha,
 }: {
-  seasonsSha256?: string;
-  clubMetadataSha256?: string;
+  seasonsUrl?: string;
+  clubMetadataUrl?: string;
+  seasonsSha256?: string | null;
+  clubMetadataSha256?: string | null;
+  seasonsGitBlobSha?: string;
+  clubMetadataGitBlobSha?: string;
 } = {}): DataBundleManifest {
   return {
     version: 'data-2026-06-18',
@@ -179,12 +318,14 @@ function manifest({
     gitSha: 'remote-sha',
     assets: {
       seasons: {
-        url: 'https://example.com/seasons.json',
-        sha256: seasonsSha256,
+        url: seasonsUrl,
+        sha256: seasonsSha256 ?? undefined,
+        gitBlobSha: seasonsGitBlobSha,
       },
       clubMetadata: {
-        url: 'https://example.com/club-metadata.json',
-        sha256: clubMetadataSha256,
+        url: clubMetadataUrl,
+        sha256: clubMetadataSha256 ?? undefined,
+        gitBlobSha: clubMetadataGitBlobSha,
       },
     },
   };
@@ -219,6 +360,19 @@ function clubMetadataDocument(): ClubMetadataDocument {
 async function sha256Hex(text: string): Promise<string> {
   const bytes = new TextEncoder().encode(text);
   const hash = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(hash))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function gitBlobSha(text: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(text);
+  const prefix = encoder.encode(`blob ${bytes.length}\0`);
+  const payload = new Uint8Array(prefix.length + bytes.length);
+  payload.set(prefix);
+  payload.set(bytes, prefix.length);
+  const hash = await globalThis.crypto.subtle.digest('SHA-1', payload);
   return Array.from(new Uint8Array(hash))
     .map((byte) => byte.toString(16).padStart(2, '0'))
     .join('');

--- a/src/app/store/services/data-update.service.ts
+++ b/src/app/store/services/data-update.service.ts
@@ -8,6 +8,8 @@ import type {
   DataBundleManifest,
   GitHubRelease,
   GitHubReleaseAsset,
+  GitHubTree,
+  GitHubTreeItem,
   InstalledDataBundle,
   SeasonsDocument,
 } from './data-bundle.models';
@@ -90,10 +92,10 @@ export class DataUpdateService {
 
       this.installState.set('verifying');
       await Promise.all([
-        this.verifySha256(seasonsText, manifest.assets.seasons.sha256, 'seasons.json'),
-        this.verifySha256(
+        this.verifyAssetIntegrity(seasonsText, manifest.assets.seasons, 'seasons.json'),
+        this.verifyAssetIntegrity(
           clubMetadataText,
-          manifest.assets.clubMetadata.sha256,
+          manifest.assets.clubMetadata,
           'club-metadata.json'
         ),
       ]);
@@ -142,59 +144,97 @@ export class DataUpdateService {
   private async buildManifestFromReleaseAssets(
     release: GitHubRelease
   ): Promise<DataBundleManifest> {
-    const seasonsAsset = this.requiredAsset(
+    const seasonsAsset = this.releaseAssetForDataSlot(
       release.assets,
-      environment.dataUpdates.seasonsAssetName
+      environment.dataUpdates.seasonsAssetNames,
+      'season data'
     );
-    const clubMetadataAsset = this.requiredAsset(
+    const clubMetadataAsset = this.releaseAssetForDataSlot(
       release.assets,
-      environment.dataUpdates.clubMetadataAssetName
+      environment.dataUpdates.clubMetadataAssetNames,
+      'club metadata'
     );
-    const [seasonsSha256, clubMetadataSha256] = await Promise.all([
-      this.fetchSha256ForAsset(release.assets, seasonsAsset.name),
-      this.fetchSha256ForAsset(release.assets, clubMetadataAsset.name),
-    ]);
+    const releaseTree = await this.fetchReleaseTree(release.tag_name);
 
     return {
       version: release.tag_name,
       generatedAt: release.published_at,
-      gitSha: release.target_commitish ?? release.tag_name,
+      gitSha: release.tag_name,
       assets: {
-        seasons: this.assetManifest(seasonsAsset, seasonsSha256),
-        clubMetadata: this.assetManifest(clubMetadataAsset, clubMetadataSha256),
+        seasons: this.rawAssetManifest(release.tag_name, releaseTree, seasonsAsset),
+        clubMetadata: this.rawAssetManifest(release.tag_name, releaseTree, clubMetadataAsset),
       },
     };
   }
 
-  private requiredAsset(assets: readonly GitHubReleaseAsset[], name: string): GitHubReleaseAsset {
-    const asset = assets.find((candidate) => candidate.name === name);
+  private releaseAssetForDataSlot(
+    assets: readonly GitHubReleaseAsset[],
+    names: readonly string[],
+    label: string
+  ): GitHubReleaseAsset {
+    const asset = assets.find((candidate) => names.includes(candidate.name));
     if (!asset) {
-      throw new Error(`The latest data release is missing ${name}.`);
+      throw new Error(`The latest data release is missing a supported ${label} file.`);
     }
 
     return asset;
   }
 
-  private async fetchSha256ForAsset(
-    assets: readonly GitHubReleaseAsset[],
-    assetName: string
-  ): Promise<string> {
-    const checksumAsset = this.requiredAsset(assets, `${assetName}.sha256`);
-    const checksumText = await this.downloadText(checksumAsset.browser_download_url);
-    const checksum = checksumText.trim().split(/\s+/)[0]?.toLowerCase();
-    if (!checksum || !/^[a-f0-9]{64}$/.test(checksum)) {
-      throw new Error(`${checksumAsset.name} does not contain a valid SHA-256 checksum.`);
+  private async fetchReleaseTree(tagName: string): Promise<GitHubTree> {
+    const tree = await lastValueFrom(
+      this.http.get<GitHubTree>(
+        `${this.githubRepoApiUrl()}/git/trees/${encodeURIComponent(tagName)}?recursive=1`
+      )
+    );
+
+    if (tree.truncated) {
+      throw new Error('The latest data release tree is too large to verify in the browser.');
     }
 
-    return checksum;
+    return tree;
   }
 
-  private assetManifest(asset: GitHubReleaseAsset, sha256: string): DataBundleAssetManifest {
+  private rawAssetManifest(
+    tagName: string,
+    releaseTree: GitHubTree,
+    asset: GitHubReleaseAsset
+  ): DataBundleAssetManifest {
+    const rawPath = this.rawPathForReleaseAsset(asset.name);
+    const treeItem = this.requiredTreeItem(releaseTree.tree, rawPath);
+
     return {
-      url: asset.browser_download_url,
-      sha256,
-      size: asset.size,
+      url: this.rawGithubUrl(tagName, rawPath),
+      gitBlobSha: treeItem.sha,
+      size: treeItem.size ?? asset.size,
     };
+  }
+
+  private rawPathForReleaseAsset(assetName: string): string {
+    const rawPath =
+      environment.dataUpdates.rawAssetPathsByName[
+        assetName as keyof typeof environment.dataUpdates.rawAssetPathsByName
+      ];
+
+    if (!rawPath) {
+      throw new Error(
+        `The latest data release does not define a browser-safe path for ${assetName}.`
+      );
+    }
+
+    return rawPath;
+  }
+
+  private requiredTreeItem(tree: readonly GitHubTreeItem[], path: string): GitHubTreeItem {
+    const item = tree.find((candidate) => candidate.type === 'blob' && candidate.path === path);
+    if (!item) {
+      throw new Error(`The latest data release is missing ${path}.`);
+    }
+
+    return item;
+  }
+
+  private rawGithubUrl(tagName: string, path: string): string {
+    return `https://raw.githubusercontent.com/dills122/footy-data-kit/${encodeURIComponent(tagName)}/${path}`;
   }
 
   private isNewerThanActiveData(manifest: DataBundleManifest): boolean {
@@ -233,5 +273,47 @@ export class DataUpdateService {
     return Array.from(new Uint8Array(hash))
       .map((byte) => byte.toString(16).padStart(2, '0'))
       .join('');
+  }
+
+  private async verifyAssetIntegrity(
+    text: string,
+    asset: DataBundleAssetManifest,
+    label: string
+  ): Promise<void> {
+    if (asset.sha256) {
+      await this.verifySha256(text, asset.sha256, label);
+      return;
+    }
+
+    if (asset.gitBlobSha) {
+      await this.verifyGitBlobSha(text, asset.gitBlobSha, label);
+      return;
+    }
+
+    throw new Error(`${label} is missing a verification checksum.`);
+  }
+
+  private async verifyGitBlobSha(text: string, expected: string, label: string): Promise<void> {
+    const actual = await this.gitBlobSha(text);
+    if (actual !== expected.toLowerCase()) {
+      throw new Error(`${label} git blob checksum mismatch.`);
+    }
+  }
+
+  private async gitBlobSha(text: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(text);
+    const prefix = encoder.encode(`blob ${bytes.length}\0`);
+    const payload = new Uint8Array(prefix.length + bytes.length);
+    payload.set(prefix);
+    payload.set(bytes, prefix.length);
+    const hash = await globalThis.crypto.subtle.digest('SHA-1', payload);
+    return Array.from(new Uint8Array(hash))
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
+  }
+
+  private githubRepoApiUrl(): string {
+    return environment.dataUpdates.githubLatestReleaseApiUrl.replace(/\/releases\/latest$/, '');
   }
 }

--- a/src/app/store/services/data-update.service.ts
+++ b/src/app/store/services/data-update.service.ts
@@ -1,0 +1,237 @@
+import { HttpClient } from '@angular/common/http';
+import { computed, Injectable, inject, signal } from '@angular/core';
+import { environment } from '@env/environment';
+import { lastValueFrom } from 'rxjs';
+import type { ClubMetadataDocument } from '../club-metadata.models';
+import type {
+  DataBundleAssetManifest,
+  DataBundleManifest,
+  GitHubRelease,
+  GitHubReleaseAsset,
+  InstalledDataBundle,
+  SeasonsDocument,
+} from './data-bundle.models';
+import { DataLoaderService } from './hydrate-store-json';
+
+type UpdateCheckStatus = 'idle' | 'checking' | 'available' | 'up-to-date' | 'error';
+type UpdateInstallStatus = 'idle' | 'downloading' | 'verifying' | 'installed' | 'error';
+
+@Injectable({ providedIn: 'root' })
+export class DataUpdateService {
+  private http = inject(HttpClient);
+  private dataLoader = inject(DataLoaderService);
+  private checkState = signal<UpdateCheckStatus>('idle');
+  private installState = signal<UpdateInstallStatus>('idle');
+  private latest = signal<DataBundleManifest | null>(null);
+  private message = signal('');
+  private dismissedVersion = signal<string | null>(null);
+
+  readonly checkStatus = this.checkState.asReadonly();
+  readonly installStatus = this.installState.asReadonly();
+  readonly latestManifest = this.latest.asReadonly();
+  readonly statusMessage = this.message.asReadonly();
+  readonly activeDataInfo = this.dataLoader.activeDataInfo;
+  readonly hasLocalOverride = computed(() => this.activeDataInfo()?.source === 'local-override');
+  readonly updateAvailable = computed(
+    () =>
+      this.checkState() === 'available' &&
+      Boolean(this.latest()) &&
+      this.dismissedVersion() !== this.latest()?.version
+  );
+
+  async checkForUpdates(): Promise<void> {
+    if (!environment.dataUpdates.githubLatestReleaseApiUrl) {
+      this.checkState.set('up-to-date');
+      return;
+    }
+
+    this.checkState.set('checking');
+    this.message.set('');
+
+    try {
+      const manifest = await this.fetchLatestManifest();
+      this.latest.set(manifest);
+
+      if (this.isNewerThanActiveData(manifest)) {
+        this.checkState.set('available');
+        return;
+      }
+
+      this.checkState.set('up-to-date');
+    } catch (error) {
+      this.checkState.set('error');
+      this.message.set(
+        error instanceof Error ? error.message : 'Could not check for data updates.'
+      );
+    }
+  }
+
+  dismissAvailableUpdate() {
+    const manifest = this.latest();
+    if (manifest) {
+      this.dismissedVersion.set(manifest.version);
+    }
+  }
+
+  async installLatestUpdate(): Promise<void> {
+    const manifest = this.latest();
+    if (!manifest) {
+      return;
+    }
+
+    try {
+      this.installState.set('downloading');
+      this.message.set('');
+
+      const [seasonsText, clubMetadataText] = await Promise.all([
+        this.downloadText(manifest.assets.seasons.url),
+        this.downloadText(manifest.assets.clubMetadata.url),
+      ]);
+
+      this.installState.set('verifying');
+      await Promise.all([
+        this.verifySha256(seasonsText, manifest.assets.seasons.sha256, 'seasons.json'),
+        this.verifySha256(
+          clubMetadataText,
+          manifest.assets.clubMetadata.sha256,
+          'club-metadata.json'
+        ),
+      ]);
+
+      const bundle: InstalledDataBundle = {
+        manifest,
+        seasonsDocument: JSON.parse(seasonsText) as SeasonsDocument,
+        clubMetadataDocument: JSON.parse(clubMetadataText) as ClubMetadataDocument,
+        installedAt: new Date().toISOString(),
+      };
+
+      await this.dataLoader.installOverride(bundle);
+      this.installState.set('installed');
+      this.checkState.set('up-to-date');
+    } catch (error) {
+      this.installState.set('error');
+      this.message.set(error instanceof Error ? error.message : 'Could not update local data.');
+    }
+  }
+
+  async clearLocalOverride(): Promise<void> {
+    await this.dataLoader.clearOverrideAndReload();
+    this.installState.set('idle');
+    await this.checkForUpdates();
+  }
+
+  private async fetchLatestManifest(): Promise<DataBundleManifest> {
+    const release = await lastValueFrom(
+      this.http.get<GitHubRelease>(environment.dataUpdates.githubLatestReleaseApiUrl)
+    );
+    const manifestAsset = this.findManifestAsset(release.assets);
+    if (manifestAsset) {
+      return lastValueFrom(this.http.get<DataBundleManifest>(manifestAsset.browser_download_url));
+    }
+
+    return this.buildManifestFromReleaseAssets(release);
+  }
+
+  private findManifestAsset(assets: readonly GitHubReleaseAsset[]): GitHubReleaseAsset | null {
+    return (
+      assets.find((asset) => environment.dataUpdates.manifestAssetNames.includes(asset.name)) ??
+      null
+    );
+  }
+
+  private async buildManifestFromReleaseAssets(
+    release: GitHubRelease
+  ): Promise<DataBundleManifest> {
+    const seasonsAsset = this.requiredAsset(
+      release.assets,
+      environment.dataUpdates.seasonsAssetName
+    );
+    const clubMetadataAsset = this.requiredAsset(
+      release.assets,
+      environment.dataUpdates.clubMetadataAssetName
+    );
+    const [seasonsSha256, clubMetadataSha256] = await Promise.all([
+      this.fetchSha256ForAsset(release.assets, seasonsAsset.name),
+      this.fetchSha256ForAsset(release.assets, clubMetadataAsset.name),
+    ]);
+
+    return {
+      version: release.tag_name,
+      generatedAt: release.published_at,
+      gitSha: release.target_commitish ?? release.tag_name,
+      assets: {
+        seasons: this.assetManifest(seasonsAsset, seasonsSha256),
+        clubMetadata: this.assetManifest(clubMetadataAsset, clubMetadataSha256),
+      },
+    };
+  }
+
+  private requiredAsset(assets: readonly GitHubReleaseAsset[], name: string): GitHubReleaseAsset {
+    const asset = assets.find((candidate) => candidate.name === name);
+    if (!asset) {
+      throw new Error(`The latest data release is missing ${name}.`);
+    }
+
+    return asset;
+  }
+
+  private async fetchSha256ForAsset(
+    assets: readonly GitHubReleaseAsset[],
+    assetName: string
+  ): Promise<string> {
+    const checksumAsset = this.requiredAsset(assets, `${assetName}.sha256`);
+    const checksumText = await this.downloadText(checksumAsset.browser_download_url);
+    const checksum = checksumText.trim().split(/\s+/)[0]?.toLowerCase();
+    if (!checksum || !/^[a-f0-9]{64}$/.test(checksum)) {
+      throw new Error(`${checksumAsset.name} does not contain a valid SHA-256 checksum.`);
+    }
+
+    return checksum;
+  }
+
+  private assetManifest(asset: GitHubReleaseAsset, sha256: string): DataBundleAssetManifest {
+    return {
+      url: asset.browser_download_url,
+      sha256,
+      size: asset.size,
+    };
+  }
+
+  private isNewerThanActiveData(manifest: DataBundleManifest): boolean {
+    const activeData = this.activeDataInfo();
+    if (!activeData) {
+      return false;
+    }
+
+    if (manifest.gitSha && activeData.gitSha && manifest.gitSha === activeData.gitSha) {
+      return false;
+    }
+
+    const remoteTime = Date.parse(manifest.generatedAt);
+    const activeTime = Date.parse(activeData.generatedAt);
+    if (Number.isFinite(remoteTime) && Number.isFinite(activeTime)) {
+      return remoteTime > activeTime;
+    }
+
+    return manifest.version !== activeData.version;
+  }
+
+  private downloadText(url: string): Promise<string> {
+    return lastValueFrom(this.http.get(url, { responseType: 'text' }));
+  }
+
+  private async verifySha256(text: string, expected: string, label: string): Promise<void> {
+    const actual = await this.sha256Hex(text);
+    if (actual !== expected.toLowerCase()) {
+      throw new Error(`${label} checksum mismatch.`);
+    }
+  }
+
+  private async sha256Hex(text: string): Promise<string> {
+    const bytes = new TextEncoder().encode(text);
+    const hash = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(hash))
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
+  }
+}

--- a/src/app/store/services/hydrate-store-json.spec.ts
+++ b/src/app/store/services/hydrate-store-json.spec.ts
@@ -1,0 +1,138 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import type { ClubMetadataDocument } from '../club-metadata.models';
+import { LeagueStore } from '../league.store';
+import { DataLoaderService } from './hydrate-store-json';
+
+describe('DataLoaderService', () => {
+  let service: DataLoaderService;
+  let http: HttpTestingController;
+  let store: InstanceType<typeof LeagueStore>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting(), LeagueStore],
+    });
+
+    service = TestBed.inject(DataLoaderService);
+    http = TestBed.inject(HttpTestingController);
+    store = TestBed.inject(LeagueStore);
+  });
+
+  afterEach(() => {
+    http.verify();
+    jest.useRealTimers();
+  });
+
+  it('delays visible loading state and hydrates archive data', async () => {
+    const loadPromise = service.loadData();
+
+    expect(service.loadStatus()).toBe('loading');
+    expect(service.showLoadingState()).toBe(false);
+
+    jest.advanceTimersByTime(399);
+
+    expect(service.showLoadingState()).toBe(false);
+
+    jest.advanceTimersByTime(1);
+
+    expect(service.showLoadingState()).toBe(true);
+
+    http.expectOne('assets/seasons.json').flush(seasonsDocument());
+    http.expectOne('assets/club-metadata.json').flush(clubMetadataDocument());
+
+    await loadPromise;
+
+    expect(service.loadStatus()).toBe('loaded');
+    expect(service.showLoadingState()).toBe(false);
+    expect(service.loadError()).toBeNull();
+    expect(store.getSeasons()).toEqual([2024]);
+    expect(store.getTeams().map((team) => team.name)).toEqual(['Alpha FC']);
+  });
+
+  it('records load failures without leaving loading visible', async () => {
+    const loadPromise = service.loadData();
+
+    http.expectOne('assets/seasons.json').flush('not found', {
+      status: 404,
+      statusText: 'Not Found',
+    });
+    http.expectOne('assets/club-metadata.json').flush(clubMetadataDocument());
+
+    await loadPromise;
+
+    expect(service.loadStatus()).toBe('error');
+    expect(service.loadError()).toBeTruthy();
+    expect(service.showLoadingState()).toBe(false);
+  });
+});
+
+function seasonsDocument() {
+  return {
+    seasons: {
+      2024: {
+        tier1: [
+          {
+            team: 'Alpha FC',
+            pos: 1,
+            played: 38,
+            won: 24,
+            drawn: 8,
+            lost: 6,
+            goalsFor: 70,
+            goalsAgainst: 35,
+            goalDifference: 35,
+            goalAverage: null,
+            points: 80,
+            notes: null,
+            wasRelegated: false,
+            wasPromoted: false,
+            isExpansionTeam: false,
+            wasReElected: false,
+            wasReprieved: false,
+          },
+        ],
+      },
+    },
+  };
+}
+
+function clubMetadataDocument(): ClubMetadataDocument {
+  return {
+    metadata: {
+      schemaVersion: 1,
+      generator: 'test',
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      gitSha: 'test',
+    },
+    clubs: {
+      'alpha-fc': {
+        canonicalName: 'Alpha FC',
+        derived: {
+          source: 'test',
+          aliases: ['Alpha FC'],
+          observedNames: [
+            {
+              rawName: 'Alpha FC',
+              normalizedName: 'alpha fc',
+              firstSeenSeason: 2024,
+              lastSeenSeason: 2024,
+              seasonsSeen: [2024],
+              tiersSeen: ['tier1'],
+            },
+          ],
+          observedNamePeriods: [{ name: 'Alpha FC', startSeason: 2024, endSeason: 2024 }],
+          firstSeenSeason: 2024,
+          lastSeenSeason: 2024,
+          seasonsSeen: [2024],
+          totalSeasonsSeen: 1,
+          tiersSeen: ['tier1'],
+          tierSeasons: [{ tierKey: 'tier1', seasons: [2024] }],
+        },
+      },
+    },
+  };
+}

--- a/src/app/store/services/hydrate-store-json.spec.ts
+++ b/src/app/store/services/hydrate-store-json.spec.ts
@@ -3,18 +3,40 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { TestBed } from '@angular/core/testing';
 import type { ClubMetadataDocument } from '../club-metadata.models';
 import { LeagueStore } from '../league.store';
+import type { InstalledDataBundle } from './data-bundle.models';
+import { DataOverrideStorage } from './data-override-storage';
 import { DataLoaderService } from './hydrate-store-json';
 
 describe('DataLoaderService', () => {
   let service: DataLoaderService;
   let http: HttpTestingController;
   let store: InstanceType<typeof LeagueStore>;
+  let overrideBundle: InstalledDataBundle | null;
+  let overrideStorage: {
+    read: jest.Mock<Promise<InstalledDataBundle | null>>;
+    write: jest.Mock<Promise<void>>;
+    clear: jest.Mock<Promise<void>>;
+  };
 
   beforeEach(() => {
     jest.useFakeTimers();
+    overrideBundle = null;
+    overrideStorage = {
+      read: jest.fn(() => Promise.resolve(overrideBundle)),
+      write: jest.fn(() => Promise.resolve()),
+      clear: jest.fn(() => Promise.resolve()),
+    };
 
     TestBed.configureTestingModule({
-      providers: [provideHttpClient(), provideHttpClientTesting(), LeagueStore],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        LeagueStore,
+        {
+          provide: DataOverrideStorage,
+          useValue: overrideStorage,
+        },
+      ],
     });
 
     service = TestBed.inject(DataLoaderService);
@@ -41,6 +63,8 @@ describe('DataLoaderService', () => {
 
     expect(service.showLoadingState()).toBe(true);
 
+    await Promise.resolve();
+
     http.expectOne('assets/seasons.json').flush(seasonsDocument());
     http.expectOne('assets/club-metadata.json').flush(clubMetadataDocument());
 
@@ -56,6 +80,8 @@ describe('DataLoaderService', () => {
   it('records load failures without leaving loading visible', async () => {
     const loadPromise = service.loadData();
 
+    await Promise.resolve();
+
     http.expectOne('assets/seasons.json').flush('not found', {
       status: 404,
       statusText: 'Not Found',
@@ -68,10 +94,55 @@ describe('DataLoaderService', () => {
     expect(service.loadError()).toBeTruthy();
     expect(service.showLoadingState()).toBe(false);
   });
+
+  it('hydrates a stored local override without fetching shipped data', async () => {
+    overrideBundle = installedBundle({
+      version: 'data-2026-06-18',
+      generatedAt: '2026-06-18T12:00:00.000Z',
+      gitSha: 'override-sha',
+    });
+
+    await service.loadData();
+
+    expect(http.match('assets/seasons.json')).toHaveLength(0);
+    expect(http.match('assets/club-metadata.json')).toHaveLength(0);
+    expect(service.activeDataInfo()).toEqual({
+      source: 'local-override',
+      version: 'data-2026-06-18',
+      generatedAt: '2026-06-18T12:00:00.000Z',
+      gitSha: 'override-sha',
+      installedAt: '2026-06-18T12:30:00.000Z',
+    });
+    expect(store.getTeams().map((team) => team.name)).toEqual(['Alpha FC']);
+  });
+
+  it('persists and hydrates an installed local override', async () => {
+    const bundle = installedBundle({
+      version: 'data-2026-06-19',
+      generatedAt: '2026-06-19T12:00:00.000Z',
+      gitSha: 'new-sha',
+    });
+
+    await service.installOverride(bundle);
+
+    expect(overrideStorage.write).toHaveBeenCalledWith(bundle);
+    expect(service.loadStatus()).toBe('loaded');
+    expect(service.activeDataInfo()).toEqual({
+      source: 'local-override',
+      version: 'data-2026-06-19',
+      generatedAt: '2026-06-19T12:00:00.000Z',
+      gitSha: 'new-sha',
+      installedAt: '2026-06-18T12:30:00.000Z',
+    });
+  });
 });
 
 function seasonsDocument() {
   return {
+    metadata: {
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      gitSha: 'shipped-sha',
+    },
     seasons: {
       2024: {
         tier1: [
@@ -97,6 +168,37 @@ function seasonsDocument() {
         ],
       },
     },
+  };
+}
+
+function installedBundle({
+  version,
+  generatedAt,
+  gitSha,
+}: {
+  version: string;
+  generatedAt: string;
+  gitSha: string;
+}): InstalledDataBundle {
+  return {
+    manifest: {
+      version,
+      generatedAt,
+      gitSha,
+      assets: {
+        seasons: {
+          url: 'https://example.com/seasons.json',
+          sha256: '0'.repeat(64),
+        },
+        clubMetadata: {
+          url: 'https://example.com/club-metadata.json',
+          sha256: '1'.repeat(64),
+        },
+      },
+    },
+    seasonsDocument: seasonsDocument(),
+    clubMetadataDocument: clubMetadataDocument(),
+    installedAt: '2026-06-18T12:30:00.000Z',
   };
 }
 

--- a/src/app/store/services/hydrate-store-json.ts
+++ b/src/app/store/services/hydrate-store-json.ts
@@ -1,26 +1,87 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable, inject } from '@angular/core';
+import { computed, Injectable, inject, signal } from '@angular/core';
 import { lastValueFrom } from 'rxjs';
 import type { ClubMetadataDocument } from '../club-metadata.models';
 import { ClubMetadataStore } from '../club-metadata.store';
 import { LeagueStore } from '../league.store';
+
+export type DataLoadStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
+const LOADING_DISCLOSURE_DELAY_MS = 400;
 
 @Injectable({ providedIn: 'root' })
 export class DataLoaderService {
   private http = inject(HttpClient);
   private store = inject(LeagueStore);
   private clubMetadataStore = inject(ClubMetadataStore);
+  private status = signal<DataLoadStatus>('idle');
+  private error = signal<unknown | null>(null);
+  private loadingDisclosed = signal(false);
+  private loadPromise: Promise<void> | null = null;
+  private loadingDisclosureTimer: ReturnType<typeof setTimeout> | null = null;
 
-  async loadData() {
+  readonly loadStatus = this.status.asReadonly();
+  readonly loadError = this.error.asReadonly();
+  readonly showLoadingState = computed(
+    () => this.status() === 'loading' && this.loadingDisclosed()
+  );
+
+  loadData(): Promise<void> {
+    if (this.status() === 'loaded') {
+      return Promise.resolve();
+    }
+
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+
+    this.status.set('loading');
+    this.error.set(null);
+    this.scheduleLoadingDisclosure();
+
+    this.loadPromise = this.fetchAndHydrate()
+      .then(() => {
+        this.status.set('loaded');
+      })
+      .catch((error: unknown) => {
+        this.error.set(error);
+        this.status.set('error');
+      })
+      .finally(() => {
+        this.clearLoadingDisclosure();
+        this.loadPromise = null;
+      });
+
+    return this.loadPromise;
+  }
+
+  private async fetchAndHydrate(): Promise<void> {
     const [data, clubMetadata] = await Promise.all([
       lastValueFrom(this.http.get('assets/seasons.json')),
       lastValueFrom(this.http.get<ClubMetadataDocument>('assets/club-metadata.json')),
     ]);
-    console.log('Data loaded from JSON:', data);
+
     this.clubMetadataStore.hydrate(clubMetadata);
     this.store.hydrate(data, (teamName, season) =>
       this.clubMetadataStore.getClubIdForTeamSeason(teamName, season)
     );
-    console.log('Store hydrated with data');
+  }
+
+  private scheduleLoadingDisclosure() {
+    this.clearLoadingDisclosure();
+    this.loadingDisclosureTimer = setTimeout(() => {
+      if (this.status() === 'loading') {
+        this.loadingDisclosed.set(true);
+      }
+    }, LOADING_DISCLOSURE_DELAY_MS);
+  }
+
+  private clearLoadingDisclosure() {
+    if (this.loadingDisclosureTimer) {
+      clearTimeout(this.loadingDisclosureTimer);
+      this.loadingDisclosureTimer = null;
+    }
+
+    this.loadingDisclosed.set(false);
   }
 }

--- a/src/app/store/services/hydrate-store-json.ts
+++ b/src/app/store/services/hydrate-store-json.ts
@@ -4,6 +4,8 @@ import { lastValueFrom } from 'rxjs';
 import type { ClubMetadataDocument } from '../club-metadata.models';
 import { ClubMetadataStore } from '../club-metadata.store';
 import { LeagueStore } from '../league.store';
+import type { ActiveDataInfo, InstalledDataBundle, SeasonsDocument } from './data-bundle.models';
+import { DataOverrideStorage } from './data-override-storage';
 
 export type DataLoadStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
@@ -14,14 +16,17 @@ export class DataLoaderService {
   private http = inject(HttpClient);
   private store = inject(LeagueStore);
   private clubMetadataStore = inject(ClubMetadataStore);
+  private overrideStorage = inject(DataOverrideStorage);
   private status = signal<DataLoadStatus>('idle');
   private error = signal<unknown | null>(null);
   private loadingDisclosed = signal(false);
+  private activeData = signal<ActiveDataInfo | null>(null);
   private loadPromise: Promise<void> | null = null;
   private loadingDisclosureTimer: ReturnType<typeof setTimeout> | null = null;
 
   readonly loadStatus = this.status.asReadonly();
   readonly loadError = this.error.asReadonly();
+  readonly activeDataInfo = this.activeData.asReadonly();
   readonly showLoadingState = computed(
     () => this.status() === 'loading' && this.loadingDisclosed()
   );
@@ -55,16 +60,71 @@ export class DataLoaderService {
     return this.loadPromise;
   }
 
+  async installOverride(bundle: InstalledDataBundle): Promise<void> {
+    await this.overrideStorage.write(bundle);
+    this.hydrateBundle(bundle.seasonsDocument, bundle.clubMetadataDocument, {
+      source: 'local-override',
+      version: bundle.manifest.version,
+      generatedAt: bundle.manifest.generatedAt,
+      gitSha: bundle.manifest.gitSha,
+      installedAt: bundle.installedAt,
+    });
+    this.status.set('loaded');
+    this.error.set(null);
+  }
+
+  async clearOverrideAndReload(): Promise<void> {
+    await this.overrideStorage.clear();
+    this.status.set('idle');
+    this.activeData.set(null);
+    await this.loadData();
+  }
+
   private async fetchAndHydrate(): Promise<void> {
+    const override = await this.overrideStorage.read();
+    if (override) {
+      this.hydrateBundle(override.seasonsDocument, override.clubMetadataDocument, {
+        source: 'local-override',
+        version: override.manifest.version,
+        generatedAt: override.manifest.generatedAt,
+        gitSha: override.manifest.gitSha,
+        installedAt: override.installedAt,
+      });
+      return;
+    }
+
     const [data, clubMetadata] = await Promise.all([
-      lastValueFrom(this.http.get('assets/seasons.json')),
+      lastValueFrom(this.http.get<SeasonsDocument>('assets/seasons.json')),
       lastValueFrom(this.http.get<ClubMetadataDocument>('assets/club-metadata.json')),
     ]);
 
+    this.hydrateBundle(data, clubMetadata, this.buildShippedDataInfo(data, clubMetadata));
+  }
+
+  private hydrateBundle(
+    data: SeasonsDocument,
+    clubMetadata: ClubMetadataDocument,
+    info: ActiveDataInfo
+  ) {
     this.clubMetadataStore.hydrate(clubMetadata);
     this.store.hydrate(data, (teamName, season) =>
       this.clubMetadataStore.getClubIdForTeamSeason(teamName, season)
     );
+    this.activeData.set(info);
+  }
+
+  private buildShippedDataInfo(
+    data: SeasonsDocument,
+    clubMetadata: ClubMetadataDocument
+  ): ActiveDataInfo {
+    const metadata = data.metadata ?? clubMetadata.metadata;
+
+    return {
+      source: 'shipped',
+      version: metadata.gitSha || metadata.generatedAt,
+      generatedAt: metadata.generatedAt,
+      gitSha: metadata.gitSha,
+    };
   }
 
   private scheduleLoadingDisclosure() {

--- a/src/app/utils/team-deep-stats.spec.ts
+++ b/src/app/utils/team-deep-stats.spec.ts
@@ -33,7 +33,13 @@ describe('buildTeamDeepStatsData', () => {
     expect(data.movementRows).toHaveLength(1);
     expect(data.movementRows[0]).toMatchObject({
       season: 2022,
+      clubId: 'alpha fc',
       movementLabel: 'Promoted',
+    });
+    expect(data.seasonRows[0]).toMatchObject({
+      season: 2022,
+      teamName: 'Alpha FC',
+      clubId: 'alpha fc',
     });
   });
 });

--- a/src/app/utils/team-deep-stats.spec.ts
+++ b/src/app/utils/team-deep-stats.spec.ts
@@ -1,0 +1,73 @@
+import type { LeagueTableEntry } from '@app/store/league.models';
+import { buildTeamDeepStatsData } from './team-deep-stats';
+
+describe('buildTeamDeepStatsData', () => {
+  it('builds dense totals, tier rows, movement rows, and record marks', () => {
+    const data = buildTeamDeepStatsData(
+      [
+        entry(2020, 'tier1', 2, 80, 70, 35, false, false),
+        entry(2021, 'tier1', 1, 91, 86, 30, false, false),
+        entry(2022, 'tier2', 3, 74, 68, 42, false, true),
+      ],
+      () => 'Alpha FC',
+      (tier) => (tier === 'tier1' ? 'Premier League' : 'Championship')
+    );
+
+    expect(data.totals.seasons).toBe(3);
+    expect(data.totals.points).toBe(245);
+    expect(data.totals.averagePosition).toBe(2);
+    expect(data.recordMarks.map((mark) => mark.label)).toContain('Best points per game');
+    expect(data.tierRows).toEqual([
+      expect.objectContaining({
+        tier: 'tier1',
+        seasons: 2,
+        bestPosition: 1,
+        points: 171,
+      }),
+      expect.objectContaining({
+        tier: 'tier2',
+        seasons: 1,
+        movementEvents: 1,
+      }),
+    ]);
+    expect(data.movementRows).toHaveLength(1);
+    expect(data.movementRows[0]).toMatchObject({
+      season: 2022,
+      movementLabel: 'Promoted',
+    });
+  });
+});
+
+function entry(
+  season: number,
+  tier: string,
+  pos: number,
+  points: number,
+  goalsFor: number,
+  goalsAgainst: number,
+  wasRelegated: boolean,
+  wasPromoted: boolean
+): LeagueTableEntry {
+  return {
+    season,
+    tier,
+    teamId: 1,
+    clubId: 'alpha fc',
+    pos,
+    played: 38,
+    won: 20,
+    drawn: 8,
+    lost: 10,
+    goalsFor,
+    goalsAgainst,
+    goalDifference: goalsFor - goalsAgainst,
+    goalAverage: null,
+    points,
+    notes: null,
+    wasRelegated,
+    wasPromoted,
+    isExpansionTeam: false,
+    wasReElected: false,
+    wasReprieved: false,
+  };
+}

--- a/src/app/utils/team-deep-stats.ts
+++ b/src/app/utils/team-deep-stats.ts
@@ -1,0 +1,366 @@
+import type { LeagueTableEntry } from '@app/store/league.models';
+
+export interface TeamDeepTotals {
+  seasons: number;
+  played: number;
+  won: number;
+  drawn: number;
+  lost: number;
+  goalsFor: number;
+  goalsAgainst: number;
+  goalDifference: number;
+  points: number;
+  averagePosition: number | null;
+  pointsPerGame: number | null;
+  goalsPerGame: number | null;
+}
+
+export interface TeamDeepTierRow {
+  tier: string;
+  tierLabel: string;
+  seasons: number;
+  firstSeason: number;
+  lastSeason: number;
+  bestPosition: number;
+  bestSeason: number;
+  points: number;
+  averagePosition: number;
+  movementEvents: number;
+}
+
+export interface TeamDeepSeasonRow {
+  season: number;
+  tier: string;
+  tierLabel: string;
+  teamName: string;
+  position: number;
+  played: number;
+  won: number;
+  drawn: number;
+  lost: number;
+  goalsFor: number;
+  goalsAgainst: number;
+  goalDifference: number | null;
+  points: number;
+  pointsPerGame: number | null;
+  movementLabel: string | null;
+}
+
+export interface TeamDeepRecordMark {
+  label: string;
+  value: string;
+  detail: string;
+  season: number;
+  tier: string;
+}
+
+export interface TeamDeepPositionBand {
+  label: string;
+  count: number;
+  detail: string;
+}
+
+export interface TeamDeepStatsData {
+  totals: TeamDeepTotals;
+  recordMarks: TeamDeepRecordMark[];
+  tierRows: TeamDeepTierRow[];
+  movementRows: TeamDeepSeasonRow[];
+  seasonRows: TeamDeepSeasonRow[];
+  positionBands: TeamDeepPositionBand[];
+}
+
+type TeamNameLookup = (teamId: number) => string;
+type TierLabelFormatter = (tier: string) => string;
+
+export function buildTeamDeepStatsData(
+  entries: readonly LeagueTableEntry[],
+  getTeamName: TeamNameLookup,
+  formatTierLabel: TierLabelFormatter
+): TeamDeepStatsData {
+  const seasonRows = entries
+    .slice()
+    .sort((a, b) => b.season - a.season || tierRank(a.tier) - tierRank(b.tier))
+    .map((entry) => seasonRow(entry, getTeamName, formatTierLabel));
+  const totals = buildTotals(entries);
+
+  return {
+    totals,
+    recordMarks: buildRecordMarks(entries, formatTierLabel),
+    tierRows: buildTierRows(entries, formatTierLabel),
+    movementRows: seasonRows.filter((row) => row.movementLabel),
+    seasonRows,
+    positionBands: buildPositionBands(entries),
+  };
+}
+
+function buildTotals(entries: readonly LeagueTableEntry[]): TeamDeepTotals {
+  const totals = entries.reduce(
+    (acc, entry) => ({
+      seasons: acc.seasons + 1,
+      played: acc.played + entry.played,
+      won: acc.won + entry.won,
+      drawn: acc.drawn + entry.drawn,
+      lost: acc.lost + entry.lost,
+      goalsFor: acc.goalsFor + entry.goalsFor,
+      goalsAgainst: acc.goalsAgainst + entry.goalsAgainst,
+      goalDifference:
+        acc.goalDifference + (entry.goalDifference ?? entry.goalsFor - entry.goalsAgainst),
+      points: acc.points + entry.points,
+      positionTotal: acc.positionTotal + entry.pos,
+    }),
+    {
+      seasons: 0,
+      played: 0,
+      won: 0,
+      drawn: 0,
+      lost: 0,
+      goalsFor: 0,
+      goalsAgainst: 0,
+      goalDifference: 0,
+      points: 0,
+      positionTotal: 0,
+    }
+  );
+
+  return {
+    seasons: totals.seasons,
+    played: totals.played,
+    won: totals.won,
+    drawn: totals.drawn,
+    lost: totals.lost,
+    goalsFor: totals.goalsFor,
+    goalsAgainst: totals.goalsAgainst,
+    goalDifference: totals.goalDifference,
+    points: totals.points,
+    averagePosition: totals.seasons ? totals.positionTotal / totals.seasons : null,
+    pointsPerGame: totals.played ? totals.points / totals.played : null,
+    goalsPerGame: totals.played ? totals.goalsFor / totals.played : null,
+  };
+}
+
+function buildTierRows(
+  entries: readonly LeagueTableEntry[],
+  formatTierLabel: TierLabelFormatter
+): TeamDeepTierRow[] {
+  const byTier = new Map<string, LeagueTableEntry[]>();
+  entries.forEach((entry) => byTier.set(entry.tier, [...(byTier.get(entry.tier) ?? []), entry]));
+
+  return Array.from(byTier.entries())
+    .map(([tier, tierEntries]) => {
+      const sorted = tierEntries.slice().sort((a, b) => a.season - b.season);
+      const best = tierEntries
+        .slice()
+        .sort((a, b) => a.pos - b.pos || b.points - a.points || b.season - a.season)[0];
+      const points = tierEntries.reduce((sum, entry) => sum + entry.points, 0);
+      const positionTotal = tierEntries.reduce((sum, entry) => sum + entry.pos, 0);
+      const movementEvents = tierEntries.filter(
+        (entry) => entry.wasPromoted || entry.wasRelegated || entry.wasReprieved
+      ).length;
+
+      return {
+        tier,
+        tierLabel: formatTierLabel(tier),
+        seasons: tierEntries.length,
+        firstSeason: sorted[0].season,
+        lastSeason: sorted.at(-1)!.season,
+        bestPosition: best.pos,
+        bestSeason: best.season,
+        points,
+        averagePosition: positionTotal / tierEntries.length,
+        movementEvents,
+      };
+    })
+    .sort((a, b) => tierRank(a.tier) - tierRank(b.tier));
+}
+
+function buildRecordMarks(
+  entries: readonly LeagueTableEntry[],
+  formatTierLabel: TierLabelFormatter
+): TeamDeepRecordMark[] {
+  const bestFinish = entries
+    .slice()
+    .sort((a, b) => a.pos - b.pos || tierRank(a.tier) - tierRank(b.tier) || b.points - a.points)[0];
+  const mostPoints = maxEntry(entries, (entry) => entry.points);
+  const bestGoalDifference = maxEntry(
+    entries,
+    (entry) => entry.goalDifference ?? entry.goalsFor - entry.goalsAgainst
+  );
+  const mostGoals = maxEntry(entries, (entry) => entry.goalsFor);
+  const fewestAgainst = minEntry(entries, (entry) => entry.goalsAgainst);
+  const bestPointsPerGame = maxEntry(
+    entries,
+    (entry) => pointsPerGame(entry) ?? Number.NEGATIVE_INFINITY
+  );
+
+  return [
+    bestFinish
+      ? recordMark('Best finish', ordinal(bestFinish.pos), bestFinish, formatTierLabel)
+      : null,
+    mostPoints
+      ? recordMark('Most points', `${mostPoints.points} pts`, mostPoints, formatTierLabel)
+      : null,
+    bestGoalDifference
+      ? recordMark(
+          'Best goal difference',
+          signedNumber(
+            bestGoalDifference.goalDifference ??
+              bestGoalDifference.goalsFor - bestGoalDifference.goalsAgainst
+          ),
+          bestGoalDifference,
+          formatTierLabel
+        )
+      : null,
+    mostGoals
+      ? recordMark('Most goals scored', `${mostGoals.goalsFor}`, mostGoals, formatTierLabel)
+      : null,
+    fewestAgainst
+      ? recordMark(
+          'Fewest goals against',
+          `${fewestAgainst.goalsAgainst}`,
+          fewestAgainst,
+          formatTierLabel
+        )
+      : null,
+    bestPointsPerGame
+      ? recordMark(
+          'Best points per game',
+          formatDecimal(pointsPerGame(bestPointsPerGame)),
+          bestPointsPerGame,
+          formatTierLabel
+        )
+      : null,
+  ].filter((mark): mark is TeamDeepRecordMark => Boolean(mark));
+}
+
+function buildPositionBands(entries: readonly LeagueTableEntry[]): TeamDeepPositionBand[] {
+  const titleCount = entries.filter((entry) => entry.pos === 1).length;
+  const podiumCount = entries.filter((entry) => entry.pos <= 3).length;
+  const topSixCount = entries.filter((entry) => entry.pos <= 6).length;
+  const relegationCount = entries.filter((entry) => entry.wasRelegated).length;
+
+  return [
+    {
+      label: 'Titles',
+      count: titleCount,
+      detail: `${percentage(titleCount, entries.length)} of tracked rows`,
+    },
+    {
+      label: 'Top three',
+      count: podiumCount,
+      detail: `${percentage(podiumCount, entries.length)} of tracked rows`,
+    },
+    {
+      label: 'Top six',
+      count: topSixCount,
+      detail: `${percentage(topSixCount, entries.length)} of tracked rows`,
+    },
+    {
+      label: 'Relegated',
+      count: relegationCount,
+      detail: `${percentage(relegationCount, entries.length)} of tracked rows`,
+    },
+  ];
+}
+
+function seasonRow(
+  entry: LeagueTableEntry,
+  getTeamName: TeamNameLookup,
+  formatTierLabel: TierLabelFormatter
+): TeamDeepSeasonRow {
+  return {
+    season: entry.season,
+    tier: entry.tier,
+    tierLabel: formatTierLabel(entry.tier),
+    teamName: getTeamName(entry.teamId),
+    position: entry.pos,
+    played: entry.played,
+    won: entry.won,
+    drawn: entry.drawn,
+    lost: entry.lost,
+    goalsFor: entry.goalsFor,
+    goalsAgainst: entry.goalsAgainst,
+    goalDifference: entry.goalDifference,
+    points: entry.points,
+    pointsPerGame: pointsPerGame(entry),
+    movementLabel: movementLabel(entry),
+  };
+}
+
+function recordMark(
+  label: string,
+  value: string,
+  entry: LeagueTableEntry,
+  formatTierLabel: TierLabelFormatter
+): TeamDeepRecordMark {
+  return {
+    label,
+    value,
+    detail: `${entry.season} / ${formatTierLabel(entry.tier)}`,
+    season: entry.season,
+    tier: entry.tier,
+  };
+}
+
+function maxEntry(
+  entries: readonly LeagueTableEntry[],
+  getValue: (entry: LeagueTableEntry) => number
+): LeagueTableEntry | null {
+  return (
+    entries.slice().sort((a, b) => getValue(b) - getValue(a) || b.season - a.season)[0] ?? null
+  );
+}
+
+function minEntry(
+  entries: readonly LeagueTableEntry[],
+  getValue: (entry: LeagueTableEntry) => number
+): LeagueTableEntry | null {
+  return (
+    entries.slice().sort((a, b) => getValue(a) - getValue(b) || b.season - a.season)[0] ?? null
+  );
+}
+
+function movementLabel(entry: LeagueTableEntry): string | null {
+  if (entry.wasPromoted) {
+    return 'Promoted';
+  }
+
+  if (entry.wasRelegated) {
+    return 'Relegated';
+  }
+
+  if (entry.wasReprieved) {
+    return 'Reprieved';
+  }
+
+  return null;
+}
+
+function pointsPerGame(entry: LeagueTableEntry): number | null {
+  return entry.played ? entry.points / entry.played : null;
+}
+
+function tierRank(tier: string): number {
+  const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+  return Number.isFinite(parsed) ? parsed : 99;
+}
+
+function ordinal(value: number): string {
+  const mod100 = value % 100;
+  if (mod100 >= 11 && mod100 <= 13) {
+    return `${value}th`;
+  }
+
+  return `${value}${{ 1: 'st', 2: 'nd', 3: 'rd' }[value % 10] ?? 'th'}`;
+}
+
+function signedNumber(value: number): string {
+  return value > 0 ? `+${value}` : String(value);
+}
+
+function formatDecimal(value: number | null): string {
+  return value === null ? 'No data' : value.toFixed(2);
+}
+
+function percentage(value: number, total: number): string {
+  return total ? `${Math.round((value / total) * 100)}%` : '0%';
+}

--- a/src/app/utils/team-deep-stats.ts
+++ b/src/app/utils/team-deep-stats.ts
@@ -33,6 +33,7 @@ export interface TeamDeepSeasonRow {
   tier: string;
   tierLabel: string;
   teamName: string;
+  clubId: string | null;
   position: number;
   played: number;
   won: number;
@@ -272,6 +273,7 @@ function seasonRow(
     tier: entry.tier,
     tierLabel: formatTierLabel(entry.tier),
     teamName: getTeamName(entry.teamId),
+    clubId: entry.clubId,
     position: entry.pos,
     played: entry.played,
     won: entry.won,

--- a/src/app/utils/tier-profile.spec.ts
+++ b/src/app/utils/tier-profile.spec.ts
@@ -68,6 +68,33 @@ describe('buildTierProfileData', () => {
       detail: 'level on points / +6 GD',
     });
   });
+
+  it('builds dominance leaders for titles, top-three finishes, and continuous stays', () => {
+    const profile = buildTierProfileData(fixtureEntries(), 'tier1', (teamId) => teams[teamId]);
+
+    expect(profile.mostTitles.map((row) => [row.name, row.count, row.detail])).toEqual([
+      ['Alpha FC', 3, '3 titles'],
+      ['Bravo Town', 1, '1 title'],
+    ]);
+    expect(profile.mostTopThreeFinishes.slice(0, 3).map((row) => [row.name, row.detail])).toEqual([
+      ['Alpha FC', '4 top-three finishes'],
+      ['Bravo Town', '4 top-three finishes'],
+      ['Charlie City', '1 top-three finish'],
+    ]);
+    expect(profile.longestStays[0]).toMatchObject({
+      name: 'Alpha FC',
+      count: 3,
+      startSeason: 2020,
+      endSeason: 2022,
+      detail: '3 seasons (2020-2022)',
+    });
+    expect(profile.longestActiveStays[0]).toMatchObject({
+      name: 'Alpha FC',
+      count: 3,
+      startSeason: 2020,
+      endSeason: 2022,
+    });
+  });
 });
 
 function fixtureEntries(): LeagueTableEntry[] {

--- a/src/app/utils/tier-profile.spec.ts
+++ b/src/app/utils/tier-profile.spec.ts
@@ -1,0 +1,134 @@
+import type { LeagueTableEntry, Team } from '@app/store/league.models';
+import { buildTierProfileData } from './tier-profile';
+
+describe('buildTierProfileData', () => {
+  const teams: Record<number, Team> = {
+    1: { id: 1, name: 'Alpha FC', clubIds: ['alpha fc'] },
+    2: { id: 2, name: 'Bravo Town', clubIds: ['bravo town'] },
+    3: { id: 3, name: 'Charlie City', clubIds: ['charlie city'] },
+    4: { id: 4, name: 'Delta United', clubIds: ['delta united'] },
+    5: { id: 5, name: 'Echo Rovers', clubIds: ['echo rovers'] },
+  };
+
+  it('counts promotions into the target tier from the tier below', () => {
+    const profile = buildTierProfileData(fixtureEntries(), 'tier1', (teamId) => teams[teamId]);
+
+    expect(profile.promotionInCount).toBe(3);
+    expect(profile.relegationOutCount).toBe(1);
+    expect(profile.mostPromotionsIn.map((row) => [row.name, row.count])).toEqual([
+      ['Charlie City', 2],
+      ['Delta United', 1],
+    ]);
+    expect(profile.mostRelegationsOut.map((row) => [row.name, row.count])).toEqual([
+      ['Echo Rovers', 1],
+    ]);
+  });
+
+  it('builds close title, survival, and promotion races for table links', () => {
+    const profile = buildTierProfileData(fixtureEntries(), 'tier1', (teamId) => teams[teamId]);
+
+    expect(profile.closeTitleRaces.find((race) => race.season === 2020)).toMatchObject({
+      season: 2020,
+      gap: 0,
+      tieBreakerGap: 8,
+      primaryName: 'Alpha FC',
+      secondaryName: 'Bravo Town',
+      detail: 'level on points and GD / +8 goals scored',
+    });
+    expect(profile.closeTitleRaces.find((race) => race.season === 1975)).toMatchObject({
+      season: 1975,
+      gap: 0,
+      tieBreakerGap: 0.25,
+      primaryName: 'Alpha FC',
+      secondaryName: 'Bravo Town',
+      detail: 'level on points / +0.25 goal average',
+    });
+    expect(profile.closeTitleRaces.find((race) => race.season === 2022)).toMatchObject({
+      season: 2022,
+      gap: 0,
+      tieBreakerGap: null,
+      primaryName: 'Alpha FC',
+      secondaryName: 'Bravo Town',
+      detail: 'level on points, GD, and goals scored / head-to-head or playoff',
+    });
+    expect(profile.closeSurvivalRaces[0]).toMatchObject({
+      season: 2020,
+      gap: 0,
+      tieBreakerGap: 11,
+      primaryName: 'Delta United',
+      secondaryName: 'Echo Rovers',
+      detail: 'level on points / +11 GD',
+    });
+    expect(profile.closePromotionRaces[0]).toMatchObject({
+      season: 2020,
+      gap: 0,
+      tieBreakerGap: 6,
+      primaryName: 'Delta United',
+      secondaryName: 'Echo Rovers',
+      detail: 'level on points / +6 GD',
+    });
+  });
+});
+
+function fixtureEntries(): LeagueTableEntry[] {
+  return [
+    row(1975, 'tier1', 1, 1, 50, 60, 30, false, false),
+    row(1975, 'tier1', 2, 2, 50, 70, 40, false, false),
+    row(2020, 'tier1', 1, 1, 82, 76, 34, false, false),
+    row(2020, 'tier1', 2, 2, 82, 68, 26, false, false),
+    row(2020, 'tier1', 4, 3, 38, 42, 55, false, false),
+    row(2020, 'tier1', 5, 4, 38, 36, 60, true, false),
+    row(2020, 'tier2', 3, 1, 84, 74, 35, false, true),
+    row(2020, 'tier2', 4, 2, 82, 68, 40, false, true),
+    row(2020, 'tier2', 5, 3, 82, 64, 42, false, false),
+    row(2021, 'tier1', 2, 1, 90, 88, 25, false, false),
+    row(2021, 'tier1', 1, 2, 83, 70, 30, false, false),
+    row(2021, 'tier1', 3, 3, 44, 52, 49, false, false),
+    row(2021, 'tier2', 3, 1, 86, 79, 30, false, true),
+    row(2022, 'tier1', 1, 1, 86, 75, 35, false, false),
+    row(2022, 'tier1', 2, 2, 86, 75, 35, false, false),
+  ];
+}
+
+function row(
+  season: number,
+  tier: string,
+  teamId: number,
+  pos: number,
+  points: number,
+  goalsFor: number,
+  goalsAgainst: number,
+  wasRelegated: boolean,
+  wasPromoted: boolean
+): LeagueTableEntry {
+  return {
+    season,
+    tier,
+    teamId,
+    clubId: `${teamsForFixture[teamId]} id`,
+    pos,
+    played: 38,
+    won: 20,
+    drawn: 8,
+    lost: 10,
+    goalsFor,
+    goalsAgainst,
+    goalDifference: goalsFor - goalsAgainst,
+    goalAverage: null,
+    points,
+    notes: null,
+    wasRelegated,
+    wasPromoted,
+    isExpansionTeam: false,
+    wasReElected: false,
+    wasReprieved: false,
+  };
+}
+
+const teamsForFixture: Record<number, string> = {
+  1: 'alpha',
+  2: 'bravo',
+  3: 'charlie',
+  4: 'delta',
+  5: 'echo',
+};

--- a/src/app/utils/tier-profile.ts
+++ b/src/app/utils/tier-profile.ts
@@ -1,0 +1,498 @@
+import type { LeagueTableEntry, Team } from '@app/store/league.models';
+
+export interface TierClubTotal {
+  key: string;
+  name: string;
+  clubId: string | null;
+  count: number;
+  detail: string;
+}
+
+export interface TierRaceRow {
+  season: number;
+  gap: number;
+  tieBreakerGap: number | null;
+  primaryName: string;
+  primaryClubId: string | null;
+  secondaryName: string;
+  secondaryClubId: string | null;
+  detail: string;
+}
+
+export interface TierNotableSeason {
+  season: number;
+  label: string;
+  value: string;
+  teamName: string;
+  clubId: string | null;
+}
+
+export interface TierSeasonChurn {
+  season: number;
+  promotedIn: number;
+  relegatedOut: number;
+  totalMovement: number;
+}
+
+export interface TierProfileData {
+  tier: string;
+  seasons: number[];
+  latestSeason: number | null;
+  uniqueClubCount: number;
+  totalRows: number;
+  promotionInCount: number;
+  relegationOutCount: number;
+  mostSeasons: TierClubTotal[];
+  mostPromotionsIn: TierClubTotal[];
+  mostRelegationsOut: TierClubTotal[];
+  closeTitleRaces: TierRaceRow[];
+  closeSurvivalRaces: TierRaceRow[];
+  closePromotionRaces: TierRaceRow[];
+  notableSeasons: TierNotableSeason[];
+  churnSeasons: TierSeasonChurn[];
+}
+
+type TeamLookup = (teamId: number) => Team | undefined;
+
+interface RaceTieBreaker {
+  gap: number | null;
+  label: string;
+  levelLabel: string;
+}
+
+export function buildTierProfileData(
+  entries: readonly LeagueTableEntry[],
+  tier: string,
+  getTeamById: TeamLookup
+): TierProfileData {
+  const targetEntries = entries.filter((entry) => entry.tier === tier);
+  const sourceTier = adjacentLowerTier(tier);
+  const sourceEntries = sourceTier ? entries.filter((entry) => entry.tier === sourceTier) : [];
+  const seasonTables = groupSeasonTables(targetEntries);
+  const sourceSeasonTables = groupSeasonTables(sourceEntries);
+  const seasons = Array.from(seasonTables.keys()).sort((a, b) => a - b);
+  const clubKeys = new Set(targetEntries.map((entry) => clubKey(entry)));
+
+  return {
+    tier,
+    seasons,
+    latestSeason: seasons.at(-1) ?? null,
+    uniqueClubCount: clubKeys.size,
+    totalRows: targetEntries.length,
+    promotionInCount: sourceEntries.filter((entry) => entry.wasPromoted).length,
+    relegationOutCount: targetEntries.filter((entry) => entry.wasRelegated).length,
+    mostSeasons: rankClubTotals(targetEntries, getTeamById, () => true, 'seasons'),
+    mostPromotionsIn: sourceTier
+      ? rankClubTotals(sourceEntries, getTeamById, (entry) => entry.wasPromoted, 'promotions')
+      : [],
+    mostRelegationsOut: rankClubTotals(
+      targetEntries,
+      getTeamById,
+      (entry) => entry.wasRelegated,
+      'relegations'
+    ),
+    closeTitleRaces: closeTitleRaces(seasonTables, getTeamById),
+    closeSurvivalRaces: closeSurvivalRaces(seasonTables, getTeamById),
+    closePromotionRaces: closePromotionRaces(sourceSeasonTables, getTeamById),
+    notableSeasons: notableSeasons(seasonTables, getTeamById),
+    churnSeasons: churnSeasons(seasonTables, sourceSeasonTables),
+  };
+}
+
+function rankClubTotals(
+  entries: readonly LeagueTableEntry[],
+  getTeamById: TeamLookup,
+  include: (entry: LeagueTableEntry) => boolean,
+  noun: string
+): TierClubTotal[] {
+  const counts = new Map<string, { entry: LeagueTableEntry; count: number }>();
+
+  entries.filter(include).forEach((entry) => {
+    const key = clubKey(entry);
+    const current = counts.get(key);
+    counts.set(key, {
+      entry,
+      count: (current?.count ?? 0) + 1,
+    });
+  });
+
+  return Array.from(counts.values())
+    .map(({ entry, count }) => ({
+      key: clubKey(entry),
+      name: getTeamById(entry.teamId)?.name ?? 'Unknown',
+      clubId: entry.clubId,
+      count,
+      detail: `${count} ${count === 1 ? noun.replace(/s$/, '') : noun}`,
+    }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    .slice(0, 8);
+}
+
+function closeTitleRaces(
+  seasonTables: ReadonlyMap<number, LeagueTableEntry[]>,
+  getTeamById: TeamLookup
+): TierRaceRow[] {
+  return Array.from(seasonTables.entries())
+    .flatMap(([season, table]) => {
+      const sorted = sortTable(table);
+      const champion = sorted[0];
+      const runnerUp = sorted[1];
+      if (!champion || !runnerUp) {
+        return [];
+      }
+
+      return [raceRow(season, champion, runnerUp, champion.points - runnerUp.points, getTeamById)];
+    })
+    .sort(byClosestRace)
+    .slice(0, 6);
+}
+
+function closeSurvivalRaces(
+  seasonTables: ReadonlyMap<number, LeagueTableEntry[]>,
+  getTeamById: TeamLookup
+): TierRaceRow[] {
+  return Array.from(seasonTables.entries())
+    .flatMap(([season, table]) => {
+      const sorted = sortTable(table);
+      const firstRelegated = sorted.filter((entry) => entry.wasRelegated).sort(byPosition)[0];
+      if (!firstRelegated) {
+        return [];
+      }
+
+      const lastSafe = sorted.find((entry) => entry.pos === firstRelegated.pos - 1);
+      if (!lastSafe) {
+        return [];
+      }
+
+      return [
+        raceRow(
+          season,
+          lastSafe,
+          firstRelegated,
+          lastSafe.points - firstRelegated.points,
+          getTeamById
+        ),
+      ];
+    })
+    .sort(byClosestRace)
+    .slice(0, 6);
+}
+
+function closePromotionRaces(
+  sourceSeasonTables: ReadonlyMap<number, LeagueTableEntry[]>,
+  getTeamById: TeamLookup
+): TierRaceRow[] {
+  return Array.from(sourceSeasonTables.entries())
+    .flatMap(([season, table]) => {
+      const sorted = sortTable(table);
+      const promoted = sorted.filter((entry) => entry.wasPromoted).sort(byPosition);
+      const lastPromoted = promoted.at(-1);
+      if (!lastPromoted) {
+        return [];
+      }
+
+      const firstOutside = sorted.find((entry) => entry.pos === lastPromoted.pos + 1);
+      if (!firstOutside) {
+        return [];
+      }
+
+      return [
+        raceRow(
+          season,
+          lastPromoted,
+          firstOutside,
+          lastPromoted.points - firstOutside.points,
+          getTeamById
+        ),
+      ];
+    })
+    .sort(byClosestRace)
+    .slice(0, 6);
+}
+
+function notableSeasons(
+  seasonTables: ReadonlyMap<number, LeagueTableEntry[]>,
+  getTeamById: TeamLookup
+): TierNotableSeason[] {
+  const tables = Array.from(seasonTables.entries()).map(([season, table]) => ({
+    season,
+    table: sortTable(table),
+  }));
+  const biggestTitleMargin = tables
+    .flatMap(({ season, table }) => {
+      const champion = table[0];
+      const runnerUp = table[1];
+      return champion && runnerUp
+        ? [
+            notableRow(
+              season,
+              'Biggest title margin',
+              `${champion.points - runnerUp.points} pts`,
+              champion,
+              getTeamById
+            ),
+          ]
+        : [];
+    })
+    .sort((a, b) => Number.parseInt(b.value, 10) - Number.parseInt(a.value, 10))[0];
+  const bestGoalDifference = tables
+    .flatMap(({ season, table }) =>
+      table.map((entry) =>
+        notableRow(
+          season,
+          'Best goal difference',
+          `${entry.goalDifference ?? 0}`,
+          entry,
+          getTeamById
+        )
+      )
+    )
+    .sort((a, b) => Number.parseInt(b.value, 10) - Number.parseInt(a.value, 10))[0];
+  const mostGoals = tables
+    .flatMap(({ season, table }) =>
+      table.map((entry) =>
+        notableRow(season, 'Most goals scored', `${entry.goalsFor}`, entry, getTeamById)
+      )
+    )
+    .sort((a, b) => Number.parseInt(b.value, 10) - Number.parseInt(a.value, 10))[0];
+  const bestDefense = tables
+    .flatMap(({ season, table }) =>
+      table.map((entry) =>
+        notableRow(season, 'Fewest goals against', `${entry.goalsAgainst}`, entry, getTeamById)
+      )
+    )
+    .sort((a, b) => Number.parseInt(a.value, 10) - Number.parseInt(b.value, 10))[0];
+
+  return [biggestTitleMargin, bestGoalDifference, mostGoals, bestDefense].filter(
+    (row): row is TierNotableSeason => Boolean(row)
+  );
+}
+
+function churnSeasons(
+  seasonTables: ReadonlyMap<number, LeagueTableEntry[]>,
+  sourceSeasonTables: ReadonlyMap<number, LeagueTableEntry[]>
+): TierSeasonChurn[] {
+  return Array.from(seasonTables.entries())
+    .map(([season, table]) => {
+      const promotedIn = (sourceSeasonTables.get(season) ?? []).filter(
+        (entry) => entry.wasPromoted
+      ).length;
+      const relegatedOut = table.filter((entry) => entry.wasRelegated).length;
+
+      return {
+        season,
+        promotedIn,
+        relegatedOut,
+        totalMovement: promotedIn + relegatedOut,
+      };
+    })
+    .sort((a, b) => b.totalMovement - a.totalMovement || b.season - a.season)
+    .slice(0, 6);
+}
+
+function groupSeasonTables(entries: readonly LeagueTableEntry[]): Map<number, LeagueTableEntry[]> {
+  const groups = new Map<number, LeagueTableEntry[]>();
+  entries.forEach((entry) => {
+    groups.set(entry.season, [...(groups.get(entry.season) ?? []), entry]);
+  });
+  return groups;
+}
+
+function sortTable(table: readonly LeagueTableEntry[]): LeagueTableEntry[] {
+  return table.slice().sort(byPosition);
+}
+
+function byPosition(a: LeagueTableEntry, b: LeagueTableEntry): number {
+  return a.pos - b.pos;
+}
+
+function byClosestRace(a: TierRaceRow, b: TierRaceRow): number {
+  return (
+    a.gap - b.gap ||
+    (a.tieBreakerGap ?? Number.POSITIVE_INFINITY) - (b.tieBreakerGap ?? Number.POSITIVE_INFINITY) ||
+    b.season - a.season
+  );
+}
+
+function raceRow(
+  season: number,
+  primary: LeagueTableEntry,
+  secondary: LeagueTableEntry,
+  gap: number,
+  getTeamById: TeamLookup
+): TierRaceRow {
+  const tieBreakerGap = raceTieBreakerGap(primary, secondary, gap);
+
+  return {
+    season,
+    gap,
+    tieBreakerGap,
+    primaryName: getTeamById(primary.teamId)?.name ?? 'Unknown',
+    primaryClubId: primary.clubId,
+    secondaryName: getTeamById(secondary.teamId)?.name ?? 'Unknown',
+    secondaryClubId: secondary.clubId,
+    detail: raceDetail(primary, secondary, gap),
+  };
+}
+
+function raceDetail(
+  primary: LeagueTableEntry,
+  secondary: LeagueTableEntry,
+  pointGap: number
+): string {
+  const normalizedPointGap = Math.max(0, pointGap);
+  if (normalizedPointGap > 0) {
+    return `${normalizedPointGap} ${normalizedPointGap === 1 ? 'pt' : 'pts'}`;
+  }
+
+  const tieBreaker = raceTieBreaker(primary, secondary, pointGap);
+  if (tieBreaker) {
+    return tieBreaker.gap === null
+      ? `${tieBreaker.levelLabel} / ${tieBreaker.label}`
+      : `${tieBreaker.levelLabel} / +${formatTieBreakerGap(tieBreaker.gap)} ${tieBreaker.label}`;
+  }
+
+  return `${levelPointsLabel()} / tie-breaker`;
+}
+
+function raceTieBreakerGap(
+  primary: LeagueTableEntry,
+  secondary: LeagueTableEntry,
+  pointGap: number
+): number | null {
+  return raceTieBreaker(primary, secondary, pointGap)?.gap ?? null;
+}
+
+function raceTieBreaker(
+  primary: LeagueTableEntry,
+  secondary: LeagueTableEntry,
+  pointGap: number
+): RaceTieBreaker | null {
+  if (pointGap !== 0) {
+    return null;
+  }
+
+  if (usesGoalAverageTieBreaker(primary.season)) {
+    return goalAverageTieBreaker(primary, secondary);
+  }
+
+  const goalDifferenceTieBreaker = goalDifferenceAndGoalsTieBreaker(primary, secondary);
+  if (goalDifferenceTieBreaker) {
+    return goalDifferenceTieBreaker;
+  }
+
+  if (usesHeadToHeadTieBreaker(primary.season)) {
+    return {
+      gap: null,
+      label: 'head-to-head or playoff',
+      levelLabel: 'level on points, GD, and goals scored',
+    };
+  }
+
+  return null;
+}
+
+function goalAverageTieBreaker(
+  primary: LeagueTableEntry,
+  secondary: LeagueTableEntry
+): RaceTieBreaker | null {
+  const primaryGoalAverage = goalAverage(primary);
+  const secondaryGoalAverage = goalAverage(secondary);
+  if (primaryGoalAverage === null || secondaryGoalAverage === null) {
+    return null;
+  }
+
+  const goalAverageGap = Math.abs(primaryGoalAverage - secondaryGoalAverage);
+  if (goalAverageGap > 0) {
+    return {
+      gap: goalAverageGap,
+      label: 'goal average',
+      levelLabel: levelPointsLabel(),
+    };
+  }
+
+  return null;
+}
+
+function goalDifferenceAndGoalsTieBreaker(
+  primary: LeagueTableEntry,
+  secondary: LeagueTableEntry
+): RaceTieBreaker | null {
+  if (primary.goalDifference !== null && secondary.goalDifference !== null) {
+    const goalDifferenceGap = Math.abs(primary.goalDifference - secondary.goalDifference);
+    if (goalDifferenceGap > 0) {
+      return {
+        gap: goalDifferenceGap,
+        label: 'GD',
+        levelLabel: levelPointsLabel(),
+      };
+    }
+
+    const goalsScoredGap = Math.abs(primary.goalsFor - secondary.goalsFor);
+    if (goalsScoredGap > 0) {
+      return {
+        gap: goalsScoredGap,
+        label: 'goals scored',
+        levelLabel: 'level on points and GD',
+      };
+    }
+  }
+
+  return null;
+}
+
+function goalAverage(entry: LeagueTableEntry): number | null {
+  if (entry.goalAverage !== null) {
+    return entry.goalAverage;
+  }
+
+  return entry.goalsAgainst === 0 ? null : entry.goalsFor / entry.goalsAgainst;
+}
+
+function usesGoalAverageTieBreaker(season: number): boolean {
+  return season <= 1975;
+}
+
+function usesHeadToHeadTieBreaker(season: number): boolean {
+  return season >= 2019;
+}
+
+function formatTieBreakerGap(value: number): string {
+  return Number.isInteger(value)
+    ? String(value)
+    : value.toFixed(3).replace(/0+$/, '').replace(/\.$/, '');
+}
+
+function levelPointsLabel(): string {
+  return 'level on points';
+}
+
+function notableRow(
+  season: number,
+  label: string,
+  value: string,
+  entry: LeagueTableEntry,
+  getTeamById: TeamLookup
+): TierNotableSeason {
+  return {
+    season,
+    label,
+    value,
+    teamName: getTeamById(entry.teamId)?.name ?? 'Unknown',
+    clubId: entry.clubId,
+  };
+}
+
+function adjacentLowerTier(tier: string): string | null {
+  const value = tierNumber(tier);
+  return value ? `tier${value + 1}` : null;
+}
+
+function tierNumber(tier: string): number | null {
+  const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function clubKey(entry: LeagueTableEntry): string {
+  return entry.clubId ?? `team:${entry.teamId}`;
+}

--- a/src/app/utils/tier-profile.ts
+++ b/src/app/utils/tier-profile.ts
@@ -34,6 +34,16 @@ export interface TierSeasonChurn {
   totalMovement: number;
 }
 
+export interface TierDominanceRun {
+  key: string;
+  name: string;
+  clubId: string | null;
+  count: number;
+  startSeason: number;
+  endSeason: number;
+  detail: string;
+}
+
 export interface TierProfileData {
   tier: string;
   seasons: number[];
@@ -43,6 +53,10 @@ export interface TierProfileData {
   promotionInCount: number;
   relegationOutCount: number;
   mostSeasons: TierClubTotal[];
+  mostTitles: TierClubTotal[];
+  mostTopThreeFinishes: TierClubTotal[];
+  longestStays: TierDominanceRun[];
+  longestActiveStays: TierDominanceRun[];
   mostPromotionsIn: TierClubTotal[];
   mostRelegationsOut: TierClubTotal[];
   closeTitleRaces: TierRaceRow[];
@@ -82,6 +96,15 @@ export function buildTierProfileData(
     promotionInCount: sourceEntries.filter((entry) => entry.wasPromoted).length,
     relegationOutCount: targetEntries.filter((entry) => entry.wasRelegated).length,
     mostSeasons: rankClubTotals(targetEntries, getTeamById, () => true, 'seasons'),
+    mostTitles: rankClubTotals(targetEntries, getTeamById, (entry) => entry.pos === 1, 'titles'),
+    mostTopThreeFinishes: rankClubTotals(
+      targetEntries,
+      getTeamById,
+      (entry) => entry.pos <= 3,
+      'top-three finishes'
+    ),
+    longestStays: longestContinuousStays(targetEntries, seasons, getTeamById, false),
+    longestActiveStays: longestContinuousStays(targetEntries, seasons, getTeamById, true),
     mostPromotionsIn: sourceTier
       ? rankClubTotals(sourceEntries, getTeamById, (entry) => entry.wasPromoted, 'promotions')
       : [],
@@ -122,10 +145,109 @@ function rankClubTotals(
       name: getTeamById(entry.teamId)?.name ?? 'Unknown',
       clubId: entry.clubId,
       count,
-      detail: `${count} ${count === 1 ? noun.replace(/s$/, '') : noun}`,
+      detail: `${count} ${count === 1 ? singularNoun(noun) : noun}`,
     }))
     .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
     .slice(0, 8);
+}
+
+function singularNoun(noun: string): string {
+  return noun.endsWith('finishes') ? noun.replace(/finishes$/, 'finish') : noun.replace(/s$/, '');
+}
+
+function longestContinuousStays(
+  entries: readonly LeagueTableEntry[],
+  seasons: readonly number[],
+  getTeamById: TeamLookup,
+  activeOnly: boolean
+): TierDominanceRun[] {
+  const latestSeason = seasons.at(-1);
+  const entriesByClub = new Map<string, LeagueTableEntry[]>();
+
+  entries.forEach((entry) => {
+    const key = clubKey(entry);
+    entriesByClub.set(key, [...(entriesByClub.get(key) ?? []), entry]);
+  });
+
+  return Array.from(entriesByClub.values())
+    .flatMap((clubEntries) => {
+      const uniqueEntries = uniqueSeasonEntries(clubEntries).sort((a, b) => a.season - b.season);
+      const runs: TierDominanceRun[] = [];
+      let runStart = uniqueEntries[0];
+      let previous = uniqueEntries[0];
+      let count = uniqueEntries[0] ? 1 : 0;
+
+      uniqueEntries.slice(1).forEach((entry) => {
+        if (isContinuousSeason(previous.season, entry.season)) {
+          previous = entry;
+          count += 1;
+          return;
+        }
+
+        if (runStart && previous) {
+          runs.push(dominanceRun(runStart, previous, count, getTeamById));
+        }
+        runStart = entry;
+        previous = entry;
+        count = 1;
+      });
+
+      if (runStart && previous) {
+        runs.push(dominanceRun(runStart, previous, count, getTeamById));
+      }
+
+      return activeOnly ? runs.filter((run) => run.endSeason === latestSeason) : runs;
+    })
+    .sort(
+      (a, b) =>
+        b.count - a.count ||
+        b.endSeason - a.endSeason ||
+        a.startSeason - b.startSeason ||
+        a.name.localeCompare(b.name)
+    )
+    .slice(0, 6);
+}
+
+function uniqueSeasonEntries(entries: readonly LeagueTableEntry[]): LeagueTableEntry[] {
+  return Array.from(
+    entries
+      .slice()
+      .sort(byPosition)
+      .reduce(
+        (bySeason, entry) => bySeason.set(entry.season, entry),
+        new Map<number, LeagueTableEntry>()
+      )
+      .values()
+  );
+}
+
+function isContinuousSeason(previousSeason: number, currentSeason: number): boolean {
+  return (
+    currentSeason === previousSeason + 1 ||
+    (previousSeason === 1914 && currentSeason === 1919) ||
+    (previousSeason === 1938 && currentSeason === 1946)
+  );
+}
+
+function dominanceRun(
+  startEntry: LeagueTableEntry,
+  endEntry: LeagueTableEntry,
+  count: number,
+  getTeamById: TeamLookup
+): TierDominanceRun {
+  return {
+    key: `${clubKey(startEntry)}:${startEntry.season}:${endEntry.season}`,
+    name: getTeamById(endEntry.teamId)?.name ?? 'Unknown',
+    clubId: endEntry.clubId,
+    count,
+    startSeason: startEntry.season,
+    endSeason: endEntry.season,
+    detail: `${count} ${count === 1 ? 'season' : 'seasons'} (${seasonRange(startEntry.season, endEntry.season)})`,
+  };
+}
+
+function seasonRange(startSeason: number, endSeason: number): string {
+  return startSeason === endSeason ? String(startSeason) : `${startSeason}-${endSeason}`;
 }
 
 function closeTitleRaces(

--- a/src/app/utils/tier-profile.ts
+++ b/src/app/utils/tier-profile.ts
@@ -68,6 +68,13 @@ export interface TierProfileData {
 
 type TeamLookup = (teamId: number) => Team | undefined;
 
+export interface TierProfileBuildOptions {
+  leaderLimit?: number;
+  raceLimit?: number;
+  runLimit?: number;
+  churnLimit?: number;
+}
+
 interface RaceTieBreaker {
   gap: number | null;
   label: string;
@@ -77,7 +84,8 @@ interface RaceTieBreaker {
 export function buildTierProfileData(
   entries: readonly LeagueTableEntry[],
   tier: string,
-  getTeamById: TeamLookup
+  getTeamById: TeamLookup,
+  options: TierProfileBuildOptions = {}
 ): TierProfileData {
   const targetEntries = entries.filter((entry) => entry.tier === tier);
   const sourceTier = adjacentLowerTier(tier);
@@ -86,6 +94,10 @@ export function buildTierProfileData(
   const sourceSeasonTables = groupSeasonTables(sourceEntries);
   const seasons = Array.from(seasonTables.keys()).sort((a, b) => a - b);
   const clubKeys = new Set(targetEntries.map((entry) => clubKey(entry)));
+  const leaderLimit = options.leaderLimit ?? 8;
+  const raceLimit = options.raceLimit ?? 6;
+  const runLimit = options.runLimit ?? 6;
+  const churnLimit = options.churnLimit ?? 6;
 
   return {
     tier,
@@ -95,30 +107,44 @@ export function buildTierProfileData(
     totalRows: targetEntries.length,
     promotionInCount: sourceEntries.filter((entry) => entry.wasPromoted).length,
     relegationOutCount: targetEntries.filter((entry) => entry.wasRelegated).length,
-    mostSeasons: rankClubTotals(targetEntries, getTeamById, () => true, 'seasons'),
-    mostTitles: rankClubTotals(targetEntries, getTeamById, (entry) => entry.pos === 1, 'titles'),
+    mostSeasons: rankClubTotals(targetEntries, getTeamById, () => true, 'seasons', leaderLimit),
+    mostTitles: rankClubTotals(
+      targetEntries,
+      getTeamById,
+      (entry) => entry.pos === 1,
+      'titles',
+      leaderLimit
+    ),
     mostTopThreeFinishes: rankClubTotals(
       targetEntries,
       getTeamById,
       (entry) => entry.pos <= 3,
-      'top-three finishes'
+      'top-three finishes',
+      leaderLimit
     ),
-    longestStays: longestContinuousStays(targetEntries, seasons, getTeamById, false),
-    longestActiveStays: longestContinuousStays(targetEntries, seasons, getTeamById, true),
+    longestStays: longestContinuousStays(targetEntries, seasons, getTeamById, false, runLimit),
+    longestActiveStays: longestContinuousStays(targetEntries, seasons, getTeamById, true, runLimit),
     mostPromotionsIn: sourceTier
-      ? rankClubTotals(sourceEntries, getTeamById, (entry) => entry.wasPromoted, 'promotions')
+      ? rankClubTotals(
+          sourceEntries,
+          getTeamById,
+          (entry) => entry.wasPromoted,
+          'promotions',
+          leaderLimit
+        )
       : [],
     mostRelegationsOut: rankClubTotals(
       targetEntries,
       getTeamById,
       (entry) => entry.wasRelegated,
-      'relegations'
+      'relegations',
+      leaderLimit
     ),
-    closeTitleRaces: closeTitleRaces(seasonTables, getTeamById),
-    closeSurvivalRaces: closeSurvivalRaces(seasonTables, getTeamById),
-    closePromotionRaces: closePromotionRaces(sourceSeasonTables, getTeamById),
+    closeTitleRaces: closeTitleRaces(seasonTables, getTeamById, raceLimit),
+    closeSurvivalRaces: closeSurvivalRaces(seasonTables, getTeamById, raceLimit),
+    closePromotionRaces: closePromotionRaces(sourceSeasonTables, getTeamById, raceLimit),
     notableSeasons: notableSeasons(seasonTables, getTeamById),
-    churnSeasons: churnSeasons(seasonTables, sourceSeasonTables),
+    churnSeasons: churnSeasons(seasonTables, sourceSeasonTables, churnLimit),
   };
 }
 
@@ -126,7 +152,8 @@ function rankClubTotals(
   entries: readonly LeagueTableEntry[],
   getTeamById: TeamLookup,
   include: (entry: LeagueTableEntry) => boolean,
-  noun: string
+  noun: string,
+  limit: number
 ): TierClubTotal[] {
   const counts = new Map<string, { entry: LeagueTableEntry; count: number }>();
 
@@ -148,7 +175,7 @@ function rankClubTotals(
       detail: `${count} ${count === 1 ? singularNoun(noun) : noun}`,
     }))
     .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
-    .slice(0, 8);
+    .slice(0, limit);
 }
 
 function singularNoun(noun: string): string {
@@ -159,7 +186,8 @@ function longestContinuousStays(
   entries: readonly LeagueTableEntry[],
   seasons: readonly number[],
   getTeamById: TeamLookup,
-  activeOnly: boolean
+  activeOnly: boolean,
+  limit: number
 ): TierDominanceRun[] {
   const latestSeason = seasons.at(-1);
   const entriesByClub = new Map<string, LeagueTableEntry[]>();
@@ -205,7 +233,7 @@ function longestContinuousStays(
         a.startSeason - b.startSeason ||
         a.name.localeCompare(b.name)
     )
-    .slice(0, 6);
+    .slice(0, limit);
 }
 
 function uniqueSeasonEntries(entries: readonly LeagueTableEntry[]): LeagueTableEntry[] {
@@ -252,7 +280,8 @@ function seasonRange(startSeason: number, endSeason: number): string {
 
 function closeTitleRaces(
   seasonTables: ReadonlyMap<number, LeagueTableEntry[]>,
-  getTeamById: TeamLookup
+  getTeamById: TeamLookup,
+  limit: number
 ): TierRaceRow[] {
   return Array.from(seasonTables.entries())
     .flatMap(([season, table]) => {
@@ -266,12 +295,13 @@ function closeTitleRaces(
       return [raceRow(season, champion, runnerUp, champion.points - runnerUp.points, getTeamById)];
     })
     .sort(byClosestRace)
-    .slice(0, 6);
+    .slice(0, limit);
 }
 
 function closeSurvivalRaces(
   seasonTables: ReadonlyMap<number, LeagueTableEntry[]>,
-  getTeamById: TeamLookup
+  getTeamById: TeamLookup,
+  limit: number
 ): TierRaceRow[] {
   return Array.from(seasonTables.entries())
     .flatMap(([season, table]) => {
@@ -297,12 +327,13 @@ function closeSurvivalRaces(
       ];
     })
     .sort(byClosestRace)
-    .slice(0, 6);
+    .slice(0, limit);
 }
 
 function closePromotionRaces(
   sourceSeasonTables: ReadonlyMap<number, LeagueTableEntry[]>,
-  getTeamById: TeamLookup
+  getTeamById: TeamLookup,
+  limit: number
 ): TierRaceRow[] {
   return Array.from(sourceSeasonTables.entries())
     .flatMap(([season, table]) => {
@@ -329,7 +360,7 @@ function closePromotionRaces(
       ];
     })
     .sort(byClosestRace)
-    .slice(0, 6);
+    .slice(0, limit);
 }
 
 function notableSeasons(
@@ -392,7 +423,8 @@ function notableSeasons(
 
 function churnSeasons(
   seasonTables: ReadonlyMap<number, LeagueTableEntry[]>,
-  sourceSeasonTables: ReadonlyMap<number, LeagueTableEntry[]>
+  sourceSeasonTables: ReadonlyMap<number, LeagueTableEntry[]>,
+  limit: number
 ): TierSeasonChurn[] {
   return Array.from(seasonTables.entries())
     .map(([season, table]) => {
@@ -409,7 +441,7 @@ function churnSeasons(
       };
     })
     .sort((a, b) => b.totalMovement - a.totalMovement || b.season - a.season)
-    .slice(0, 6);
+    .slice(0, limit);
 }
 
 function groupSeasonTables(entries: readonly LeagueTableEntry[]): Map<number, LeagueTableEntry[]> {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,13 @@ export const environment = {
     githubLatestReleaseApiUrl:
       'https://api.github.com/repos/dills122/footy-data-kit/releases/latest',
     manifestAssetNames: ['footy-stats-data-manifest.json', 'data-manifest.json'],
-    seasonsAssetName: 'seasons.json',
-    clubMetadataAssetName: 'club-metadata.json',
+    seasonsAssetNames: ['seasons.json', 'all-seasons.min.json', 'all-seasons.json'],
+    clubMetadataAssetNames: ['club-metadata.json'],
+    rawAssetPathsByName: {
+      'seasons.json': 'data-output/all-seasons.json',
+      'all-seasons.min.json': 'data-output/all-seasons.min.json',
+      'all-seasons.json': 'data-output/all-seasons.json',
+      'club-metadata.json': 'data/club-metadata.json',
+    },
   },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,3 +1,10 @@
 export const environment = {
   web3FormsAccessKey: '2a8d025b-bb66-4ca9-939b-ac6e2639c4ad',
+  dataUpdates: {
+    githubLatestReleaseApiUrl:
+      'https://api.github.com/repos/dills122/footy-data-kit/releases/latest',
+    manifestAssetNames: ['footy-stats-data-manifest.json', 'data-manifest.json'],
+    seasonsAssetName: 'seasons.json',
+    clubMetadataAssetName: 'club-metadata.json',
+  },
 };

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -210,6 +210,23 @@ body {
   box-shadow: none;
 }
 
+.app-club-link {
+  color: inherit;
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+.app-club-link:hover {
+  color: #fde68a;
+  text-decoration: underline;
+}
+
+.app-club-link:focus-visible {
+  outline: 2px solid var(--app-focus-ring);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 .app-data-shell {
   border-radius: 10px;
   overflow: auto;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -284,3 +284,173 @@ button:focus-visible,
   outline-offset: 2px;
   border-radius: 8px;
 }
+
+@media print {
+  @page {
+    margin: 0.45in;
+  }
+
+  :root {
+    color-scheme: light;
+    --app-bg-gradient: #ffffff;
+    --app-bg-spot-1: none;
+    --app-bg-spot-2: none;
+    --app-bg-spot-3: none;
+    --app-surface-bg: #ffffff;
+    --app-border: #cbd5e1;
+    --app-surface-border: 1px solid #cbd5e1;
+    --app-text-strong: #111827;
+    --app-text-subtle: #374151;
+    --app-text-muted: #4b5563;
+  }
+
+  html,
+  body {
+    width: auto;
+    height: auto;
+    overflow: visible !important;
+    background: #ffffff !important;
+    color: #111827 !important;
+    font-size: 10pt;
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-shadow: none !important;
+    text-shadow: none !important;
+    animation: none !important;
+    transition: none !important;
+  }
+
+  a {
+    color: inherit !important;
+    text-decoration: none !important;
+  }
+
+  .app-header,
+  .app-footer,
+  .profile-top-actions,
+  .record-control-row,
+  .record-header-action,
+  .preset-panel,
+  .era-filter-panel,
+  .panel-actions,
+  .panel-toggle,
+  .control-action,
+  .chip-toggle,
+  app-data-issue-report-dialog {
+    display: none !important;
+  }
+
+  .app-page-shell {
+    width: 100% !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  .app-surface,
+  .app-panel,
+  .app-data-shell {
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: #ffffff !important;
+    color: #111827 !important;
+  }
+
+  .app-panel,
+  .stat-grid,
+  .profile-panel,
+  .summary,
+  .table-result-shell {
+    break-inside: avoid;
+  }
+
+  .app-page-title {
+    color: #111827 !important;
+  }
+
+  .app-page-eyebrow,
+  .app-page-lede {
+    color: #374151 !important;
+  }
+
+  .team-overview {
+    gap: 12px;
+  }
+
+  .team-overview .profile-header {
+    padding-bottom: 10px;
+    border-bottom: 2px solid #111827;
+  }
+
+  .team-overview .stat-grid,
+  .team-overview .profile-feature-grid,
+  .team-overview .profile-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .team-overview .profile-panel,
+  .team-overview .stat-cell,
+  .team-overview .tier-row,
+  .team-overview .relationship-list > div,
+  .team-overview .gap-list > div,
+  .team-overview .period-list > div,
+  .team-overview .milestone-list > div,
+  .team-overview .historical-status,
+  .team-overview .compact-snapshot-summary > div {
+    border-color: #cbd5e1;
+    background: #ffffff;
+  }
+
+  .team-overview .profile-panel {
+    padding: 10px;
+  }
+
+  .team-overview .profile-panel::before,
+  .team-overview .stat-cell::before,
+  .team-overview .milestone-panel--collapsed::after,
+  .team-overview .status-block {
+    display: none;
+  }
+
+  .team-overview .milestone-panel--collapsed,
+  .team-overview .milestone-panel--expanded {
+    max-height: none;
+  }
+
+  .team-overview .path-chart,
+  .team-overview .path-chart--small {
+    display: none;
+  }
+
+  .team-overview .recent-panel {
+    overflow: visible;
+    break-before: page;
+  }
+
+  .team-overview .recent-table {
+    min-width: 0;
+    display: grid;
+    border-color: #cbd5e1;
+    background: #ffffff;
+    font-size: 8pt;
+  }
+
+  .team-overview .recent-row {
+    grid-template-columns: 0.55fr 1.15fr 1fr 0.52fr 0.62fr 0.54fr;
+  }
+
+  .team-overview .recent-row span {
+    padding: 5px 4px;
+    color: #111827;
+    background: #ffffff !important;
+  }
+
+  .team-overview .recent-row span:last-child,
+  .team-overview .recent-report,
+  .team-overview .mobile-recent-list {
+    display: none;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -287,7 +287,7 @@ button:focus-visible,
 
 @media print {
   @page {
-    margin: 0.45in;
+    margin: 0.25in;
   }
 
   :root {
@@ -297,11 +297,11 @@ button:focus-visible,
     --app-bg-spot-2: none;
     --app-bg-spot-3: none;
     --app-surface-bg: #ffffff;
-    --app-border: #cbd5e1;
-    --app-surface-border: 1px solid #cbd5e1;
-    --app-text-strong: #111827;
-    --app-text-subtle: #374151;
-    --app-text-muted: #4b5563;
+    --app-border: #d4d4d4;
+    --app-surface-border: 0;
+    --app-text-strong: #000000;
+    --app-text-subtle: #222222;
+    --app-text-muted: #555555;
   }
 
   html,
@@ -310,8 +310,10 @@ button:focus-visible,
     height: auto;
     overflow: visible !important;
     background: #ffffff !important;
-    color: #111827 !important;
-    font-size: 10pt;
+    color: #000000 !important;
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 8.5pt;
+    line-height: 1.22;
   }
 
   *,
@@ -355,40 +357,232 @@ button:focus-visible,
     border: 0 !important;
     border-radius: 0 !important;
     background: #ffffff !important;
-    color: #111827 !important;
+    color: #000000 !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
   }
 
-  .app-panel,
-  .stat-grid,
-  .profile-panel,
-  .summary,
-  .table-result-shell {
-    break-inside: avoid;
+  .app-page-header,
+  .profile-header,
+  .record-header {
+    margin: 0 0 8pt !important;
+    padding: 0 0 5pt !important;
+    border: 0 !important;
+    border-bottom: 1px solid #000000 !important;
+    border-radius: 0 !important;
   }
 
   .app-page-title {
-    color: #111827 !important;
+    margin: 0 0 4pt !important;
+    color: #000000 !important;
+    font-size: 17pt !important;
+    line-height: 1.1 !important;
+    letter-spacing: 0 !important;
   }
 
   .app-page-eyebrow,
   .app-page-lede {
-    color: #374151 !important;
+    color: #222222 !important;
+  }
+
+  .app-page-eyebrow {
+    margin: 0 0 3pt !important;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 8pt !important;
+    font-weight: 700;
+    letter-spacing: 0.04em !important;
+  }
+
+  .app-page-lede {
+    max-width: none !important;
+    margin: 0 !important;
+    font-size: 8.5pt !important;
+    line-height: 1.22 !important;
+  }
+
+  h1,
+  h2,
+  h3,
+  th,
+  .data-head,
+  .panel-head,
+  .stat-cell span {
+    font-family: Arial, Helvetica, sans-serif;
+  }
+
+  h2 {
+    margin: 0 0 4pt !important;
+    font-size: 10.5pt !important;
+  }
+
+  h3 {
+    margin: 0 0 3pt !important;
+    font-size: 8.5pt !important;
+  }
+
+  p {
+    margin: 0 0 4pt;
+  }
+
+  .stat-grid,
+  .profile-grid,
+  .profile-feature-grid,
+  .deep-grid,
+  .leaderboard-grid,
+  .race-table-grid,
+  .mark-grid,
+  .band-grid {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 8pt 12pt !important;
+    align-items: start;
+  }
+
+  .stat-grid {
+    margin: 0 0 7pt !important;
+    padding: 4pt 0 !important;
+    border-top: 1px solid #999999;
+    border-bottom: 1px solid #999999;
+    display: grid !important;
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+    gap: 4pt 8pt !important;
+  }
+
+  .stat-cell {
+    min-height: 0 !important;
+    margin: 0 0 5pt !important;
+    padding: 0 !important;
+    display: block !important;
+    break-inside: avoid;
+  }
+
+  .stat-cell span,
+  .stat-cell strong {
+    display: inline !important;
+    color: #000000 !important;
+    font-size: 8pt !important;
+    line-height: 1.2 !important;
+  }
+
+  .stat-cell span {
+    margin-right: 4pt;
+    font-weight: 700;
+    letter-spacing: 0 !important;
+    text-transform: none !important;
+  }
+
+  .stat-cell span::after {
+    content: ':';
+  }
+
+  .profile-panel,
+  .deep-panel,
+  .summary,
+  .data-notice {
+    margin: 0 0 7pt !important;
+    padding: 0 !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: #ffffff !important;
+  }
+
+  .profile-panel::before,
+  .deep-panel::before,
+  .stat-cell::before,
+  .data-notice::before {
+    display: none !important;
+  }
+
+  .panel-head {
+    margin: 0 0 4pt !important;
+    padding: 0 0 2pt !important;
+    display: block !important;
+    border: 0 !important;
+    border-bottom: 1px solid #999999 !important;
+  }
+
+  .panel-head span {
+    display: block;
+    margin-top: 2pt;
+    color: #555555 !important;
+    font-size: 7pt !important;
+    letter-spacing: 0 !important;
+    text-transform: none !important;
+  }
+
+  .leader-list > div,
+  .rank-list div,
+  .race-row,
+  .mark-row,
+  .churn-list a,
+  .churn-table a,
+  .deep-table a,
+  .movement-list a,
+  .mark-grid a,
+  .band-grid div,
+  .tier-row,
+  .relationship-list > div,
+  .gap-list > div,
+  .period-list > div,
+  .milestone-list > div,
+  .historical-status,
+  .compact-snapshot-summary > div,
+  .data-row {
+    min-height: 0 !important;
+    margin: 0 !important;
+    padding: 1.8pt 0 !important;
+    border: 0 !important;
+    border-bottom: 1px solid #dddddd !important;
+    border-radius: 0 !important;
+    background: #ffffff !important;
+    color: #000000 !important;
+  }
+
+  .leader-list,
+  .rank-list,
+  .race-list,
+  .mark-list,
+  .churn-list,
+  .churn-table,
+  .deep-table,
+  .movement-list,
+  .mark-grid,
+  .band-grid {
+    gap: 0 !important;
+  }
+
+  em,
+  small,
+  .race-list em,
+  .churn-list em,
+  .churn-table em,
+  .deep-table em,
+  .movement-list em {
+    border: 0 !important;
+    background: transparent !important;
+    color: #333333 !important;
+    font-style: normal !important;
+  }
+
+  .data-notice {
+    border-left: 3pt solid #666666 !important;
+    padding-left: 6pt !important;
   }
 
   .team-overview {
-    gap: 12px;
+    gap: 6pt;
   }
 
   .team-overview .profile-header {
-    padding-bottom: 10px;
-    border-bottom: 2px solid #111827;
+    padding-bottom: 5pt;
+    border-bottom: 1px solid #000000;
   }
 
   .team-overview .stat-grid,
   .team-overview .profile-feature-grid,
   .team-overview .profile-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 8pt 12pt !important;
   }
 
   .team-overview .profile-panel,
@@ -400,12 +594,12 @@ button:focus-visible,
   .team-overview .milestone-list > div,
   .team-overview .historical-status,
   .team-overview .compact-snapshot-summary > div {
-    border-color: #cbd5e1;
+    border-color: #dddddd;
     background: #ffffff;
   }
 
   .team-overview .profile-panel {
-    padding: 10px;
+    padding: 0;
   }
 
   .team-overview .profile-panel::before,
@@ -427,13 +621,13 @@ button:focus-visible,
 
   .team-overview .recent-panel {
     overflow: visible;
-    break-before: page;
+    break-before: auto;
   }
 
   .team-overview .recent-table {
     min-width: 0;
     display: grid;
-    border-color: #cbd5e1;
+    border-color: #dddddd;
     background: #ffffff;
     font-size: 8pt;
   }
@@ -444,7 +638,7 @@ button:focus-visible,
 
   .team-overview .recent-row span {
     padding: 5px 4px;
-    color: #111827;
+    color: #000000;
     background: #ffffff !important;
   }
 


### PR DESCRIPTION
This branch adds a large polish and data-refresh pass across FootyStats.

Added verified browser data updates:
- Checks the latest `footy-data-kit` GitHub release.
- Shows a small update banner when newer data is available.
- Downloads updated data from CORS-safe tagged raw GitHub files.
- Verifies downloaded files before installing them locally.
- Stores the refreshed data in browser storage as a local override.
- Keeps the shipped JSON as the fallback.
- Added tests around update detection, download mapping, checksum/blob verification, install, and failure handling.

Improved loading and layout stability:
- Reduced initial loading flash and UI jitter.
- Added cleaner loading behavior around table/header controls.
- Added reserved container rendering where needed so content does not jump while data loads.
- Added number/ticker loading polish on the home page, with simpler mobile behavior.

Built out league/tier views:
- Added league/tier overview pages modeled after team overview.
- Added close-season insights, movement leaders, most seasons, notable marks, and high-churn seasons.
- Added era filtering and compacted/collapsible dense sections.
- Added tie-breaker handling for historical rules:
  - goal average before 1976-77
  - goal difference and goals scored afterward
  - modern Premier League tie-breaker ordering

Added deep stats routes:
- Added team deep stats routes.
- Added league deep stats routes.
- Added print-focused versions for data-heavy views.
- Made more club names clickable through to club overview pages.

Improved table page UX:
- Added presets/quick filters.
- Added jump-to-table action.
- Added minimize/expand behavior for the controls area.
- Fixed vertical scrollbar and large promoted/relegated chip overflow.
- Added regional Third Division warning banners for affected historical seasons/tiers.

Improved reporting flow:
- Polished the data issue report dialog.
- Successful submission now swaps to a sent state and can close automatically or manually.

Added print improvements:
- Reworked print CSS to be plainer and more document-like.
- Reduced oversized spacing/margins so printed pages are more compact and useful.
- Covered table, team, league, and deep-stat views more consistently.

Added global app polish:
- Added app-wide scroll-to-top control.
- Moved the scroll control into the page gutter.
- Expanded the footer into a clearer link tree:
  - Explore
  - Profiles
  - Deep Data
  - Source
  - Studio
- Added GitHub repo and GitHub issues links with icons.
- Kept data issue reporting available in the footer.

Verification run during the branch:
- Full Jest suite passing
- Lint passing
- Production build passing
- `git diff --check` passing where run

Final branch state:
- Working tree is clean.
- Latest commits include:
  - `64d795a Move scroll control into page gutter`
  - `b0e5b54 Polish footer and add scroll to top`
  - `35542eb Fix browser-safe data refresh flow`
  - `0a33d3a Add verified local data updates`