### PR TITLE
Add rivalry comparison workbench and data visualizations

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { LeagueDeepStats } from './pages/league-deep-stats/league-deep-stats';
 import { LeagueSystemHistory } from './pages/league-system-history/league-system-history';
 import { LeagueTableHistoric } from './pages/league-table-historic/league-table-historic';
 import { MovementExplorer } from './pages/movement-explorer/movement-explorer';
+import { RivalryComparison } from './pages/rivalry-comparison/rivalry-comparison';
 import { TeamDeepStats } from './pages/team-deep-stats/team-deep-stats';
 import { TeamOverview } from './pages/team-overview/team-overview';
 import { Teams } from './pages/teams/teams';
@@ -14,6 +15,7 @@ export const routes: Routes = [
   { path: 'tables', component: LeagueTableHistoric },
   { path: 'system', component: LeagueSystemHistory },
   { path: 'movement', component: MovementExplorer },
+  { path: 'rivalries', component: RivalryComparison },
   { path: 'leagues/:tier/deep-stats', component: LeagueDeepStats },
   { path: 'leagues/:tier', component: TierProfile },
   { path: 'teams/:clubId/deep-stats', component: TeamDeepStats },

--- a/src/app/components/main-toolbar/main-toolbar.html
+++ b/src/app/components/main-toolbar/main-toolbar.html
@@ -22,6 +22,7 @@
       <a mat-button routerLink="/tables" routerLinkActive="is-active">Tables</a>
       <a mat-button routerLink="/system" routerLinkActive="is-active">System</a>
       <a mat-button routerLink="/movement" routerLinkActive="is-active">Movement</a>
+      <a mat-button routerLink="/rivalries" routerLinkActive="is-active">Rivalries</a>
       <a mat-button routerLink="/teams" routerLinkActive="is-active">Clubs</a>
     </nav>
 
@@ -53,6 +54,7 @@
       <a mat-menu-item routerLink="/tables" routerLinkActive="is-active">Tables</a>
       <a mat-menu-item routerLink="/system" routerLinkActive="is-active">System</a>
       <a mat-menu-item routerLink="/movement" routerLinkActive="is-active">Movement</a>
+      <a mat-menu-item routerLink="/rivalries" routerLinkActive="is-active">Rivalries</a>
       <a mat-menu-item routerLink="/teams" routerLinkActive="is-active">Clubs</a>
     </mat-menu>
   </div>

--- a/src/app/pages/league-deep-stats/league-deep-stats.html
+++ b/src/app/pages/league-deep-stats/league-deep-stats.html
@@ -281,6 +281,34 @@
 
   <section class="deep-panel app-panel">
     <div class="panel-head">
+      <h2>Season Competitiveness</h2>
+      <span>points gaps by season</span>
+    </div>
+    <div
+      echarts
+      class="competitiveness-chart"
+      [options]="competitivenessChartOptions()"
+      [autoResize]="true"
+      aria-label="Title gap and table compression by season"
+    ></div>
+  </section>
+
+  <section class="deep-panel app-panel">
+    <div class="panel-head">
+      <h2>Unique Clubs by Decade</h2>
+      <span>tier variety</span>
+    </div>
+    <div
+      echarts
+      class="decade-chart"
+      [options]="uniqueClubsChartOptions()"
+      [autoResize]="true"
+      aria-label="Unique clubs by decade"
+    ></div>
+  </section>
+
+  <section class="deep-panel app-panel">
+    <div class="panel-head">
       <h2>High-Churn Seasons</h2>
       <span>top movement seasons</span>
     </div>

--- a/src/app/pages/league-deep-stats/league-deep-stats.scss
+++ b/src/app/pages/league-deep-stats/league-deep-stats.scss
@@ -82,6 +82,10 @@
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.leaderboard-grid section {
+  container-type: inline-size;
+}
+
 .stat-cell,
 .deep-panel {
   position: relative;
@@ -171,6 +175,12 @@
   gap: 7px;
 }
 
+.competitiveness-chart,
+.decade-chart {
+  min-height: 280px;
+  margin: 2px 0 14px;
+}
+
 .rank-list div,
 .deep-table .race-row,
 .churn-table a {
@@ -183,10 +193,19 @@
 
 .rank-list div {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) minmax(7rem, fit-content(58%));
+  align-items: start;
+  gap: 5px 12px;
   padding: 8px 10px;
+}
+
+.rank-list span,
+.rank-list strong,
+.rank-list .app-club-link {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  line-height: 1.25;
 }
 
 .rank-list strong,
@@ -196,6 +215,10 @@
   font-style: normal;
   font-weight: 850;
   text-align: right;
+}
+
+.rank-list strong {
+  justify-self: end;
 }
 
 .deep-table .table-row-link,
@@ -250,6 +273,17 @@
   }
 }
 
+@container (max-width: 320px) {
+  .rank-list div {
+    grid-template-columns: 1fr;
+  }
+
+  .rank-list strong {
+    justify-self: start;
+    text-align: left;
+  }
+}
+
 @media print {
   .deep-stats {
     gap: 6pt;
@@ -276,6 +310,11 @@
   .deep-table,
   .churn-table {
     gap: 0;
+  }
+
+  .competitiveness-chart,
+  .decade-chart {
+    display: none;
   }
 
   .rank-list div,

--- a/src/app/pages/league-deep-stats/league-deep-stats.spec.ts
+++ b/src/app/pages/league-deep-stats/league-deep-stats.spec.ts
@@ -6,8 +6,31 @@ import { DataLoaderService } from '@app/store/services/hydrate-store-json';
 import { of } from 'rxjs';
 import { LeagueDeepStats } from './league-deep-stats';
 
+jest.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {} }));
+jest.mock('echarts/components', () => ({
+  DataZoomComponent: {},
+  GridComponent: {},
+  LegendComponent: {},
+  TooltipComponent: {},
+}));
+jest.mock('echarts/core', () => ({ use: jest.fn() }));
+jest.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+jest.mock('ngx-echarts', () => {
+  const core = jest.requireActual('@angular/core');
+  class MockNgxEchartsDirective {}
+  core.Directive({ selector: '[echarts]' })(MockNgxEchartsDirective);
+  core.Input()(MockNgxEchartsDirective.prototype, 'options');
+  core.Input()(MockNgxEchartsDirective.prototype, 'autoResize');
+
+  return {
+    NgxEchartsDirective: MockNgxEchartsDirective,
+    provideEchartsCore: () => [],
+  };
+});
+
 describe('LeagueDeepStats', () => {
   let fixture: ComponentFixture<LeagueDeepStats>;
+  let component: LeagueDeepStats;
   let store: InstanceType<typeof LeagueStore>;
 
   beforeEach(async () => {
@@ -40,6 +63,7 @@ describe('LeagueDeepStats', () => {
     store = TestBed.inject(LeagueStore);
     store.hydrate(deepStatsFixture(), (teamName: string) => `${teamName.toLowerCase()} id`);
     fixture = TestBed.createComponent(LeagueDeepStats);
+    component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
@@ -61,6 +85,57 @@ describe('LeagueDeepStats', () => {
         link.textContent?.trim() === 'Alpha FC' && link.getAttribute('href')?.includes('/teams/')
     );
     expect(clubLink?.getAttribute('href')).toBe('/teams/alpha%20fc%20id');
+
+    expect(element.textContent).toContain('Season Competitiveness');
+    expect(element.querySelector('.competitiveness-chart')?.getAttribute('aria-label')).toBe(
+      'Title gap and table compression by season'
+    );
+    expect(element.textContent).toContain('Unique Clubs by Decade');
+    expect(element.querySelector('.decade-chart')?.getAttribute('aria-label')).toBe(
+      'Unique clubs by decade'
+    );
+  });
+
+  it('builds a season competitiveness chart from title and table gaps', () => {
+    expect(component.competitivenessChartRows().map((row) => row.season)).toEqual([2020, 2021]);
+    expect(component.competitivenessChartOptions()).toMatchObject({
+      xAxis: {
+        data: ['2020', '2021'],
+      },
+      series: [
+        {
+          name: 'Title gap',
+          type: 'line',
+          data: [1, 3],
+        },
+        {
+          name: 'Champion to middle',
+          type: 'line',
+          data: [1, 3],
+        },
+        {
+          name: 'Champion to last',
+          type: 'line',
+          data: [45, 45],
+        },
+      ],
+    });
+  });
+
+  it('builds a unique clubs by decade chart', () => {
+    expect(component.uniqueClubsChartRows().map((row) => row.label)).toEqual(['2020s']);
+    expect(component.uniqueClubsChartOptions()).toMatchObject({
+      xAxis: {
+        data: ['2020s'],
+      },
+      series: [
+        {
+          name: 'Unique clubs',
+          type: 'bar',
+          data: [4],
+        },
+      ],
+    });
   });
 });
 

--- a/src/app/pages/league-deep-stats/league-deep-stats.ts
+++ b/src/app/pages/league-deep-stats/league-deep-stats.ts
@@ -3,6 +3,17 @@ import { Component, computed, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { ActivatedRoute, RouterLink } from '@angular/router';
+import { BarChart, LineChart } from 'echarts/charts';
+import {
+  DataZoomComponent,
+  GridComponent,
+  LegendComponent,
+  TooltipComponent,
+} from 'echarts/components';
+import type { EChartsCoreOption } from 'echarts/core';
+import * as echarts from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { NgxEchartsDirective, provideEchartsCore } from 'ngx-echarts';
 import { DataExportMenu } from '@app/components/data-export-menu/data-export-menu';
 import { LeagueTierToStringyPipe } from '@app/pipes/league-tier-to-stringy-pipe';
 import { LeagueStore } from '@app/store/league.store';
@@ -14,10 +25,20 @@ import {
 } from '@app/utils/tier-profile';
 import type { ExportRow, ExportSummary } from '@app/utils/data-export';
 
+echarts.use([
+  BarChart,
+  LineChart,
+  GridComponent,
+  TooltipComponent,
+  LegendComponent,
+  DataZoomComponent,
+  CanvasRenderer,
+]);
+
 @Component({
   selector: 'app-league-deep-stats',
-  imports: [CommonModule, MatButtonModule, RouterLink, DataExportMenu],
-  providers: [LeagueTierToStringyPipe],
+  imports: [CommonModule, MatButtonModule, RouterLink, NgxEchartsDirective, DataExportMenu],
+  providers: [LeagueTierToStringyPipe, provideEchartsCore({ echarts })],
   templateUrl: './league-deep-stats.html',
   styleUrl: './league-deep-stats.scss',
 })
@@ -113,6 +134,28 @@ export class LeagueDeepStats {
     addRaces('Close title races', profile.closeTitleRaces);
     addRaces('Close survival races', profile.closeSurvivalRaces);
     addRaces('Close promotion races', profile.closePromotionRaces);
+    profile.seasonCompetitiveness.forEach((row) =>
+      rows.push({
+        section: 'Season competitiveness',
+        season: row.season,
+        teams: row.teamCount,
+        champion: row.championName,
+        runnerUp: row.runnerUpName,
+        medianTeam: row.medianName,
+        lastTeam: row.lastName,
+        titleGap: row.titleGap,
+        midTableGap: row.midTableGap,
+        fullTableSpread: row.fullTableSpread,
+      })
+    );
+    profile.uniqueClubsByDecade.forEach((row) =>
+      rows.push({
+        section: 'Unique clubs by decade',
+        decade: row.label,
+        uniqueClubCount: row.uniqueClubCount,
+        seasons: row.seasons,
+      })
+    );
     profile.churnSeasons.forEach((row) =>
       rows.push({
         section: 'High-churn seasons',
@@ -126,6 +169,249 @@ export class LeagueDeepStats {
     return rows;
   });
   exportFilename = computed(() => `footy-stats-league-deep-stats-${this.tierId()}`);
+  uniqueClubsChartRows = computed(() => this.profile()?.uniqueClubsByDecade ?? []);
+  uniqueClubsChartOptions = computed<EChartsCoreOption>(() => {
+    const rows = this.uniqueClubsChartRows();
+
+    if (!rows.length) {
+      return {
+        animation: false,
+        xAxis: { type: 'category', data: [] },
+        yAxis: { type: 'value' },
+        series: [],
+      };
+    }
+
+    return {
+      animation: false,
+      backgroundColor: 'transparent',
+      grid: {
+        left: 44,
+        right: 18,
+        top: 20,
+        bottom: rows.length > 12 ? 54 : 30,
+        containLabel: true,
+      },
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        backgroundColor: 'rgba(7, 10, 19, 0.94)',
+        borderColor: 'rgba(148, 163, 184, 0.28)',
+        textStyle: {
+          color: '#d7deeb',
+        },
+      },
+      xAxis: {
+        type: 'category',
+        data: rows.map((row) => row.label),
+        axisLabel: {
+          color: '#c5d0e4',
+          fontSize: 11,
+          hideOverlap: true,
+        },
+        axisLine: {
+          lineStyle: { color: 'rgba(148, 163, 184, 0.45)' },
+        },
+        axisTick: { show: false },
+      },
+      yAxis: {
+        type: 'value',
+        minInterval: 1,
+        axisLabel: {
+          color: '#c5d0e4',
+          fontSize: 11,
+        },
+        axisLine: { show: false },
+        splitLine: {
+          lineStyle: { color: 'rgba(148, 163, 184, 0.18)' },
+        },
+      },
+      dataZoom:
+        rows.length > 12
+          ? [
+              {
+                type: 'slider',
+                xAxisIndex: 0,
+                height: 18,
+                bottom: 18,
+                filterMode: 'none',
+                backgroundColor: 'rgba(15, 23, 42, 0.75)',
+                fillerColor: 'rgba(217, 119, 6, 0.22)',
+                borderColor: 'rgba(148, 163, 184, 0.42)',
+                handleStyle: {
+                  color: '#d97706',
+                  borderColor: '#f59e0b',
+                },
+                textStyle: {
+                  color: '#d7deeb',
+                  fontSize: 10,
+                },
+              },
+            ]
+          : [],
+      series: [
+        {
+          name: 'Unique clubs',
+          type: 'bar',
+          data: rows.map((row) => row.uniqueClubCount),
+          barMaxWidth: 34,
+          itemStyle: {
+            color: '#38bdf8',
+            borderRadius: [4, 4, 0, 0],
+          },
+          emphasis: {
+            focus: 'series',
+          },
+        },
+      ],
+    };
+  });
+  competitivenessChartRows = computed(() => this.profile()?.seasonCompetitiveness ?? []);
+  competitivenessChartOptions = computed<EChartsCoreOption>(() => {
+    const rows = this.competitivenessChartRows();
+
+    if (!rows.length) {
+      return {
+        animation: false,
+        xAxis: { type: 'category', data: [] },
+        yAxis: { type: 'value' },
+        series: [],
+      };
+    }
+
+    return {
+      animation: false,
+      backgroundColor: 'transparent',
+      grid: {
+        left: 44,
+        right: 18,
+        top: 42,
+        bottom: rows.length > 35 ? 54 : 30,
+        containLabel: true,
+      },
+      legend: {
+        top: 6,
+        right: 10,
+        itemWidth: 12,
+        itemHeight: 8,
+        textStyle: {
+          color: '#d7deeb',
+          fontSize: 12,
+          fontWeight: 700,
+        },
+      },
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'line' },
+        backgroundColor: 'rgba(7, 10, 19, 0.94)',
+        borderColor: 'rgba(148, 163, 184, 0.28)',
+        textStyle: {
+          color: '#d7deeb',
+        },
+      },
+      xAxis: {
+        type: 'category',
+        data: rows.map((row) => String(row.season)),
+        axisLabel: {
+          color: '#c5d0e4',
+          fontSize: 11,
+          hideOverlap: true,
+        },
+        axisLine: {
+          lineStyle: { color: 'rgba(148, 163, 184, 0.45)' },
+        },
+        axisTick: { show: false },
+      },
+      yAxis: {
+        type: 'value',
+        minInterval: 1,
+        axisLabel: {
+          color: '#c5d0e4',
+          fontSize: 11,
+        },
+        axisLine: { show: false },
+        splitLine: {
+          lineStyle: { color: 'rgba(148, 163, 184, 0.18)' },
+        },
+      },
+      dataZoom:
+        rows.length > 35
+          ? [
+              {
+                type: 'slider',
+                xAxisIndex: 0,
+                height: 18,
+                bottom: 18,
+                filterMode: 'none',
+                backgroundColor: 'rgba(15, 23, 42, 0.75)',
+                fillerColor: 'rgba(217, 119, 6, 0.22)',
+                borderColor: 'rgba(148, 163, 184, 0.42)',
+                handleStyle: {
+                  color: '#d97706',
+                  borderColor: '#f59e0b',
+                },
+                textStyle: {
+                  color: '#d7deeb',
+                  fontSize: 10,
+                },
+              },
+            ]
+          : [],
+      series: [
+        {
+          name: 'Title gap',
+          type: 'line',
+          data: rows.map((row) => row.titleGap),
+          showSymbol: false,
+          smooth: true,
+          lineStyle: {
+            width: 2.4,
+            color: '#f59e0b',
+          },
+          itemStyle: {
+            color: '#f59e0b',
+          },
+          emphasis: {
+            focus: 'series',
+          },
+        },
+        {
+          name: 'Champion to middle',
+          type: 'line',
+          data: rows.map((row) => row.midTableGap),
+          showSymbol: false,
+          smooth: true,
+          lineStyle: {
+            width: 2.1,
+            color: '#38bdf8',
+          },
+          itemStyle: {
+            color: '#38bdf8',
+          },
+          emphasis: {
+            focus: 'series',
+          },
+        },
+        {
+          name: 'Champion to last',
+          type: 'line',
+          data: rows.map((row) => row.fullTableSpread),
+          showSymbol: false,
+          smooth: true,
+          lineStyle: {
+            width: 2,
+            color: '#16a34a',
+          },
+          itemStyle: {
+            color: '#16a34a',
+          },
+          emphasis: {
+            focus: 'series',
+          },
+        },
+      ],
+    };
+  });
 
   retryArchiveLoad() {
     void this.dataLoader.loadData();

--- a/src/app/pages/rivalry-comparison/rivalry-comparison.html
+++ b/src/app/pages/rivalry-comparison/rivalry-comparison.html
@@ -10,24 +10,49 @@
   @if (teams().length < 2) {
   <div class="empty-state app-panel">At least two clubs are needed for a rivalry comparison.</div>
   } @else {
-  <section class="selector-panel app-panel" aria-label="Club selectors">
-    <label>
-      <span>First club</span>
-      <select [value]="firstTeamId()" (change)="onFirstTeamChange($any($event.target).value)">
-        @for (team of teams(); track team.id) {
-        <option [value]="team.id">{{ team.name }}</option>
+  <section class="comparison-controls app-panel" aria-label="Rivalry controls">
+    @if (availablePresets().length) {
+    <div class="preset-panel" aria-label="Known rivalry presets">
+      <div class="panel-head panel-head--compact">
+        <h2>Known Rivalries</h2>
+        <span>{{ availablePresets().length }} presets</span>
+      </div>
+      <div class="preset-grid">
+        @for (preset of availablePresets(); track preset.id) {
+        <button
+          type="button"
+          class="preset-card"
+          [class.is-active]="activePresetId() === preset.id"
+          (click)="applyPreset(preset.id)"
+        >
+          <span>{{ preset.region }}</span>
+          <strong>{{ preset.label }}</strong>
+          <small>{{ preset.teamNames[0] }} / {{ preset.teamNames[1] }}</small>
+        </button>
         }
-      </select>
-    </label>
+      </div>
+    </div>
+    }
 
-    <label>
-      <span>Second club</span>
-      <select [value]="secondTeamId()" (change)="onSecondTeamChange($any($event.target).value)">
-        @for (team of teams(); track team.id) {
-        <option [value]="team.id">{{ team.name }}</option>
-        }
-      </select>
-    </label>
+    <div class="selector-panel" aria-label="Club selectors">
+      <label>
+        <span>First club</span>
+        <select [ngModel]="firstTeamId()" (ngModelChange)="onFirstTeamChange($event)">
+          @for (team of teams(); track team.id) {
+          <option [ngValue]="team.id">{{ team.name }}</option>
+          }
+        </select>
+      </label>
+
+      <label>
+        <span>Second club</span>
+        <select [ngModel]="secondTeamId()" (ngModelChange)="onSecondTeamChange($event)">
+          @for (team of teams(); track team.id) {
+          <option [ngValue]="team.id">{{ team.name }}</option>
+          }
+        </select>
+      </label>
+    </div>
   </section>
 
   @if (selectedTeams().first && selectedTeams().second) {
@@ -48,6 +73,54 @@
       <span>Same Tier</span>
       <strong>{{ scorecard().sameTier }}</strong>
     </div>
+  </section>
+
+  <section class="chart-grid" aria-label="Rivalry visualizations">
+    <section class="rivalry-panel app-panel">
+      <div class="panel-head">
+        <h2>Relative Standing</h2>
+        <span>higher / lower</span>
+      </div>
+      <div
+        echarts
+        class="rivalry-chart"
+        [options]="relativeStandingChartOptions()"
+        [autoResize]="true"
+        aria-label="Relative standing by shared season"
+      ></div>
+    </section>
+
+    <section class="rivalry-panel app-panel">
+      <div class="panel-head">
+        <h2>Same-Tier Points Gap</h2>
+        <span>{{ sameTierChartRows().length }} seasons</span>
+      </div>
+      @if (sameTierChartRows().length) {
+      <div
+        echarts
+        class="rivalry-chart"
+        [options]="pointsGapChartOptions()"
+        [autoResize]="true"
+        aria-label="Same-tier points gap by season"
+      ></div>
+      } @else {
+      <div class="empty-state">No same-tier shared seasons for this pair.</div>
+      }
+    </section>
+
+    <section class="rivalry-panel app-panel chart-grid-wide">
+      <div class="panel-head">
+        <h2>Tier Paths</h2>
+        <span>shared seasons</span>
+      </div>
+      <div
+        echarts
+        class="rivalry-chart"
+        [options]="tierPathChartOptions()"
+        [autoResize]="true"
+        aria-label="Tier path comparison by shared season"
+      ></div>
+    </section>
   </section>
 
   <div class="rivalry-grid">
@@ -102,27 +175,6 @@
       } @else {
       <div class="empty-state">No shared seasons found for this pair.</div>
       }
-    </section>
-
-    <section class="rivalry-panel app-panel">
-      <div class="panel-head">
-        <h2>Visualization Slots</h2>
-        <span>next pass</span>
-      </div>
-      <div class="slot-list">
-        <div>
-          <strong>Points Gap</strong>
-          <span>Shared-season points delta for same-tier seasons.</span>
-        </div>
-        <div>
-          <strong>Position Gap</strong>
-          <span>Relative finish by season, using tier as the first ordering.</span>
-        </div>
-        <div>
-          <strong>Tier Paths</strong>
-          <span>Side-by-side pyramid movement for the selected pair.</span>
-        </div>
-      </div>
     </section>
   </div>
   } }

--- a/src/app/pages/rivalry-comparison/rivalry-comparison.html
+++ b/src/app/pages/rivalry-comparison/rivalry-comparison.html
@@ -1,0 +1,129 @@
+<section class="rivalry-page app-surface app-page-shell">
+  <header class="app-page-header">
+    <p class="app-page-eyebrow">Rivalry Comparison</p>
+    <h1 class="app-page-title">Club Comparison Workbench</h1>
+    <p class="app-page-lede">
+      Compare shared seasons, table position, and tier standing for two selected clubs.
+    </p>
+  </header>
+
+  @if (teams().length < 2) {
+  <div class="empty-state app-panel">At least two clubs are needed for a rivalry comparison.</div>
+  } @else {
+  <section class="selector-panel app-panel" aria-label="Club selectors">
+    <label>
+      <span>First club</span>
+      <select [value]="firstTeamId()" (change)="onFirstTeamChange($any($event.target).value)">
+        @for (team of teams(); track team.id) {
+        <option [value]="team.id">{{ team.name }}</option>
+        }
+      </select>
+    </label>
+
+    <label>
+      <span>Second club</span>
+      <select [value]="secondTeamId()" (change)="onSecondTeamChange($any($event.target).value)">
+        @for (team of teams(); track team.id) {
+        <option [value]="team.id">{{ team.name }}</option>
+        }
+      </select>
+    </label>
+  </section>
+
+  @if (selectedTeams().first && selectedTeams().second) {
+  <section class="score-grid" aria-label="Rivalry scorecard">
+    <div class="score-cell">
+      <span>Shared Seasons</span>
+      <strong>{{ scorecard().sharedSeasons }}</strong>
+    </div>
+    <div class="score-cell">
+      <span>{{ selectedTeams().first!.name }} Higher</span>
+      <strong>{{ scorecard().firstHigher }}</strong>
+    </div>
+    <div class="score-cell">
+      <span>{{ selectedTeams().second!.name }} Higher</span>
+      <strong>{{ scorecard().secondHigher }}</strong>
+    </div>
+    <div class="score-cell">
+      <span>Same Tier</span>
+      <strong>{{ scorecard().sameTier }}</strong>
+    </div>
+  </section>
+
+  <div class="rivalry-grid">
+    <section class="rivalry-panel app-panel">
+      <div class="panel-head">
+        <h2>Shared Season Rows</h2>
+        <span>{{ comparisonRows().length }} seasons</span>
+      </div>
+      @if (recentRows().length) {
+      <div class="comparison-table" role="table" aria-label="Shared season comparison">
+        <div class="comparison-row comparison-head" role="row">
+          <span role="columnheader">Season</span>
+          <span role="columnheader">{{ selectedTeams().first!.name }}</span>
+          <span role="columnheader">{{ selectedTeams().second!.name }}</span>
+          <span role="columnheader">Leader</span>
+        </div>
+        @for (row of recentRows(); track row.season) {
+        <div class="comparison-row" role="row">
+          <span role="cell">
+            <a class="table-link" [routerLink]="['/tables']" [queryParams]="{ season: row.season }">
+              {{ row.season }}
+            </a>
+          </span>
+          <span role="cell">
+            @if (row.first.clubId) {
+            <a class="app-club-link" [routerLink]="['/teams', row.first.clubId]">
+              {{ row.first.teamName }}
+            </a>
+            } @else { {{ row.first.teamName }} }
+            <small>
+              {{ row.first.tierLabel }} / {{ ordinal(row.first.position) }} / {{ row.first.points }}
+              pts
+            </small>
+          </span>
+          <span role="cell">
+            @if (row.second.clubId) {
+            <a class="app-club-link" [routerLink]="['/teams', row.second.clubId]">
+              {{ row.second.teamName }}
+            </a>
+            } @else { {{ row.second.teamName }} }
+            <small>
+              {{ row.second.tierLabel }} / {{ ordinal(row.second.position) }} / {{ row.second.points
+              }} pts
+            </small>
+          </span>
+          <span role="cell">
+            <strong [class.is-level]="row.leader === 'level'">{{ row.leaderLabel }}</strong>
+          </span>
+        </div>
+        }
+      </div>
+      } @else {
+      <div class="empty-state">No shared seasons found for this pair.</div>
+      }
+    </section>
+
+    <section class="rivalry-panel app-panel">
+      <div class="panel-head">
+        <h2>Visualization Slots</h2>
+        <span>next pass</span>
+      </div>
+      <div class="slot-list">
+        <div>
+          <strong>Points Gap</strong>
+          <span>Shared-season points delta for same-tier seasons.</span>
+        </div>
+        <div>
+          <strong>Position Gap</strong>
+          <span>Relative finish by season, using tier as the first ordering.</span>
+        </div>
+        <div>
+          <strong>Tier Paths</strong>
+          <span>Side-by-side pyramid movement for the selected pair.</span>
+        </div>
+      </div>
+    </section>
+  </div>
+  } }
+</section>

--- a/src/app/pages/rivalry-comparison/rivalry-comparison.scss
+++ b/src/app/pages/rivalry-comparison/rivalry-comparison.scss
@@ -1,0 +1,194 @@
+:host {
+  display: block;
+}
+
+.rivalry-page {
+  display: grid;
+  gap: 20px;
+}
+
+.selector-panel,
+.score-grid,
+.rivalry-grid,
+.comparison-table,
+.slot-list {
+  display: grid;
+  gap: 12px;
+}
+
+.selector-panel {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.selector-panel label {
+  display: grid;
+  gap: 6px;
+}
+
+.selector-panel span,
+.score-cell span,
+.panel-head span {
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.selector-panel select {
+  min-height: 42px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 7px;
+  padding: 8px 10px;
+  background: rgba(7, 10, 19, 0.42);
+  color: var(--app-text-strong);
+  font: inherit;
+}
+
+.selector-panel select:focus-visible {
+  outline: 2px solid var(--app-focus-ring);
+  outline-offset: 2px;
+}
+
+.score-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.score-cell,
+.rivalry-panel {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(148, 163, 184, 0.06), transparent 90px),
+    color-mix(in srgb, var(--app-surface-bg) 86%, transparent);
+}
+
+.score-cell {
+  min-height: 72px;
+  display: grid;
+  align-content: center;
+  gap: 4px;
+  padding: 11px 12px;
+}
+
+.score-cell strong {
+  color: var(--app-text-strong);
+  font-size: 1.2rem;
+}
+
+.rivalry-grid {
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.55fr);
+}
+
+.rivalry-panel {
+  padding: 16px;
+}
+
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 14px;
+  padding: 0 0 11px 6px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.26);
+}
+
+.panel-head h2 {
+  margin: 0;
+  color: var(--app-text-strong);
+  font-size: 1.02rem;
+}
+
+.comparison-row {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr) minmax(0, 1fr) minmax(124px, 0.55fr);
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 7px;
+  padding: 8px 10px;
+  background: rgba(7, 10, 19, 0.2);
+  color: var(--app-text-subtle);
+}
+
+.comparison-row > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.comparison-head {
+  min-height: 34px;
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(7, 10, 19, 0.38);
+}
+
+.comparison-row small,
+.slot-list span {
+  display: block;
+  margin-top: 3px;
+  color: var(--app-text-muted);
+}
+
+.comparison-row strong {
+  color: var(--app-text-strong);
+}
+
+.comparison-row strong.is-level {
+  color: var(--app-text-muted);
+}
+
+.table-link,
+.slot-list a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.table-link:hover,
+.table-link:focus-visible {
+  color: #fde68a;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.slot-list div,
+.empty-state {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 7px;
+  padding: 10px 11px;
+  background: rgba(7, 10, 19, 0.2);
+  color: var(--app-text-subtle);
+}
+
+.slot-list strong {
+  color: var(--app-text-strong);
+}
+
+@media (max-width: 980px) {
+  .selector-panel,
+  .score-grid,
+  .rivalry-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .comparison-head {
+    display: none;
+  }
+
+  .comparison-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/pages/rivalry-comparison/rivalry-comparison.scss
+++ b/src/app/pages/rivalry-comparison/rivalry-comparison.scss
@@ -7,17 +7,82 @@
   gap: 20px;
 }
 
+.comparison-controls,
 .selector-panel,
 .score-grid,
 .rivalry-grid,
+.chart-grid,
 .comparison-table,
-.slot-list {
+.preset-grid {
   display: grid;
   gap: 12px;
 }
 
+.comparison-controls {
+  gap: 16px;
+  padding: 16px;
+}
+
 .selector-panel {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.preset-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.preset-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.preset-card {
+  min-height: 84px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 7px;
+  padding: 10px 12px;
+  background: rgba(7, 10, 19, 0.2);
+  color: var(--app-text-subtle);
+  cursor: pointer;
+  display: grid;
+  align-content: start;
+  gap: 4px;
+  text-align: left;
+}
+
+.preset-card span {
+  color: var(--app-text-muted);
+  font-size: 0.7rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.preset-card strong {
+  color: var(--app-text-strong);
+  font-size: 0.94rem;
+  line-height: 1.25;
+}
+
+.preset-card small {
+  color: var(--app-text-muted);
+  line-height: 1.3;
+}
+
+.preset-card:hover,
+.preset-card:focus-visible,
+.preset-card.is-active {
+  border-color: rgba(245, 158, 11, 0.5);
+  background: rgba(245, 158, 11, 0.12);
+}
+
+.preset-card:focus-visible {
+  outline: 2px solid var(--app-focus-ring);
+  outline-offset: 2px;
 }
 
 .selector-panel label {
@@ -52,7 +117,20 @@
 
 .score-grid {
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 10px;
+  gap: 14px;
+}
+
+.chart-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.chart-grid-wide {
+  grid-column: 1 / -1;
+}
+
+.rivalry-chart {
+  min-height: 270px;
 }
 
 .score-cell,
@@ -67,11 +145,11 @@
 }
 
 .score-cell {
-  min-height: 72px;
+  min-height: 74px;
   display: grid;
   align-content: center;
-  gap: 4px;
-  padding: 11px 12px;
+  gap: 5px;
+  padding: 12px 14px;
 }
 
 .score-cell strong {
@@ -80,11 +158,11 @@
 }
 
 .rivalry-grid {
-  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.55fr);
+  grid-template-columns: 1fr;
 }
 
 .rivalry-panel {
-  padding: 16px;
+  padding: 17px 18px 18px;
 }
 
 .panel-head {
@@ -93,8 +171,13 @@
   justify-content: space-between;
   gap: 14px;
   margin-bottom: 14px;
-  padding: 0 0 11px 6px;
+  padding: 0 0 11px;
   border-bottom: 1px solid rgba(148, 163, 184, 0.26);
+}
+
+.panel-head--compact {
+  margin-bottom: 0;
+  padding-bottom: 10px;
 }
 
 .panel-head h2 {
@@ -107,11 +190,11 @@
   display: grid;
   grid-template-columns: 76px minmax(0, 1fr) minmax(0, 1fr) minmax(124px, 0.55fr);
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   min-height: 44px;
   border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 7px;
-  padding: 8px 10px;
+  padding: 10px 12px;
   background: rgba(7, 10, 19, 0.2);
   color: var(--app-text-subtle);
 }
@@ -131,11 +214,11 @@
   background: rgba(7, 10, 19, 0.38);
 }
 
-.comparison-row small,
-.slot-list span {
+.comparison-row small {
   display: block;
-  margin-top: 3px;
+  margin-top: 4px;
   color: var(--app-text-muted);
+  line-height: 1.3;
 }
 
 .comparison-row strong {
@@ -146,8 +229,7 @@
   color: var(--app-text-muted);
 }
 
-.table-link,
-.slot-list a {
+.table-link {
   color: inherit;
   text-decoration: none;
 }
@@ -159,7 +241,6 @@
   text-underline-offset: 3px;
 }
 
-.slot-list div,
 .empty-state {
   border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 7px;
@@ -168,20 +249,35 @@
   color: var(--app-text-subtle);
 }
 
-.slot-list strong {
-  color: var(--app-text-strong);
+@media (max-width: 980px) {
+  .score-grid,
+  .rivalry-grid,
+  .chart-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .preset-grid,
+  .score-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
-@media (max-width: 980px) {
+@media (max-width: 700px) {
+  .comparison-controls,
+  .rivalry-panel {
+    padding: 14px;
+  }
+
   .selector-panel,
-  .score-grid,
-  .rivalry-grid {
+  .preset-grid,
+  .score-grid {
     grid-template-columns: 1fr;
   }
 
   .panel-head {
     align-items: flex-start;
     flex-direction: column;
+    gap: 6px;
   }
 
   .comparison-head {
@@ -190,5 +286,9 @@
 
   .comparison-row {
     grid-template-columns: 1fr;
+  }
+
+  .rivalry-chart {
+    min-height: 240px;
   }
 }

--- a/src/app/pages/rivalry-comparison/rivalry-comparison.spec.ts
+++ b/src/app/pages/rivalry-comparison/rivalry-comparison.spec.ts
@@ -1,0 +1,89 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { LeagueStore } from '@app/store/league.store';
+import { RivalryComparison } from './rivalry-comparison';
+
+describe('RivalryComparison', () => {
+  let component: RivalryComparison;
+  let fixture: ComponentFixture<RivalryComparison>;
+  let store: InstanceType<typeof LeagueStore>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RivalryComparison],
+      providers: [LeagueStore, provideRouter([])],
+    }).compileComponents();
+
+    store = TestBed.inject(LeagueStore);
+    store.hydrate(rivalryFixture(), (teamName: string) => `${teamName.toLowerCase()} id`);
+    fixture = TestBed.createComponent(RivalryComparison);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('renders the rivalry workbench with shared season rows', () => {
+    const element: HTMLElement = fixture.nativeElement;
+
+    expect(element.textContent).toContain('Rivalry Comparison');
+    expect(element.textContent).toContain('Shared Season Rows');
+    expect(component.scorecard()).toMatchObject({
+      sharedSeasons: 3,
+      firstHigher: 1,
+      secondHigher: 2,
+      sameTier: 2,
+    });
+
+    const tableLink = Array.from(element.querySelectorAll<HTMLAnchorElement>('a')).find((link) =>
+      link.textContent?.includes('2022')
+    );
+    expect(tableLink?.getAttribute('href')).toContain('/tables?season=2022');
+  });
+
+  it('switches selected clubs from the selector handlers', () => {
+    const charlie = store.getTeams().find((team) => team.name === 'Charlie City')!;
+
+    component.onSecondTeamChange(String(charlie.id));
+
+    expect(component.selectedTeams().second?.name).toBe('Charlie City');
+    expect(component.comparisonRows().map((row) => row.season)).toEqual([2021]);
+  });
+});
+
+function rivalryFixture() {
+  return {
+    seasons: {
+      2020: {
+        tier1: [row('Alpha FC', 1, 82), row('Bravo Town', 2, 80)],
+      },
+      2021: {
+        tier1: [row('Bravo Town', 3, 66), row('Charlie City', 4, 61)],
+        tier2: [row('Alpha FC', 1, 91)],
+      },
+      2022: {
+        tier1: [row('Bravo Town', 1, 88), row('Alpha FC', 2, 84)],
+      },
+    },
+  };
+}
+
+function row(team: string, pos: number, points: number) {
+  return {
+    team,
+    pos,
+    played: 38,
+    won: 20,
+    drawn: 8,
+    lost: 10,
+    goalsFor: 70,
+    goalsAgainst: 35,
+    goalDifference: 35,
+    goalAverage: null,
+    points,
+    notes: null,
+    wasRelegated: false,
+    wasPromoted: false,
+    isExpansionTeam: false,
+    wasReElected: false,
+    wasReprieved: false,
+  };
+}

--- a/src/app/pages/rivalry-comparison/rivalry-comparison.spec.ts
+++ b/src/app/pages/rivalry-comparison/rivalry-comparison.spec.ts
@@ -3,6 +3,28 @@ import { provideRouter } from '@angular/router';
 import { LeagueStore } from '@app/store/league.store';
 import { RivalryComparison } from './rivalry-comparison';
 
+jest.mock('echarts/charts', () => ({ LineChart: {} }));
+jest.mock('echarts/components', () => ({
+  DataZoomComponent: {},
+  GridComponent: {},
+  LegendComponent: {},
+  TooltipComponent: {},
+}));
+jest.mock('echarts/core', () => ({ use: jest.fn() }));
+jest.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+jest.mock('ngx-echarts', () => {
+  const core = jest.requireActual('@angular/core');
+  class MockNgxEchartsDirective {}
+  core.Directive({ selector: '[echarts]' })(MockNgxEchartsDirective);
+  core.Input()(MockNgxEchartsDirective.prototype, 'options');
+  core.Input()(MockNgxEchartsDirective.prototype, 'autoResize');
+
+  return {
+    NgxEchartsDirective: MockNgxEchartsDirective,
+    provideEchartsCore: () => [],
+  };
+});
+
 describe('RivalryComparison', () => {
   let component: RivalryComparison;
   let fixture: ComponentFixture<RivalryComparison>;
@@ -25,6 +47,12 @@ describe('RivalryComparison', () => {
     const element: HTMLElement = fixture.nativeElement;
 
     expect(element.textContent).toContain('Rivalry Comparison');
+    expect(element.textContent).toContain('Known Rivalries');
+    expect(component.availablePresets().map((preset) => preset.id)).toContain('north-london');
+    expect(component.activePresetId()).toBe('north-london');
+    const selects = element.querySelectorAll<HTMLSelectElement>('select');
+    expect(selects[0].selectedOptions[0]?.textContent?.trim()).toBe('Arsenal');
+    expect(selects[1].selectedOptions[0]?.textContent?.trim()).toBe('Tottenham Hotspur');
     expect(element.textContent).toContain('Shared Season Rows');
     expect(component.scorecard()).toMatchObject({
       sharedSeasons: 3,
@@ -37,6 +65,51 @@ describe('RivalryComparison', () => {
       link.textContent?.includes('2022')
     );
     expect(tableLink?.getAttribute('href')).toContain('/tables?season=2022');
+    expect(element.querySelector('.rivalry-chart')?.getAttribute('aria-label')).toBe(
+      'Relative standing by shared season'
+    );
+  });
+
+  it('builds relative standing, same-tier points gap, and tier path charts', () => {
+    expect(component.chartRows().map((row) => row.season)).toEqual([2020, 2021, 2022]);
+    expect(component.relativeStandingChartOptions()).toMatchObject({
+      xAxis: {
+        data: ['2020', '2021', '2022'],
+      },
+      series: [
+        {
+          name: 'Relative standing',
+          type: 'line',
+          data: [1, -98, -1],
+        },
+      ],
+    });
+    expect(component.pointsGapChartOptions()).toMatchObject({
+      xAxis: {
+        data: ['2020', '2022'],
+      },
+      series: [
+        {
+          name: 'Points gap',
+          type: 'line',
+          data: [2, -4],
+        },
+      ],
+    });
+    expect(component.tierPathChartOptions()).toMatchObject({
+      series: [
+        {
+          name: 'Arsenal',
+          type: 'line',
+          data: [1, 2, 1],
+        },
+        {
+          name: 'Tottenham Hotspur',
+          type: 'line',
+          data: [1, 1, 1],
+        },
+      ],
+    });
   });
 
   it('switches selected clubs from the selector handlers', () => {
@@ -53,14 +126,14 @@ function rivalryFixture() {
   return {
     seasons: {
       2020: {
-        tier1: [row('Alpha FC', 1, 82), row('Bravo Town', 2, 80)],
+        tier1: [row('Arsenal', 1, 82), row('Tottenham Hotspur', 2, 80)],
       },
       2021: {
-        tier1: [row('Bravo Town', 3, 66), row('Charlie City', 4, 61)],
-        tier2: [row('Alpha FC', 1, 91)],
+        tier1: [row('Tottenham Hotspur', 3, 66), row('Charlie City', 4, 61)],
+        tier2: [row('Arsenal', 1, 91)],
       },
       2022: {
-        tier1: [row('Bravo Town', 1, 88), row('Alpha FC', 2, 84)],
+        tier1: [row('Tottenham Hotspur', 1, 88), row('Arsenal', 2, 84)],
       },
     },
   };

--- a/src/app/pages/rivalry-comparison/rivalry-comparison.ts
+++ b/src/app/pages/rivalry-comparison/rivalry-comparison.ts
@@ -1,0 +1,214 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, effect, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import type { LeagueTableEntry, Team } from '@app/store/league.models';
+import { LeagueStore } from '@app/store/league.store';
+import { buildClubIdentityTeamIndex } from '@app/utils/club-aliases';
+
+interface RivalrySeasonRow {
+  season: number;
+  first: RivalryEntryView;
+  second: RivalryEntryView;
+  leader: 'first' | 'second' | 'level';
+  leaderLabel: string;
+}
+
+interface RivalryEntryView {
+  teamName: string;
+  clubId: string | null;
+  tier: string;
+  tierLabel: string;
+  position: number;
+  points: number;
+}
+
+interface RivalryScorecard {
+  sharedSeasons: number;
+  firstHigher: number;
+  secondHigher: number;
+  level: number;
+  sameTier: number;
+}
+
+@Component({
+  selector: 'app-rivalry-comparison',
+  imports: [CommonModule, RouterLink],
+  templateUrl: './rivalry-comparison.html',
+  styleUrl: './rivalry-comparison.scss',
+})
+export class RivalryComparison {
+  private store = inject(LeagueStore);
+
+  firstTeamId = signal<number | null>(null);
+  secondTeamId = signal<number | null>(null);
+
+  teams = computed(() =>
+    this.store
+      .getTeams()
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+  );
+  selectedTeams = computed(() => {
+    const first = this.teamById(this.firstTeamId());
+    const second = this.teamById(this.secondTeamId());
+    return {
+      first,
+      second,
+    };
+  });
+  comparisonRows = computed<RivalrySeasonRow[]>(() => {
+    const firstTeamId = this.firstTeamId();
+    const secondTeamId = this.secondTeamId();
+    const teams = this.teams();
+
+    if (!firstTeamId || !secondTeamId || firstTeamId === secondTeamId) {
+      return [];
+    }
+
+    const selectedIdByTeamId = buildClubIdentityTeamIndex([firstTeamId, secondTeamId], teams);
+    const entriesBySelectedTeam = new Map<number, Map<number, LeagueTableEntry>>();
+
+    this.store.getFullTable().forEach((entry) => {
+      const selectedTeamId = selectedIdByTeamId.get(entry.teamId);
+      if (!selectedTeamId) {
+        return;
+      }
+
+      const entriesBySeason = entriesBySelectedTeam.get(selectedTeamId) ?? new Map();
+      const existing = entriesBySeason.get(entry.season);
+      if (!existing || this.compareEntryStanding(entry, existing) < 0) {
+        entriesBySeason.set(entry.season, entry);
+      }
+      entriesBySelectedTeam.set(selectedTeamId, entriesBySeason);
+    });
+
+    const firstEntries = entriesBySelectedTeam.get(firstTeamId) ?? new Map();
+    const secondEntries = entriesBySelectedTeam.get(secondTeamId) ?? new Map();
+
+    return Array.from(firstEntries.keys())
+      .filter((season) => secondEntries.has(season))
+      .sort((a, b) => b - a)
+      .map((season) => {
+        const first = this.entryView(firstEntries.get(season)!);
+        const second = this.entryView(secondEntries.get(season)!);
+        const comparison = this.compareEntryStanding(
+          firstEntries.get(season)!,
+          secondEntries.get(season)!
+        );
+        const leader = comparison < 0 ? 'first' : comparison > 0 ? 'second' : 'level';
+
+        return {
+          season,
+          first,
+          second,
+          leader,
+          leaderLabel:
+            leader === 'first'
+              ? `${first.teamName} higher`
+              : leader === 'second'
+                ? `${second.teamName} higher`
+                : 'Level',
+        };
+      });
+  });
+  scorecard = computed<RivalryScorecard>(() => {
+    const rows = this.comparisonRows();
+    return {
+      sharedSeasons: rows.length,
+      firstHigher: rows.filter((row) => row.leader === 'first').length,
+      secondHigher: rows.filter((row) => row.leader === 'second').length,
+      level: rows.filter((row) => row.leader === 'level').length,
+      sameTier: rows.filter((row) => row.first.tier === row.second.tier).length,
+    };
+  });
+  recentRows = computed(() => this.comparisonRows().slice(0, 16));
+
+  constructor() {
+    effect(() => {
+      const teams = this.teams();
+      if (teams.length < 2 || (this.firstTeamId() && this.secondTeamId())) {
+        return;
+      }
+
+      const first = teams.find((team) => team.name === 'Arsenal') ?? teams[0];
+      const second =
+        teams.find((team) => team.name === 'Tottenham Hotspur' && team.id !== first.id) ??
+        teams.find((team) => team.id !== first.id);
+
+      this.firstTeamId.set(first.id);
+      this.secondTeamId.set(second?.id ?? null);
+    });
+  }
+
+  onFirstTeamChange(value: string) {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed)) {
+      return;
+    }
+
+    this.firstTeamId.set(parsed);
+    if (this.secondTeamId() === parsed) {
+      this.secondTeamId.set(this.teams().find((team) => team.id !== parsed)?.id ?? null);
+    }
+  }
+
+  onSecondTeamChange(value: string) {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed)) {
+      return;
+    }
+
+    this.secondTeamId.set(parsed);
+    if (this.firstTeamId() === parsed) {
+      this.firstTeamId.set(this.teams().find((team) => team.id !== parsed)?.id ?? null);
+    }
+  }
+
+  tierLabel(tier: string): string {
+    const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+    return Number.isFinite(parsed) ? `Tier ${parsed}` : tier;
+  }
+
+  ordinal(value: number): string {
+    const mod100 = value % 100;
+    if (mod100 >= 11 && mod100 <= 13) {
+      return `${value}th`;
+    }
+
+    const suffixByMod10: Record<number, string> = {
+      1: 'st',
+      2: 'nd',
+      3: 'rd',
+    };
+    return `${value}${suffixByMod10[value % 10] ?? 'th'}`;
+  }
+
+  private teamById(teamId: number | null): Team | null {
+    return teamId ? (this.store.getTeamById(teamId) ?? null) : null;
+  }
+
+  private entryView(entry: LeagueTableEntry): RivalryEntryView {
+    return {
+      teamName: this.store.getTeamNameById(entry.teamId),
+      clubId: entry.clubId,
+      tier: entry.tier,
+      tierLabel: this.tierLabel(entry.tier),
+      position: entry.pos,
+      points: entry.points,
+    };
+  }
+
+  private compareEntryStanding(first: LeagueTableEntry, second: LeagueTableEntry): number {
+    const tierDifference = this.tierRank(first.tier) - this.tierRank(second.tier);
+    if (tierDifference !== 0) {
+      return tierDifference;
+    }
+
+    return first.pos - second.pos;
+  }
+
+  private tierRank(tier: string): number {
+    const parsed = Number.parseInt(tier.replace('tier', ''), 10);
+    return Number.isFinite(parsed) ? parsed : 99;
+  }
+}

--- a/src/app/pages/rivalry-comparison/rivalry-comparison.ts
+++ b/src/app/pages/rivalry-comparison/rivalry-comparison.ts
@@ -1,9 +1,29 @@
 import { CommonModule } from '@angular/common';
 import { Component, computed, effect, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
+import { LineChart } from 'echarts/charts';
+import {
+  DataZoomComponent,
+  GridComponent,
+  LegendComponent,
+  TooltipComponent,
+} from 'echarts/components';
+import type { EChartsCoreOption } from 'echarts/core';
+import * as echarts from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { NgxEchartsDirective, provideEchartsCore } from 'ngx-echarts';
 import type { LeagueTableEntry, Team } from '@app/store/league.models';
 import { LeagueStore } from '@app/store/league.store';
 import { buildClubIdentityTeamIndex } from '@app/utils/club-aliases';
+
+interface RivalryPreset {
+  id: string;
+  label: string;
+  region: string;
+  description: string;
+  teamNames: readonly [string, string];
+}
 
 interface RivalrySeasonRow {
   season: number;
@@ -11,6 +31,8 @@ interface RivalrySeasonRow {
   second: RivalryEntryView;
   leader: 'first' | 'second' | 'level';
   leaderLabel: string;
+  relativeStanding: number;
+  pointsGap: number | null;
 }
 
 interface RivalryEntryView {
@@ -28,19 +50,92 @@ interface RivalryScorecard {
   secondHigher: number;
   level: number;
   sameTier: number;
+  firstMorePoints: number;
+  secondMorePoints: number;
 }
+
+const RIVALRY_PRESETS: RivalryPreset[] = [
+  {
+    id: 'north-london',
+    label: 'North London',
+    region: 'London',
+    description: 'Arsenal and Tottenham across shared league seasons.',
+    teamNames: ['Arsenal', 'Tottenham Hotspur'],
+  },
+  {
+    id: 'manchester',
+    label: 'Manchester',
+    region: 'North West',
+    description: 'United and City from long archive history into the modern era.',
+    teamNames: ['Manchester United', 'Manchester City'],
+  },
+  {
+    id: 'merseyside',
+    label: 'Merseyside',
+    region: 'North West',
+    description: 'Liverpool and Everton in one of the longest-running top-flight pairings.',
+    teamNames: ['Liverpool', 'Everton'],
+  },
+  {
+    id: 'tyne-wear',
+    label: 'Tyne-Wear',
+    region: 'North East',
+    description: 'Newcastle and Sunderland across promotion, relegation, and top-tier spells.',
+    teamNames: ['Newcastle United', 'Sunderland'],
+  },
+  {
+    id: 'second-city',
+    label: 'Second City',
+    region: 'Midlands',
+    description: 'Aston Villa and Birmingham across shared league records.',
+    teamNames: ['Aston Villa', 'Birmingham'],
+  },
+  {
+    id: 'east-midlands',
+    label: 'East Midlands',
+    region: 'Midlands',
+    description: 'Derby and Forest as a focused two-club comparison.',
+    teamNames: ['Derby County', 'Nottingham Forest'],
+  },
+  {
+    id: 'steel-city',
+    label: 'Steel City',
+    region: 'Yorkshire',
+    description: 'Sheffield United and Wednesday through shared archive seasons.',
+    teamNames: ['Sheffield United', 'Sheffield Wednesday'],
+  },
+  {
+    id: 'west-london',
+    label: 'West London',
+    region: 'London',
+    description: 'Chelsea and Fulham as a first West London comparison preset.',
+    teamNames: ['Chelsea', 'Fulham'],
+  },
+];
+
+echarts.use([
+  LineChart,
+  GridComponent,
+  TooltipComponent,
+  LegendComponent,
+  DataZoomComponent,
+  CanvasRenderer,
+]);
 
 @Component({
   selector: 'app-rivalry-comparison',
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, FormsModule, RouterLink, NgxEchartsDirective],
+  providers: [provideEchartsCore({ echarts })],
   templateUrl: './rivalry-comparison.html',
   styleUrl: './rivalry-comparison.scss',
 })
 export class RivalryComparison {
   private store = inject(LeagueStore);
 
+  readonly rivalryPresets = RIVALRY_PRESETS;
   firstTeamId = signal<number | null>(null);
   secondTeamId = signal<number | null>(null);
+  activePresetId = signal<string>('');
 
   teams = computed(() =>
     this.store
@@ -56,6 +151,16 @@ export class RivalryComparison {
       second,
     };
   });
+  availablePresets = computed(() =>
+    this.rivalryPresets
+      .map((preset) => ({
+        ...preset,
+        teamIds: preset.teamNames
+          .map((teamName) => this.teams().find((team) => team.name === teamName)?.id ?? null)
+          .filter((teamId): teamId is number => teamId !== null),
+      }))
+      .filter((preset) => preset.teamIds.length === 2)
+  );
   comparisonRows = computed<RivalrySeasonRow[]>(() => {
     const firstTeamId = this.firstTeamId();
     const secondTeamId = this.secondTeamId();
@@ -96,12 +201,21 @@ export class RivalryComparison {
           secondEntries.get(season)!
         );
         const leader = comparison < 0 ? 'first' : comparison > 0 ? 'second' : 'level';
+        const relativeStanding =
+          this.absoluteStandingScore(secondEntries.get(season)!) -
+          this.absoluteStandingScore(firstEntries.get(season)!);
+        const pointsGap =
+          first.tier === second.tier
+            ? firstEntries.get(season)!.points - secondEntries.get(season)!.points
+            : null;
 
         return {
           season,
           first,
           second,
           leader,
+          relativeStanding,
+          pointsGap,
           leaderLabel:
             leader === 'first'
               ? `${first.teamName} higher`
@@ -119,14 +233,80 @@ export class RivalryComparison {
       secondHigher: rows.filter((row) => row.leader === 'second').length,
       level: rows.filter((row) => row.leader === 'level').length,
       sameTier: rows.filter((row) => row.first.tier === row.second.tier).length,
+      firstMorePoints: rows.filter((row) => row.pointsGap !== null && row.pointsGap > 0).length,
+      secondMorePoints: rows.filter((row) => row.pointsGap !== null && row.pointsGap < 0).length,
     };
   });
   recentRows = computed(() => this.comparisonRows().slice(0, 16));
+  chartRows = computed(() =>
+    this.comparisonRows()
+      .slice()
+      .sort((a, b) => a.season - b.season)
+  );
+  sameTierChartRows = computed(() => this.chartRows().filter((row) => row.pointsGap !== null));
+  relativeStandingChartOptions = computed<EChartsCoreOption>(() => {
+    const rows = this.chartRows();
+    return this.lineChartOptions({
+      rows,
+      yAxisName: 'Relative standing',
+      series: [
+        {
+          name: 'Relative standing',
+          data: rows.map((row) => row.relativeStanding),
+          color: '#f59e0b',
+        },
+      ],
+    });
+  });
+  pointsGapChartOptions = computed<EChartsCoreOption>(() => {
+    const rows = this.sameTierChartRows();
+    return this.lineChartOptions({
+      rows,
+      yAxisName: 'Points gap',
+      series: [
+        {
+          name: 'Points gap',
+          data: rows.map((row) => row.pointsGap ?? 0),
+          color: '#38bdf8',
+        },
+      ],
+    });
+  });
+  tierPathChartOptions = computed<EChartsCoreOption>(() => {
+    const rows = this.chartRows();
+    const selected = this.selectedTeams();
+    return this.lineChartOptions({
+      rows,
+      inverseYAxis: true,
+      yAxisName: 'Tier',
+      yAxisFormatter: (value) => this.tierLabel(`tier${Math.round(value)}`),
+      series: [
+        {
+          name: selected.first?.name ?? 'First club',
+          data: rows.map((row) => this.tierRank(row.first.tier)),
+          color: '#f59e0b',
+        },
+        {
+          name: selected.second?.name ?? 'Second club',
+          data: rows.map((row) => this.tierRank(row.second.tier)),
+          color: '#38bdf8',
+        },
+      ],
+    });
+  });
 
   constructor() {
     effect(() => {
       const teams = this.teams();
       if (teams.length < 2 || (this.firstTeamId() && this.secondTeamId())) {
+        return;
+      }
+
+      const defaultPreset =
+        this.availablePresets().find((preset) => preset.id === 'north-london') ??
+        this.availablePresets()[0];
+      if (defaultPreset) {
+        this.applyPreset(defaultPreset.id);
         return;
       }
 
@@ -140,25 +320,38 @@ export class RivalryComparison {
     });
   }
 
-  onFirstTeamChange(value: string) {
-    const parsed = Number.parseInt(value, 10);
+  applyPreset(presetId: string) {
+    const preset = this.availablePresets().find((candidate) => candidate.id === presetId);
+    if (!preset) {
+      return;
+    }
+
+    this.firstTeamId.set(preset.teamIds[0]);
+    this.secondTeamId.set(preset.teamIds[1]);
+    this.activePresetId.set(preset.id);
+  }
+
+  onFirstTeamChange(value: number | string) {
+    const parsed = Number.parseInt(String(value), 10);
     if (!Number.isFinite(parsed)) {
       return;
     }
 
     this.firstTeamId.set(parsed);
+    this.activePresetId.set('');
     if (this.secondTeamId() === parsed) {
       this.secondTeamId.set(this.teams().find((team) => team.id !== parsed)?.id ?? null);
     }
   }
 
-  onSecondTeamChange(value: string) {
-    const parsed = Number.parseInt(value, 10);
+  onSecondTeamChange(value: number | string) {
+    const parsed = Number.parseInt(String(value), 10);
     if (!Number.isFinite(parsed)) {
       return;
     }
 
     this.secondTeamId.set(parsed);
+    this.activePresetId.set('');
     if (this.firstTeamId() === parsed) {
       this.firstTeamId.set(this.teams().find((team) => team.id !== parsed)?.id ?? null);
     }
@@ -210,5 +403,136 @@ export class RivalryComparison {
   private tierRank(tier: string): number {
     const parsed = Number.parseInt(tier.replace('tier', ''), 10);
     return Number.isFinite(parsed) ? parsed : 99;
+  }
+
+  private absoluteStandingScore(entry: LeagueTableEntry): number {
+    return this.tierRank(entry.tier) * 100 + entry.pos;
+  }
+
+  private lineChartOptions({
+    rows,
+    series,
+    yAxisName,
+    inverseYAxis = false,
+    yAxisFormatter,
+  }: {
+    rows: readonly RivalrySeasonRow[];
+    series: { name: string; data: number[]; color: string }[];
+    yAxisName: string;
+    inverseYAxis?: boolean;
+    yAxisFormatter?: (value: number) => string;
+  }): EChartsCoreOption {
+    if (!rows.length) {
+      return {
+        animation: false,
+        xAxis: { type: 'category', data: [] },
+        yAxis: { type: 'value' },
+        series: [],
+      };
+    }
+
+    return {
+      animation: false,
+      backgroundColor: 'transparent',
+      grid: {
+        left: 44,
+        right: 18,
+        top: series.length > 1 ? 42 : 24,
+        bottom: rows.length > 35 ? 54 : 30,
+        containLabel: true,
+      },
+      legend: {
+        show: series.length > 1,
+        top: 6,
+        right: 10,
+        textStyle: {
+          color: '#d7deeb',
+          fontSize: 12,
+          fontWeight: 700,
+        },
+      },
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'line' },
+        backgroundColor: 'rgba(7, 10, 19, 0.94)',
+        borderColor: 'rgba(148, 163, 184, 0.28)',
+        textStyle: {
+          color: '#d7deeb',
+        },
+      },
+      xAxis: {
+        type: 'category',
+        data: rows.map((row) => String(row.season)),
+        axisLabel: {
+          color: '#c5d0e4',
+          fontSize: 11,
+          hideOverlap: true,
+        },
+        axisLine: {
+          lineStyle: { color: 'rgba(148, 163, 184, 0.45)' },
+        },
+        axisTick: { show: false },
+      },
+      yAxis: {
+        type: 'value',
+        name: yAxisName,
+        inverse: inverseYAxis,
+        minInterval: 1,
+        nameTextStyle: {
+          color: '#c5d0e4',
+          fontSize: 11,
+        },
+        axisLabel: {
+          color: '#c5d0e4',
+          fontSize: 11,
+          formatter: yAxisFormatter,
+        },
+        axisLine: { show: false },
+        splitLine: {
+          lineStyle: { color: 'rgba(148, 163, 184, 0.18)' },
+        },
+      },
+      dataZoom:
+        rows.length > 35
+          ? [
+              {
+                type: 'slider',
+                xAxisIndex: 0,
+                height: 18,
+                bottom: 18,
+                filterMode: 'none',
+                backgroundColor: 'rgba(15, 23, 42, 0.75)',
+                fillerColor: 'rgba(217, 119, 6, 0.22)',
+                borderColor: 'rgba(148, 163, 184, 0.42)',
+                handleStyle: {
+                  color: '#d97706',
+                  borderColor: '#f59e0b',
+                },
+                textStyle: {
+                  color: '#d7deeb',
+                  fontSize: 10,
+                },
+              },
+            ]
+          : [],
+      series: series.map((item) => ({
+        name: item.name,
+        type: 'line',
+        data: item.data,
+        showSymbol: rows.length <= 24,
+        symbolSize: 5,
+        smooth: true,
+        lineStyle: {
+          width: 2.3,
+          color: item.color,
+        },
+        itemStyle: {
+          color: item.color,
+        },
+        emphasis: {
+          focus: 'series',
+        },
+      })),
+    };
   }
 }

--- a/src/app/pages/team-deep-stats/team-deep-stats.html
+++ b/src/app/pages/team-deep-stats/team-deep-stats.html
@@ -62,6 +62,31 @@
     </div>
   </section>
 
+  <section class="deep-panel app-panel">
+    <div class="panel-head">
+      <h2>Points Trend</h2>
+      <div class="chart-tools" aria-label="Points chart mode">
+        @for (mode of pointsChartModes; track mode.id) {
+        <button
+          type="button"
+          [class.is-active]="pointsChartMode() === mode.id"
+          [attr.aria-pressed]="pointsChartMode() === mode.id"
+          (click)="setPointsChartMode(mode.id)"
+        >
+          {{ mode.label }}
+        </button>
+        }
+      </div>
+    </div>
+    <div
+      echarts
+      class="points-chart"
+      [options]="pointsChartOptions()"
+      [autoResize]="true"
+      aria-label="Club points over time"
+    ></div>
+  </section>
+
   <div class="deep-grid">
     <section class="deep-panel app-panel">
       <div class="panel-head">

--- a/src/app/pages/team-deep-stats/team-deep-stats.scss
+++ b/src/app/pages/team-deep-stats/team-deep-stats.scss
@@ -15,6 +15,7 @@
 .profile-top-actions,
 .profile-action-links,
 .panel-head,
+.chart-tools,
 .movement-list a {
   display: flex;
   align-items: center;
@@ -212,6 +213,42 @@
   gap: 7px;
 }
 
+.points-chart {
+  min-height: 300px;
+}
+
+.chart-tools {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.chart-tools button {
+  min-height: 30px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: rgba(7, 10, 19, 0.22);
+  color: var(--app-text-muted);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.chart-tools button:hover,
+.chart-tools button:focus-visible,
+.chart-tools button.is-active {
+  border-color: rgba(245, 158, 11, 0.55);
+  background: rgba(245, 158, 11, 0.14);
+  color: #fde68a;
+}
+
+.chart-tools button:focus-visible {
+  outline: 2px solid var(--app-focus-ring);
+  outline-offset: 2px;
+}
+
 .data-row {
   display: grid;
   align-items: center;
@@ -308,6 +345,11 @@
   .data-table {
     gap: 0;
     font-size: 7.2pt;
+  }
+
+  .points-chart,
+  .chart-tools {
+    display: none;
   }
 
   .data-head {

--- a/src/app/pages/team-deep-stats/team-deep-stats.spec.ts
+++ b/src/app/pages/team-deep-stats/team-deep-stats.spec.ts
@@ -7,7 +7,30 @@ import { DataLoaderService } from '@app/store/services/hydrate-store-json';
 import { of } from 'rxjs';
 import { TeamDeepStats } from './team-deep-stats';
 
+jest.mock('echarts/charts', () => ({ LineChart: {} }));
+jest.mock('echarts/components', () => ({
+  DataZoomComponent: {},
+  GridComponent: {},
+  LegendComponent: {},
+  TooltipComponent: {},
+}));
+jest.mock('echarts/core', () => ({ use: jest.fn() }));
+jest.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+jest.mock('ngx-echarts', () => {
+  const core = jest.requireActual('@angular/core');
+  class MockNgxEchartsDirective {}
+  core.Directive({ selector: '[echarts]' })(MockNgxEchartsDirective);
+  core.Input()(MockNgxEchartsDirective.prototype, 'options');
+  core.Input()(MockNgxEchartsDirective.prototype, 'autoResize');
+
+  return {
+    NgxEchartsDirective: MockNgxEchartsDirective,
+    provideEchartsCore: () => [],
+  };
+});
+
 describe('TeamDeepStats', () => {
+  let component: TeamDeepStats;
   let fixture: ComponentFixture<TeamDeepStats>;
   let leagueStore: InstanceType<typeof LeagueStore>;
   let clubMetadataStore: InstanceType<typeof ClubMetadataStore>;
@@ -47,6 +70,7 @@ describe('TeamDeepStats', () => {
       teamName === 'Alpha FC' ? 'alpha fc' : null
     );
     fixture = TestBed.createComponent(TeamDeepStats);
+    component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
@@ -68,6 +92,39 @@ describe('TeamDeepStats', () => {
         link.textContent?.trim() === 'Alpha FC' && link.getAttribute('href')?.includes('/teams/')
     );
     expect(clubLink?.getAttribute('href')).toBe('/teams/alpha%20fc');
+
+    expect(element.textContent).toContain('Points Trend');
+    expect(element.querySelector('.points-chart')?.getAttribute('aria-label')).toBe(
+      'Club points over time'
+    );
+  });
+
+  it('builds a points trend chart with points and points-per-game modes', () => {
+    expect(component.pointsChartRows().map((row) => row.season)).toEqual([2020, 2021]);
+    expect(component.pointsChartOptions()).toMatchObject({
+      xAxis: {
+        data: ['2020', '2021'],
+      },
+      series: [
+        {
+          name: 'Points',
+          type: 'line',
+          data: [80, 91],
+        },
+      ],
+    });
+
+    component.setPointsChartMode('ppg');
+
+    expect(component.pointsChartOptions()).toMatchObject({
+      series: [
+        {
+          name: 'Points per game',
+          type: 'line',
+          data: [80 / 38, 91 / 38],
+        },
+      ],
+    });
   });
 });
 

--- a/src/app/pages/team-deep-stats/team-deep-stats.ts
+++ b/src/app/pages/team-deep-stats/team-deep-stats.ts
@@ -1,8 +1,19 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { ActivatedRoute, RouterLink } from '@angular/router';
+import { LineChart } from 'echarts/charts';
+import {
+  DataZoomComponent,
+  GridComponent,
+  LegendComponent,
+  TooltipComponent,
+} from 'echarts/components';
+import type { EChartsCoreOption } from 'echarts/core';
+import * as echarts from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { NgxEchartsDirective, provideEchartsCore } from 'ngx-echarts';
 import { DataExportMenu } from '@app/components/data-export-menu/data-export-menu';
 import { LeagueTierToStringyPipe } from '@app/pipes/league-tier-to-stringy-pipe';
 import { ClubMetadataStore } from '@app/store/club-metadata.store';
@@ -11,10 +22,21 @@ import { DataLoaderService } from '@app/store/services/hydrate-store-json';
 import { buildTeamDeepStatsData } from '@app/utils/team-deep-stats';
 import type { ExportRow, ExportSummary } from '@app/utils/data-export';
 
+type PointsChartMode = 'points' | 'ppg';
+
+echarts.use([
+  LineChart,
+  GridComponent,
+  TooltipComponent,
+  LegendComponent,
+  DataZoomComponent,
+  CanvasRenderer,
+]);
+
 @Component({
   selector: 'app-team-deep-stats',
-  imports: [CommonModule, MatButtonModule, RouterLink, DataExportMenu],
-  providers: [LeagueTierToStringyPipe],
+  imports: [CommonModule, MatButtonModule, RouterLink, NgxEchartsDirective, DataExportMenu],
+  providers: [LeagueTierToStringyPipe, provideEchartsCore({ echarts })],
   templateUrl: './team-deep-stats.html',
   styleUrl: './team-deep-stats.scss',
 })
@@ -28,6 +50,12 @@ export class TeamDeepStats {
     initialValue: this.route.snapshot.paramMap,
   });
 
+  readonly pointsChartModes: { id: PointsChartMode; label: string }[] = [
+    { id: 'points', label: 'Points' },
+    { id: 'ppg', label: 'PPG' },
+  ];
+
+  pointsChartMode = signal<PointsChartMode>('points');
   clubId = computed(() => this.paramMap().get('clubId') ?? '');
   metadataLoaded = computed(() => Boolean(this.clubMetadataStore.getGeneratedAt()));
   showLoadingState = computed(() => !this.metadataLoaded() && this.dataLoader.showLoadingState());
@@ -73,9 +101,123 @@ export class TeamDeepStats {
     }))
   );
   exportFilename = computed(() => `footy-stats-club-deep-stats-${this.clubId() || 'unknown'}`);
+  pointsChartRows = computed(() =>
+    this.deepStats()
+      .seasonRows.slice()
+      .sort((a, b) => a.season - b.season || this.tierRank(a.tier) - this.tierRank(b.tier))
+  );
+  pointsChartOptions = computed<EChartsCoreOption>(() => {
+    const rows = this.pointsChartRows();
+    const mode = this.pointsChartMode();
+    const data = rows.map((row) => (mode === 'points' ? row.points : row.pointsPerGame));
+
+    if (!rows.length) {
+      return {
+        animation: false,
+        xAxis: { type: 'category', data: [] },
+        yAxis: { type: 'value' },
+        series: [],
+      };
+    }
+
+    return {
+      animation: false,
+      backgroundColor: 'transparent',
+      grid: {
+        left: 46,
+        right: 18,
+        top: 24,
+        bottom: rows.length > 35 ? 54 : 30,
+        containLabel: true,
+      },
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'line' },
+        backgroundColor: 'rgba(7, 10, 19, 0.94)',
+        borderColor: 'rgba(148, 163, 184, 0.28)',
+        textStyle: {
+          color: '#d7deeb',
+        },
+      },
+      xAxis: {
+        type: 'category',
+        data: rows.map((row) => String(row.season)),
+        axisLabel: {
+          color: '#c5d0e4',
+          fontSize: 11,
+          hideOverlap: true,
+        },
+        axisLine: {
+          lineStyle: { color: 'rgba(148, 163, 184, 0.45)' },
+        },
+        axisTick: { show: false },
+      },
+      yAxis: {
+        type: 'value',
+        minInterval: mode === 'points' ? 1 : 0,
+        axisLabel: {
+          color: '#c5d0e4',
+          fontSize: 11,
+          formatter: (value: number) => (mode === 'points' ? String(value) : value.toFixed(1)),
+        },
+        axisLine: { show: false },
+        splitLine: {
+          lineStyle: { color: 'rgba(148, 163, 184, 0.18)' },
+        },
+      },
+      dataZoom:
+        rows.length > 35
+          ? [
+              {
+                type: 'slider',
+                xAxisIndex: 0,
+                height: 18,
+                bottom: 18,
+                filterMode: 'none',
+                backgroundColor: 'rgba(15, 23, 42, 0.75)',
+                fillerColor: 'rgba(217, 119, 6, 0.22)',
+                borderColor: 'rgba(148, 163, 184, 0.42)',
+                handleStyle: {
+                  color: '#d97706',
+                  borderColor: '#f59e0b',
+                },
+                textStyle: {
+                  color: '#d7deeb',
+                  fontSize: 10,
+                },
+              },
+            ]
+          : [],
+      series: [
+        {
+          name: mode === 'points' ? 'Points' : 'Points per game',
+          type: 'line',
+          data,
+          showSymbol: rows.length <= 24,
+          symbolSize: 5,
+          connectNulls: false,
+          smooth: true,
+          lineStyle: {
+            width: 2.4,
+            color: '#f59e0b',
+          },
+          itemStyle: {
+            color: '#f59e0b',
+          },
+          emphasis: {
+            focus: 'series',
+          },
+        },
+      ],
+    };
+  });
 
   retryArchiveLoad() {
     void this.dataLoader.loadData();
+  }
+
+  setPointsChartMode(mode: PointsChartMode) {
+    this.pointsChartMode.set(mode);
   }
 
   tableQueryParams(season: number, tier: string): { season: number; tier: string } {

--- a/src/app/utils/tier-profile.spec.ts
+++ b/src/app/utils/tier-profile.spec.ts
@@ -95,6 +95,73 @@ describe('buildTierProfileData', () => {
       endSeason: 2022,
     });
   });
+
+  it('builds season competitiveness gaps in chronological order', () => {
+    const profile = buildTierProfileData(fixtureEntries(), 'tier1', (teamId) => teams[teamId]);
+
+    expect(
+      profile.seasonCompetitiveness.map((row) => ({
+        season: row.season,
+        championName: row.championName,
+        runnerUpName: row.runnerUpName,
+        titleGap: row.titleGap,
+        midTableGap: row.midTableGap,
+        fullTableSpread: row.fullTableSpread,
+      }))
+    ).toEqual([
+      {
+        season: 1975,
+        championName: 'Alpha FC',
+        runnerUpName: 'Bravo Town',
+        titleGap: 0,
+        midTableGap: 0,
+        fullTableSpread: 0,
+      },
+      {
+        season: 2020,
+        championName: 'Alpha FC',
+        runnerUpName: 'Bravo Town',
+        titleGap: 0,
+        midTableGap: 44,
+        fullTableSpread: 44,
+      },
+      {
+        season: 2021,
+        championName: 'Bravo Town',
+        runnerUpName: 'Alpha FC',
+        titleGap: 7,
+        midTableGap: 7,
+        fullTableSpread: 46,
+      },
+      {
+        season: 2022,
+        championName: 'Alpha FC',
+        runnerUpName: 'Bravo Town',
+        titleGap: 0,
+        midTableGap: 0,
+        fullTableSpread: 0,
+      },
+    ]);
+  });
+
+  it('counts unique clubs by decade in the selected tier', () => {
+    const profile = buildTierProfileData(fixtureEntries(), 'tier1', (teamId) => teams[teamId]);
+
+    expect(profile.uniqueClubsByDecade).toEqual([
+      {
+        decade: 1970,
+        label: '1970s',
+        uniqueClubCount: 2,
+        seasons: 1,
+      },
+      {
+        decade: 2020,
+        label: '2020s',
+        uniqueClubCount: 5,
+        seasons: 3,
+      },
+    ]);
+  });
 });
 
 function fixtureEntries(): LeagueTableEntry[] {

--- a/src/app/utils/tier-profile.ts
+++ b/src/app/utils/tier-profile.ts
@@ -34,6 +34,29 @@ export interface TierSeasonChurn {
   totalMovement: number;
 }
 
+export interface TierSeasonCompetitiveness {
+  season: number;
+  teamCount: number;
+  championName: string;
+  championClubId: string | null;
+  runnerUpName: string;
+  runnerUpClubId: string | null;
+  medianName: string;
+  medianClubId: string | null;
+  lastName: string;
+  lastClubId: string | null;
+  titleGap: number;
+  midTableGap: number;
+  fullTableSpread: number;
+}
+
+export interface TierDecadeClubCount {
+  decade: number;
+  label: string;
+  uniqueClubCount: number;
+  seasons: number;
+}
+
 export interface TierDominanceRun {
   key: string;
   name: string;
@@ -63,6 +86,8 @@ export interface TierProfileData {
   closeSurvivalRaces: TierRaceRow[];
   closePromotionRaces: TierRaceRow[];
   notableSeasons: TierNotableSeason[];
+  seasonCompetitiveness: TierSeasonCompetitiveness[];
+  uniqueClubsByDecade: TierDecadeClubCount[];
   churnSeasons: TierSeasonChurn[];
 }
 
@@ -144,6 +169,8 @@ export function buildTierProfileData(
     closeSurvivalRaces: closeSurvivalRaces(seasonTables, getTeamById, raceLimit),
     closePromotionRaces: closePromotionRaces(sourceSeasonTables, getTeamById, raceLimit),
     notableSeasons: notableSeasons(seasonTables, getTeamById),
+    seasonCompetitiveness: seasonCompetitiveness(seasonTables, getTeamById),
+    uniqueClubsByDecade: uniqueClubsByDecade(targetEntries),
     churnSeasons: churnSeasons(seasonTables, sourceSeasonTables, churnLimit),
   };
 }
@@ -442,6 +469,64 @@ function churnSeasons(
     })
     .sort((a, b) => b.totalMovement - a.totalMovement || b.season - a.season)
     .slice(0, limit);
+}
+
+function seasonCompetitiveness(
+  seasonTables: ReadonlyMap<number, LeagueTableEntry[]>,
+  getTeamById: TeamLookup
+): TierSeasonCompetitiveness[] {
+  return Array.from(seasonTables.entries())
+    .flatMap(([season, table]) => {
+      const sorted = sortTable(table);
+      const champion = sorted[0];
+      const runnerUp = sorted[1];
+      const median = sorted[Math.floor(sorted.length / 2)];
+      const last = sorted.at(-1);
+
+      if (!champion || !runnerUp || !median || !last) {
+        return [];
+      }
+
+      return [
+        {
+          season,
+          teamCount: sorted.length,
+          championName: getTeamById(champion.teamId)?.name ?? 'Unknown',
+          championClubId: champion.clubId,
+          runnerUpName: getTeamById(runnerUp.teamId)?.name ?? 'Unknown',
+          runnerUpClubId: runnerUp.clubId,
+          medianName: getTeamById(median.teamId)?.name ?? 'Unknown',
+          medianClubId: median.clubId,
+          lastName: getTeamById(last.teamId)?.name ?? 'Unknown',
+          lastClubId: last.clubId,
+          titleGap: Math.max(0, champion.points - runnerUp.points),
+          midTableGap: Math.max(0, champion.points - median.points),
+          fullTableSpread: Math.max(0, champion.points - last.points),
+        },
+      ];
+    })
+    .sort((a, b) => a.season - b.season);
+}
+
+function uniqueClubsByDecade(entries: readonly LeagueTableEntry[]): TierDecadeClubCount[] {
+  const byDecade = new Map<number, { seasons: Set<number>; clubs: Set<string> }>();
+
+  entries.forEach((entry) => {
+    const decade = Math.floor(entry.season / 10) * 10;
+    const group = byDecade.get(decade) ?? { seasons: new Set<number>(), clubs: new Set<string>() };
+    group.seasons.add(entry.season);
+    group.clubs.add(clubKey(entry));
+    byDecade.set(decade, group);
+  });
+
+  return Array.from(byDecade.entries())
+    .map(([decade, group]) => ({
+      decade,
+      label: `${decade}s`,
+      uniqueClubCount: group.clubs.size,
+      seasons: group.seasons.size,
+    }))
+    .sort((a, b) => a.decade - b.decade);
 }
 
 function groupSeasonTables(entries: readonly LeagueTableEntry[]): Map<number, LeagueTableEntry[]> {


### PR DESCRIPTION
## Summary
- Adds new chart-driven views for league, club, and rivalry analysis.
- Introduces a rivalry comparison workbench with presets, selectors, scorecards, charts, and shared-season rows.

## What Changed
- Added season competitiveness and unique-clubs-by-decade visualizations to league deep stats.
- Added club points-over-time visualization with points/PPG mode.
- Added `/rivalries` route and toolbar navigation.
- Built known rivalry presets, club selectors, scorecard metrics, relative standing chart, same-tier points gap chart, tier path chart, and shared-season table.
- Fixed rivalry selector initial-load state with `ngModel`/`ngValue`.
- Polished rivalry page spacing, responsive grids, panel rhythm, and long-text handling.
- Added focused tests for rivalry defaults, chart data, selector behavior, and deep-stats visualization helpers.

## Validation
- `fnm exec --using=22.22.1 -- pnpm test -- rivalry-comparison`
- `fnm exec --using=22.22.1 -- pnpm lint`
- `fnm exec --using=22.22.1 -- pnpm build`
- `curl -I http://127.0.0.1:4300/rivalries`

## Scope Notes
- Branch is clean.
- Branch commits: `b5cc552 Add visualization and rivalry comparison slice`, `1431c52 Polish rivalry comparison workbench`.
- Dev servers were stopped after route verification.