### PR TITLE
chore: add automated footy data update workflow

### DIFF
--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -1,0 +1,144 @@
+name: Data Update
+
+on:
+  schedule:
+    - cron: '23 9 * * 1,4'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Optional footy-data-kit release tag to import'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: footy-data-kit-data-update
+  cancel-in-progress: false
+
+jobs:
+  update-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify PR token
+        env:
+          DATA_UPDATE_PR_TOKEN: ${{ secrets.DATA_UPDATE_PR_TOKEN }}
+        run: |
+          if [ -z "${DATA_UPDATE_PR_TOKEN}" ]; then
+            echo "::error::Missing DATA_UPDATE_PR_TOKEN secret. Add a token with contents and pull request write access."
+            exit 1
+          fi
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.13.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Update shipped data
+        id: update
+        run: pnpm data:update
+        env:
+          FOOTY_DATA_KIT_TOKEN: ${{ secrets.FOOTY_DATA_KIT_TOKEN }}
+          FOOTY_DATA_KIT_RELEASE_TAG: ${{ inputs.release_tag }}
+
+      - name: Lint
+        if: steps.update.outputs.changed == 'true'
+        run: pnpm lint
+
+      - name: Test
+        if: steps.update.outputs.changed == 'true'
+        run: pnpm test
+
+      - name: Build
+        if: steps.update.outputs.changed == 'true'
+        run: pnpm build
+
+      - name: Commit data update
+        if: steps.update.outputs.changed == 'true'
+        id: commit
+        env:
+          DATA_UPDATE_PR_TOKEN: ${{ secrets.DATA_UPDATE_PR_TOKEN }}
+          DATA_VERSION: ${{ steps.update.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          safe_version="$(printf '%s' "${DATA_VERSION}" | tr -c 'A-Za-z0-9._-' '-')"
+          branch="codex/data-update-${safe_version}"
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git fetch origin "${branch}:refs/remotes/origin/${branch}" || true
+          git switch -C "${branch}"
+          git add src/assets/seasons.json src/assets/club-metadata.json
+          git commit -m "chore: update footy data to ${DATA_VERSION}"
+          git remote set-url origin "https://x-access-token:${DATA_UPDATE_PR_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force-with-lease origin "${branch}"
+
+          echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
+
+      - name: Open or update pull request
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.DATA_UPDATE_PR_TOKEN }}
+          DATA_VERSION: ${{ steps.update.outputs.version }}
+          DATA_GENERATED_AT: ${{ steps.update.outputs.generated_at }}
+          DATA_GIT_SHA: ${{ steps.update.outputs.data_git_sha }}
+          DATA_RELEASE_URL: ${{ steps.update.outputs.release_url }}
+          DATA_SEASONS_SOURCE: ${{ steps.update.outputs.seasons_source }}
+          DATA_CLUB_METADATA_SOURCE: ${{ steps.update.outputs.club_metadata_source }}
+          DATA_CHANGED_FILES: ${{ steps.update.outputs.changed_files }}
+          UPDATE_BRANCH: ${{ steps.commit.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          title="chore: update footy data to ${DATA_VERSION}"
+          body_file="$(mktemp)"
+          cat > "${body_file}" <<EOF
+          ## Summary
+
+          Updates shipped Footy Stats data from footy-data-kit ${DATA_VERSION}.
+
+          - Release: ${DATA_RELEASE_URL}
+          - Generated at: ${DATA_GENERATED_AT}
+          - Data git SHA: ${DATA_GIT_SHA}
+          - Changed files: ${DATA_CHANGED_FILES}
+
+          ## Sources
+
+          - Seasons: ${DATA_SEASONS_SOURCE}
+          - Club metadata: ${DATA_CLUB_METADATA_SOURCE}
+
+          ## Verification
+
+          - pnpm lint
+          - pnpm test
+          - pnpm build
+          EOF
+
+          if gh pr view "${UPDATE_BRANCH}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh pr edit "${UPDATE_BRANCH}" --repo "${GITHUB_REPOSITORY}" --title "${title}" --body-file "${body_file}"
+          else
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --base main \
+              --head "${UPDATE_BRANCH}" \
+              --title "${title}" \
+              --body-file "${body_file}"
+          fi

--- a/README.md
+++ b/README.md
@@ -31,6 +31,29 @@ When newer data is available, the app can refresh the archive in the browser:
 This keeps the site static-host friendly while still allowing newer verified data to be used
 without redeploying the app.
 
+Shipped data is also refreshed by the `Data Update` GitHub Actions workflow. It runs on
+Monday and Thursday, can be started manually, and opens or updates a review PR when
+`footy-data-kit` publishes data that changes `src/assets/seasons.json` or
+`src/assets/club-metadata.json`.
+
+The workflow expects a repository secret named `DATA_UPDATE_PR_TOKEN`. Use a fine-grained
+token for this repository with contents read/write and pull request read/write access so
+the generated branch and PR behave like a normal contributor update and trigger regular CI.
+If unauthenticated upstream API limits become a problem, add `FOOTY_DATA_KIT_TOKEN` as a
+separate optional token for reading `footy-data-kit` releases.
+
+Run the importer locally with:
+
+```bash
+pnpm data:update
+```
+
+To import a specific upstream release locally:
+
+```bash
+FOOTY_DATA_KIT_RELEASE_TAG=v0.8.2 pnpm data:update
+```
+
 ## Getting Started
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "codex:links": "node scripts/dev/setup-codex-links.mjs",
+    "data:update": "node scripts/data/update-from-footy-data-kit.mjs",
     "hooks:setup": "npx lefthook install",
     "lint": "eslint . --ext .ts,.js,.html,.json",
     "lint:fix": "eslint . --ext .ts,.js,.html,.json --fix"

--- a/scripts/data/update-from-footy-data-kit.mjs
+++ b/scripts/data/update-from-footy-data-kit.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { appendFileSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const FOOTY_DATA_KIT_OWNER = 'dills122';
+const FOOTY_DATA_KIT_REPO = 'footy-data-kit';
+const FOOTY_DATA_KIT_API = `https://api.github.com/repos/${FOOTY_DATA_KIT_OWNER}/${FOOTY_DATA_KIT_REPO}`;
+const FOOTY_DATA_KIT_RAW = `https://raw.githubusercontent.com/${FOOTY_DATA_KIT_OWNER}/${FOOTY_DATA_KIT_REPO}`;
+
+const manifestAssetNames = ['footy-stats-data-manifest.json', 'data-manifest.json'];
+const seasonsAssetNames = ['seasons.json', 'all-seasons.json', 'all-seasons.min.json'];
+const clubMetadataAssetNames = ['club-metadata.json'];
+const rawAssetPathsByName = {
+  'seasons.json': 'data-output/all-seasons.json',
+  'all-seasons.json': 'data-output/all-seasons.json',
+  'all-seasons.min.json': 'data-output/all-seasons.min.json',
+  'club-metadata.json': 'data/club-metadata.json',
+};
+
+const targetFiles = {
+  seasons: path.resolve('src/assets/seasons.json'),
+  clubMetadata: path.resolve('src/assets/club-metadata.json'),
+};
+
+async function main() {
+  const release = await fetchRelease();
+  const manifest = await fetchManifestForRelease(release);
+
+  const [seasonsText, clubMetadataText] = await Promise.all([
+    downloadVerifiedAsset(manifest.assets.seasons, 'seasons.json'),
+    downloadVerifiedAsset(manifest.assets.clubMetadata, 'club-metadata.json'),
+  ]);
+
+  const changes = [];
+  if (await writeJsonWhenChanged(targetFiles.seasons, seasonsText, 'seasons.json')) {
+    changes.push('src/assets/seasons.json');
+  }
+
+  if (
+    await writeJsonWhenChanged(
+      targetFiles.clubMetadata,
+      clubMetadataText,
+      'club-metadata.json'
+    )
+  ) {
+    changes.push('src/assets/club-metadata.json');
+  }
+
+  const changed = changes.length > 0;
+  writeOutput('changed', String(changed));
+  writeOutput('version', manifest.version);
+  writeOutput('generated_at', manifest.generatedAt);
+  writeOutput('data_git_sha', manifest.gitSha);
+  writeOutput('release_url', release.html_url ?? release.browser_download_url ?? '');
+  writeOutput('seasons_source', manifest.assets.seasons.url);
+  writeOutput('club_metadata_source', manifest.assets.clubMetadata.url);
+  writeOutput('changed_files', changes.join(', '));
+
+  if (changed) {
+    console.log(`Updated shipped data from ${manifest.version}: ${changes.join(', ')}`);
+  } else {
+    console.log(`Shipped data is already current for ${manifest.version}.`);
+  }
+}
+
+async function fetchRelease() {
+  const releaseTag = process.env.FOOTY_DATA_KIT_RELEASE_TAG?.trim();
+  const endpoint = releaseTag
+    ? `${FOOTY_DATA_KIT_API}/releases/tags/${encodeURIComponent(releaseTag)}`
+    : `${FOOTY_DATA_KIT_API}/releases/latest`;
+
+  return fetchJson(endpoint);
+}
+
+async function fetchManifestForRelease(release) {
+  const manifestAsset = findAssetByPriority(release.assets ?? [], manifestAssetNames);
+  if (manifestAsset) {
+    return fetchJson(manifestAsset.browser_download_url);
+  }
+
+  return buildManifestFromReleaseAssets(release);
+}
+
+async function buildManifestFromReleaseAssets(release) {
+  const releaseTree = await fetchReleaseTree(release.tag_name);
+  const seasonsAsset = requiredReleaseAsset(
+    release.assets ?? [],
+    seasonsAssetNames,
+    'season data'
+  );
+  const clubMetadataAsset = requiredReleaseAsset(
+    release.assets ?? [],
+    clubMetadataAssetNames,
+    'club metadata'
+  );
+
+  return {
+    version: release.tag_name,
+    generatedAt: release.published_at,
+    gitSha: release.target_commitish || release.tag_name,
+    assets: {
+      seasons: buildAssetManifest(release.tag_name, releaseTree, seasonsAsset),
+      clubMetadata: buildAssetManifest(release.tag_name, releaseTree, clubMetadataAsset),
+    },
+  };
+}
+
+async function fetchReleaseTree(tagName) {
+  const tree = await fetchJson(
+    `${FOOTY_DATA_KIT_API}/git/trees/${encodeURIComponent(tagName)}?recursive=1`
+  );
+
+  if (tree.truncated) {
+    throw new Error(`Release tree for ${tagName} is truncated and cannot be verified.`);
+  }
+
+  return tree;
+}
+
+function buildAssetManifest(tagName, releaseTree, asset) {
+  const rawPath = rawAssetPathsByName[asset.name];
+  if (!rawPath) {
+    throw new Error(`No raw path is configured for release asset ${asset.name}.`);
+  }
+
+  const treeItem = releaseTree.tree.find(
+    (candidate) => candidate.type === 'blob' && candidate.path === rawPath
+  );
+  if (!treeItem) {
+    throw new Error(`Release ${tagName} is missing ${rawPath}.`);
+  }
+
+  return {
+    url: `${FOOTY_DATA_KIT_RAW}/${encodeURIComponent(tagName)}/${rawPath}`,
+    gitBlobSha: treeItem.sha,
+    size: treeItem.size ?? asset.size,
+  };
+}
+
+function requiredReleaseAsset(assets, names, label) {
+  const asset = findAssetByPriority(assets, names);
+  if (!asset) {
+    throw new Error(`Release is missing a supported ${label} file.`);
+  }
+
+  return asset;
+}
+
+function findAssetByPriority(assets, names) {
+  for (const name of names) {
+    const asset = assets.find((candidate) => candidate.name === name);
+    if (asset) {
+      return asset;
+    }
+  }
+
+  return null;
+}
+
+async function downloadVerifiedAsset(asset, label) {
+  const text = await fetchText(asset.url);
+
+  if (asset.sha256) {
+    verifySha256(text, asset.sha256, label);
+    return text;
+  }
+
+  if (asset.digest?.startsWith('sha256:')) {
+    verifySha256(text, asset.digest.slice('sha256:'.length), label);
+    return text;
+  }
+
+  if (asset.gitBlobSha) {
+    verifyGitBlobSha(text, asset.gitBlobSha, label);
+    return text;
+  }
+
+  throw new Error(`${label} is missing a supported checksum.`);
+}
+
+async function writeJsonWhenChanged(targetFile, rawJson, label) {
+  const nextDocument = parseJson(rawJson, label);
+  const currentDocument = parseJson(await readFile(targetFile, 'utf8'), targetFile);
+
+  if (JSON.stringify(currentDocument) === JSON.stringify(nextDocument)) {
+    return false;
+  }
+
+  await mkdir(path.dirname(targetFile), { recursive: true });
+  await writeFile(targetFile, `${JSON.stringify(nextDocument, null, 2)}\n`);
+  return true;
+}
+
+function parseJson(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${label} is not valid JSON: ${message}`);
+  }
+}
+
+function verifySha256(text, expected, label) {
+  const actual = createHash('sha256').update(text).digest('hex');
+  if (actual !== expected.toLowerCase()) {
+    throw new Error(`${label} checksum mismatch.`);
+  }
+}
+
+function verifyGitBlobSha(text, expected, label) {
+  const body = Buffer.from(text);
+  const prefix = Buffer.from(`blob ${body.length}\0`);
+  const actual = createHash('sha1').update(Buffer.concat([prefix, body])).digest('hex');
+
+  if (actual !== expected.toLowerCase()) {
+    throw new Error(`${label} git blob checksum mismatch.`);
+  }
+}
+
+async function fetchJson(url) {
+  return parseJson(await fetchText(url, { accept: 'application/vnd.github+json' }), url);
+}
+
+async function fetchText(url, options = {}) {
+  const headers = {
+    Accept: options.accept ?? 'application/octet-stream',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'footy-stats-data-updater',
+  };
+  const token = process.env.FOOTY_DATA_KIT_TOKEN ?? process.env.GITHUB_TOKEN;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Request failed for ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  return response.text();
+}
+
+function writeOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) {
+    return;
+  }
+
+  appendFileSync(outputFile, `${name}<<EOF\n${value}\nEOF\n`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Adds an automated GitHub Actions workflow to refresh shipped Footy Stats data from `footy-data-kit`.
- Uses a custom PR token so generated branches and PRs behave like normal contributor updates.

## What Changed
- Added `.github/workflows/data-update.yml` with Monday/Thursday cron, manual dispatch, validation gates, branch push, and PR create/update steps.
- Added `scripts/data/update-from-footy-data-kit.mjs` to fetch releases, resolve manifests/assets, verify checksums, and update shipped JSON only when content changes.
- Added `pnpm data:update` for local/manual importer runs.
- Documented `DATA_UPDATE_PR_TOKEN`, optional `FOOTY_DATA_KIT_TOKEN`, and local importer usage in `README.md`.

## Validation
- `node --check scripts/data/update-from-footy-data-kit.mjs`
- `fnm exec --using=22.22.1 -- pnpm lint`
- `fnm exec --using=22.22.1 -- pnpm test`
- `fnm exec --using=22.22.1 -- pnpm build`
- `git diff --check`

## Scope Notes
- The live updater was not run against GitHub locally to avoid changing shipped data during workflow setup.
- `actionlint` is not installed locally, so the workflow was reviewed and covered by repo checks but not actionlint-validated.